### PR TITLE
CORE-8443 Provide passthrough to apps for redirect uris

### DIFF
--- a/src/terrain/routes/oauth.clj
+++ b/src/terrain/routes/oauth.clj
@@ -13,6 +13,9 @@
    (GET "/oauth/access-code/:api-name" [api-name :as {params :params}]
      (service/success-response (apps/get-oauth-access-token api-name params)))
 
+   (GET "/oauth/redirect-uris" []
+     (service/success-response (apps/get-oauth-redirect-uris)))
+
    (GET "/oauth/token-info/:api-name" [api-name]
      (service/success-response (apps/get-oauth-token-info api-name)))))
 


### PR DESCRIPTION
The UI typically is informed of any redirect uris via the bootstrap endpoint.  Exposing this will allow the UI an opportunity to retrieve those uris outside of bootstrap.