### PR TITLE
CORE-8720 Add new apps endpoints for private tools.

### DIFF
--- a/src/terrain/clients/apps.clj
+++ b/src/terrain/clients/apps.clj
@@ -27,9 +27,9 @@
       (:body)
       (service/decode-json)))
 
-(defn import-tools
+(defn admin-add-tools
   [body]
-  (raw/import-tools (cheshire/encode body)))
+  (raw/admin-add-tools (cheshire/encode body)))
 
 (defn submit-job
   [submission]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -8,6 +8,7 @@
 (def apps-analysis-listing-params (conj apps-sort-params :include-hidden :filter))
 (def apps-search-params (conj apps-sort-params :search))
 (def apps-hierarchy-sort-params (conj apps-sort-params :attr))
+(def tools-search-params (conj apps-search-params :include-hidden :public))
 
 (defn- apps-url
   [& components]
@@ -627,7 +628,14 @@
                :as               :stream
                :follow-redirects false}))
 
-(defn import-tools
+(defn admin-list-tools
+  [params]
+  (client/get (apps-url "admin" "tools")
+              {:query-params     (secured-params params tools-search-params)
+               :as               :stream
+               :follow-redirects :false}))
+
+(defn admin-add-tools
   [body]
   (client/post (apps-url "admin" "tools")
                {:query-params     (secured-params)
@@ -636,14 +644,21 @@
                 :content-type     :json
                 :follow-redirects false}))
 
-(defn delete-tool
+(defn admin-delete-tool
   [tool-id]
   (client/delete (apps-url "admin" "tools" tool-id)
                  {:query-params     (secured-params)
                   :as               :stream
                   :follow-redirects false}))
 
-(defn update-tool
+(defn admin-get-tool
+  [tool-id]
+  (client/get (apps-url "admin" "tools" tool-id)
+              {:query-params     (secured-params)
+               :as               :stream
+               :follow-redirects false}))
+
+(defn admin-update-tool
   [tool-id params tool]
   (client/patch (apps-url "admin" "tools" tool-id)
                 {:query-params     (secured-params params [:overwrite-public])
@@ -652,12 +667,55 @@
                  :content-type     :json
                  :follow-redirects false}))
 
-(defn search-tools
+(defn list-tools
   [params]
   (client/get (apps-url "tools")
-              {:query-params     (secured-params params (conj apps-search-params :include-hidden))
+              {:query-params     (secured-params params tools-search-params)
                :as               :stream
                :follow-redirects :false}))
+
+(defn create-private-tool
+  [body]
+  (client/post (apps-url "tools")
+               {:query-params     (secured-params)
+                :body             body
+                :content-type     :json
+                :as               :stream
+                :follow-redirects false}))
+
+(defn list-tool-permissions
+  [body]
+  (client/post (apps-url "tools" "permission-lister")
+               {:query-params     (secured-params)
+                :body             body
+                :content-type     :json
+                :as               :stream
+                :follow-redirects false}))
+
+(defn share-tool
+  [body]
+  (client/post (apps-url "tools" "sharing")
+               {:query-params     (secured-params)
+                :body             body
+                :content-type     :json
+                :as               :stream
+                :follow-redirects false}))
+
+(defn unshare-tool
+  [body]
+  (client/post (apps-url "tools" "unsharing")
+               {:query-params     (secured-params)
+                :body             body
+                :content-type     :json
+                :as               :stream
+                :follow-redirects false}))
+
+(defn delete-private-tool
+  [tool-id params]
+  (client/delete (apps-url "tools" tool-id)
+                 {:query-params     (secured-params params [:force-delete])
+                  :as               :stream
+                  :follow-redirects false}))
 
 (defn get-tool
   [tool-id]
@@ -665,6 +723,15 @@
               {:query-params     (secured-params)
                :as               :stream
                :follow-redirects false}))
+
+(defn update-private-tool
+  [tool-id tool]
+  (client/patch (apps-url "tools" tool-id)
+                {:query-params     (secured-params)
+                 :as               :stream
+                 :body             tool
+                 :content-type     :json
+                 :follow-redirects false}))
 
 (defn list-reference-genomes
   [params]

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -334,14 +334,20 @@
    [#(and (config/admin-routes-enabled)
           (config/app-routes-enabled))]
 
+   (GET "/tools" [:as {:keys [params]}]
+     (service/success-response (apps/admin-list-tools params)))
+
    (POST "/tools" [:as {:keys [body]}]
      (import-tools body))
 
    (DELETE "/tools/:tool-id" [tool-id]
-     (apps/delete-tool tool-id))
+     (apps/admin-delete-tool tool-id))
+
+   (GET "/tools/:tool-id" [tool-id]
+     (service/success-response (apps/admin-get-tool tool-id)))
 
    (PATCH "/tools/:tool-id" [tool-id :as {:keys [params body]}]
-          (apps/update-tool tool-id params body))
+     (apps/admin-update-tool tool-id params body))
 
    (PUT "/tools/:tool-id/integration-data/:integration-data-id" [tool-id integration-data-id]
      (service/success-response (apps/update-tool-integration-data tool-id integration-data-id)))
@@ -361,10 +367,28 @@
    [config/app-routes-enabled]
 
    (GET "/tools" [:as {:keys [params]}]
-     (service/success-response (apps/search-tools params)))
+     (service/success-response (apps/list-tools params)))
+
+   (POST "/tools" [:as {:keys [body]}]
+     (service/success-response (apps/create-private-tool body)))
+
+   (POST "/tools/permission-lister" [:as {:keys [body]}]
+     (service/success-response (apps/list-tool-permissions body)))
+
+   (POST "/tools/sharing" [:as {:keys [body]}]
+     (service/success-response (apps/share-tool body)))
+
+   (POST "/tools/unsharing" [:as {:keys [body]}]
+     (service/success-response (apps/unshare-tool body)))
+
+   (DELETE "/tools/:tool-id" [tool-id :as {:keys [params]}]
+     (apps/delete-private-tool tool-id params))
 
    (GET "/tools/:tool-id" [tool-id]
      (service/success-response (apps/get-tool tool-id)))
+
+   (PATCH "/tools/:tool-id" [tool-id :as {:keys [body]}]
+     (apps/update-private-tool tool-id body))
 
    (GET "/tools/:tool-id/integration-data" [tool-id]
      (service/success-response (apps/get-tool-integration-data tool-id)))

--- a/src/terrain/services/metadata/apps.clj
+++ b/src/terrain/services/metadata/apps.clj
@@ -32,7 +32,7 @@
    components are successfully imported."
   [body]
   (let [json (decode-json body)]
-    (dm/import-tools json)
+    (dm/admin-add-tools json)
     (dorun (map dn/send-tool-notification (:tools json))))
   (success-response))
 


### PR DESCRIPTION
The following apps service endpoint passthroughs have been added:

* `GET /admin/tools`
* `GET /admin/tools/:tool-id`
* `POST /tools`
* `POST /tools/permission-lister`
* `POST /tools/sharing`
* `POST /tools/unsharing`
* `DELETE /tools/:tool-id`
* `PATCH /tools/:tool-id`

Also the `public` parameter is now allowed with the `GET /tools` endpoint.