### PR TITLE
CORE-7813 Reorganize /secured/bootstrap response

### DIFF
--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -47,22 +47,19 @@
   (cp/user-home-dir user))
 
 
-(defn ^String base-trash-folder
-  "It returns the root directory for all users' trash folders."
-  []
-  (cp/base-trash-path))
-
-
-(defn ^String user-trash-folder
-  "Determines the top-level trash folder for the given user.
+(defn ^String user-base-paths
+  "Fetches the home and trash paths for the given user.
 
    Parameters:
-     user - the user of the trash folder.
+     user - the user of the base paths.
 
    Returns:
-     It returns the absolute path to the trash folder."
+     A map of the absolute paths to the home and trash folders."
   [^String user]
-  (cp/user-trash-path user))
+  (-> (raw/base-paths user)
+      :body
+      (json/decode true)))
+
 
 (defn uuid-for-path
   [^String user ^String path]

--- a/src/terrain/clients/data_info/raw.clj
+++ b/src/terrain/clients/data_info/raw.clj
@@ -59,6 +59,11 @@
 
 ;; NAVIGATION
 
+(defn base-paths
+  "Uses the data-info navigation/base-paths endpoint to list a user's home and trash paths."
+  [user]
+  (request :get ["navigation" "base-paths"] (mk-req-map user)))
+
 (defn list-roots
   "Uses the data-info navigation/root endpoint to list a user's navigation roots."
   [user]

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -1,6 +1,7 @@
 (ns terrain.routes.metadata
   (:use [compojure.core]
         [terrain.services.metadata.apps]
+        [terrain.services.bootstrap]
         [terrain.util])
   (:require [terrain.clients.apps.raw :as apps]
             [terrain.clients.metadata :as metadata]

--- a/src/terrain/services/bootstrap.clj
+++ b/src/terrain/services/bootstrap.clj
@@ -13,7 +13,7 @@
   [body]
   (try+
     (service/decode-json body)
-    (catch Throwable e
+    (catch Object _
       body)))
 
 (defn- trap-bootstrap-request
@@ -24,9 +24,9 @@
       (log/error e)
       {:status status
        :error  (decode-error-response body)})
-    (catch Throwable e
-      (log/error e)
-      {:error (str e)})))
+    (catch Object _
+      (log/error (:throwable &throw-context) "bootstrap request failed")
+      {:error (str (:throwable &throw-context))})))
 
 (defn- get-login-session
   [ip-address user-agent]

--- a/src/terrain/services/bootstrap.clj
+++ b/src/terrain/services/bootstrap.clj
@@ -1,0 +1,71 @@
+(ns terrain.services.bootstrap
+  (:use
+    [slingshot.slingshot :only [try+]]
+    [terrain.auth.user-attributes :only [current-user]])
+  (:require
+    [clojure.tools.logging :as log]
+    [terrain.clients.apps :as apps-client]
+    [terrain.clients.data-info :as data-info-client]
+    [terrain.services.user-prefs :as prefs]
+    [terrain.util.service :as service]))
+
+(defn- decode-error-response
+  [body]
+  (try+
+    (service/decode-json body)
+    (catch Throwable e
+      body)))
+
+(defn- trap-bootstrap-request
+  [req]
+  (try+
+    (req)
+    (catch #(not (nil? (:status %))) {:keys [status body] :as e}
+      (log/error e)
+      {:status status
+       :error  (decode-error-response body)})
+    (catch Throwable e
+      (log/error e)
+      {:error (str e)})))
+
+(defn- get-login-session
+  [ip-address user-agent]
+  (trap-bootstrap-request
+    #(select-keys (apps-client/record-login ip-address user-agent) [:login_time :auth_redirect])))
+
+(defn- get-workspace
+  []
+  (trap-bootstrap-request
+    #(select-keys (apps-client/get-workspace) [:id :new_workspace])))
+
+(defn- get-user-data-info
+  [user]
+  (trap-bootstrap-request
+    #(data-info-client/user-base-paths user)))
+
+(defn- get-user-prefs
+  [username]
+  (trap-bootstrap-request
+    #(prefs/user-prefs username)))
+
+(defn bootstrap
+  "This service obtains information about and initializes the workspace for the authenticated user.
+   It also records the fact that the user logged in."
+  [{{:keys [ip-address]} :params {user-agent "user-agent"} :headers}]
+  (service/assert-valid ip-address "Missing or empty query string parameter: ip-address")
+  (service/assert-valid user-agent "Missing or empty request parameter: user-agent")
+  (let [{user :shortUsername :keys [email firstName lastName username]} current-user
+        login-session (future (get-login-session ip-address user-agent))
+        workspace     (future (get-workspace))
+        data-info     (future (get-user-data-info user))
+        preferences   (future (get-user-prefs username))]
+    (service/success-response
+      {:user_info   {:username      user
+                     :full_username username
+                     :email         email
+                     :first_name    firstName
+                     :last_name     lastName}
+       :session     @login-session
+       :workspace   @workspace
+       :data_info   @data-info
+       :preferences @preferences})))

--- a/src/terrain/services/metadata/apps.clj
+++ b/src/terrain/services/metadata/apps.clj
@@ -66,10 +66,7 @@
 
 (defn- get-user-data-info
   [user]
-  (trap-bootstrap-request
-    #(hash-map :user_home_path  (di/user-home-folder user)
-               :user_trash_path (di/user-trash-folder user)
-               :base_trash_path (di/base-trash-folder))))
+  (trap-bootstrap-request #(di/user-base-paths user)))
 
 (defn- get-user-prefs
   [username]
@@ -83,6 +80,7 @@
   (assert-valid user-agent "Missing or empty request parameter: user-agent")
   (let [{user :shortUsername :keys [email firstName lastName username]} current-user
         workspace (future (get-workspace))
+        data-info (future (get-user-data-info user))
         preferences (future (get-user-prefs username))
         login-record (future (dm/record-login ip-address user-agent))
         auth-redirect (future (dm/get-auth-redirect-uris))]
@@ -95,7 +93,7 @@
                      :session       {:login_time    (str (:login_time @login-record))
                                      :auth_redirect @auth-redirect}}
        :workspace   @workspace
-       :data_info   (get-user-data-info user)
+       :data_info   @data-info
        :preferences @preferences})))
 
 (defn logout

--- a/src/terrain/services/user_prefs/output_dir.clj
+++ b/src/terrain/services/user_prefs/output_dir.clj
@@ -6,7 +6,12 @@
             [terrain.clients.data-info :as di]
             [terrain.util.config :as cfg]))
 
-(def default-output-dir-key :defaultOutputFolder)
+(def default-output-dir-key :default_output_folder)
+
+(defn- convert-default-output-dir-keys
+  [prefs]
+  (clojure.set/rename-keys prefs {:defaultOutputFolder    default-output-dir-key
+                                  :systemDefaultOutputDir :system_default_output_dir}))
 
 (defn add-default-output-dir
   "Adds the default output directory to a set of user preferences."
@@ -35,12 +40,12 @@
   "Adds system default output directory to the preferences that are passed in."
   [prefs]
   (assoc prefs
-    :systemDefaultOutputDir {:id   (system-default-output-dir)
-                             :path (system-default-output-dir)}))
+    :system_default_output_dir {:id   (system-default-output-dir)
+                                :path (system-default-output-dir)}))
 
 (defn- sysdefoutdir
   [prefs]
-  (let [out-dir (:systemDefaultOutputDir prefs)]
+  (let [out-dir (:system_default_output_dir prefs)]
     (if (map? out-dir)
       (:path out-dir)
       out-dir)))
@@ -80,7 +85,7 @@
   [prefs]
   (let [user                (:shortUsername current-user)
         user-default        (default-output-dir-key prefs)
-        sys-default         (:systemDefaultOutputDir prefs)
+        sys-default         (:system_default_output_dir prefs)
         restore-sys-default #(assoc prefs default-output-dir-key sys-default)]
     (cond (= user-default sys-default)                   prefs
           (di/can-create-dir? user (:path user-default)) prefs
@@ -89,6 +94,7 @@
 (defn process-outgoing
   [user prefs]
   (->> prefs
+       (convert-default-output-dir-keys)
        (handle-blank-default-output-dir user)
        (handle-string-default-output-dir)
        (add-system-default-output-dir)


### PR DESCRIPTION
The current `GET /secured/bootstrap` endpoint response has the following structure:
```json
{
    "loginTime": "1374190755304",
    "newWorkspace": false,
    "workspaceId": "4",
    "username": "snow-dog",
    "full_username": "snow-dog@iplantcollaborative.org",
    "email": "sd@example.org",
    "firstName": "Snow",
    "lastName": "Dog",
    "userHomePath": "/iplant/home/snow-dog",
    "userTrashPath": "/iplant/trash/snow-dog",
    "baseTrashPath": "/iplant/trash",
    "preferences": {
        "systemDefaultOutputDir": {
            "id": "/iplant/home/snow-dog/analyses",
            "path": "/iplant/home/snow-dog/analyses"
        },
        "defaultOutputFolder": {
            "id": "/iplant/home/snow-dog/analyses",
            "path": "/iplant/home/snow-dog/analyses"
        }
    },
    "auth-redirect": {
        "example": "https://example.org"
    }
}
```

These fields are pieced together from 3 different services other than terrain (apps, data-info, and preferences).

It would be helpful to group the info of each service under its own field, similar to the existing `preferences` field. Then if a service is down, rather than this terrain endpoint immediately throwing an error that prevents the UI from loading, the field that should contain that service's info will contain the error response instead. This will allow the UI to finish loading, with partial user info, and could also help the UI determine which service is down from the initial bootstrap endpoint response.

Since the response format is getting updated, the JSON keys can also be converted from camel-case to underscores (snake-case), which is more standard in our other endpoints.

For example:
```json
{
  "user_info": {
    "username": "snow-dog",
    "full_username": "snow-dog@iplantcollaborative.org",
    "email": "sd@example.org",
    "first_name": "Snow",
    "last_name": "Dog"
  },
  "session": {
    "login_time": 1374190755304,
    "auth_redirect": {
      "example": "https://example.org"
    }
  },
  "workspace": {
    "new_workspace": false,
    "workspace_id": "4"
  },
  "data_info": {
    "user_home_path": "/iplant/home/snow-dog",
    "user_trash_path": "/iplant/trash/snow-dog",
    "base_trash_path": "/iplant/trash"
  },
  "preferences": {
    "system_default_output_dir": {
      "id": "/iplant/home/snow-dog/analyses",
      "path": "/iplant/home/snow-dog/analyses"
    },
    "default_output_folder": {
      "id": "/iplant/home/snow-dog/analyses",
      "path": "/iplant/home/snow-dog/analyses"
    }
  }
}
```
Then if these services (besides terrain) are down, the bootstrap endpoint can still return success to the UI, but provide an error message letting the UI know which services are down or inaccessible.

For example:
```json
{
  "user_info": {
    "username": "snow-dog",
    "full_username": "snow-dog@iplantcollaborative.org",
    "email": "sd@example.org",
    "first_name": "Snow",
    "last_name": "Dog"
  },
  "session": {
    "error": "java.net.ConnectException: Connection refused"
  },
  "workspace": {
    "status": 400,
    "error": {
      "error_code": "ERR_ILLEGAL_ARGUMENT",
      "reason": {
        "foo": "disallowed-key"
      }
    }
  },
  "data_info": {
    "status": 404,
    "error": {
      "success": false,
      "reason": "unrecognized service path"
    }
  },
  "preferences": {
    "status": 503,
    "error": "<html>\r\n<head><title>503 Service Unavailable</title></head>\r\n<body bgcolor=\"white\">\r\n<center><h1>503 Service Unavailable</h1></center>\r\n<hr><center>nginx/1.11.4</center>\r\n</body>\r\n</html>\r\n"
  }
}
```
