### PR TITLE
CORE-8446 Fix /bootstrap error encoding.

### DIFF
--- a/src/terrain/clients/user_prefs.clj
+++ b/src/terrain/clients/user_prefs.clj
@@ -23,7 +23,10 @@
 
      (= (:status resp) 500)
      (throw+ {:error_code ERR_UNCHECKED_EXCEPTION :msg "Error thrown by user-preferences service."})
-     
+
+     (or (= (:status resp) 503) (= (:status resp) 504))
+     (throw+ resp)
+
      (not (<= 200 (:status resp) 299))
      (throw+ {:error_code ERR_UNCHECKED_EXCEPTION :msg "Unknown error thrown by the user-preferences service"})
 

--- a/src/terrain/services/bootstrap.clj
+++ b/src/terrain/services/bootstrap.clj
@@ -11,10 +11,11 @@
 
 (defn- decode-error-response
   [body]
-  (try+
-    (service/decode-json body)
+  (let [response (if (string? body) body (slurp body))]
+    (try+
+      (service/decode-json response)
     (catch Object _
-      body)))
+      response))))
 
 (defn- trap-bootstrap-request
   [req]
@@ -24,6 +25,9 @@
       (log/error e)
       {:status status
        :error  (decode-error-response body)})
+    (catch map? e
+      (log/error e)
+      {:error e})
     (catch Object _
       (log/error (:throwable &throw-context) "bootstrap request failed")
       {:error (str (:throwable &throw-context))})))


### PR DESCRIPTION
This PR includes fixes in the `/bootstrap` endpoint for parsing error responses from the apps and preferences services when they are under maintenance (503 or 504 responses).