### PR TITLE
CORE-8800: get and delte endpoints for specific collaborator lists.

### DIFF
--- a/src/terrain/clients/iplant_groups.clj
+++ b/src/terrain/clients/iplant_groups.clj
@@ -69,11 +69,16 @@
   (c/grant-folder-privilege client (config/grouper-user) name user :stem)
   nil)
 
-(defn- ensure-folder-exists [client user name]
+(defn- folder-exists? [client user name]
   (try+
    (c/get-folder client user name)
+   true
    (catch [:status 404] _
-     (create-folder client user name)))
+     false)))
+
+(defn- ensure-folder-exists [client user name]
+  (when-not (folder-exists? client user name)
+    (create-folder client user name))
   nil)
 
 (def ^:private collaborator-list-group-type "group")
@@ -93,9 +98,15 @@
     (update-in (dissoc collaborator-list :detail) [:name] (fn [s] (string/replace s regex "")))))
 
 (defn- get-collaborator-lists* [client user lookup-fn]
-  (ensure-collaborator-list-folder-exists client user)
   (let [folder (get-collaborator-list-folder-name client user)]
-    {:groups (mapv (partial format-collaborator-list folder) (:groups (lookup-fn folder)))}))
+    (if (folder-exists? client user folder)
+      {:groups (mapv (partial format-collaborator-list folder) (:groups (lookup-fn folder)))}
+      {:groups []})))
+
+(defn- verify-group-exists [client user name]
+  ;; get-group will return a 404 if the group doesn't exist.
+  (c/get-group client user name)
+  nil)
 
 ;; This function kind of uses a hack. A search string is required, but if we make it the
 ;; same as the folder name then that approximates listing all groups in the folder. An
@@ -117,14 +128,14 @@
 
 (defn get-collaborator-list [user name]
   (let [client (get-client)
-        _      (ensure-collaborator-list-folder-exists client user)
         folder (get-collaborator-list-folder-name client user)]
     (->> (c/get-group client user (format "%s:%s" folder name))
          (format-collaborator-list folder))))
 
 (defn delete-collaborator-list [user name]
   (let [client (get-client)
-        _      (ensure-collaborator-list-folder-exists client user)
-        folder (get-collaborator-list-folder-name client user)]
-    (->> (c/delete-group client user (format "%s:%s" folder name))
+        folder (get-collaborator-list-folder-name client user)
+        group  (format "%s:%s" folder name)]
+    (verify-group-exists client user group)
+    (->> (c/delete-group client user group)
          (format-collaborator-list folder))))

--- a/src/terrain/clients/iplant_groups.clj
+++ b/src/terrain/clients/iplant_groups.clj
@@ -121,3 +121,10 @@
         folder (get-collaborator-list-folder-name client user)]
     (->> (c/get-group client user (format "%s:%s" folder name))
          (format-collaborator-list folder))))
+
+(defn delete-collaborator-list [user name]
+  (let [client (get-client)
+        _      (ensure-collaborator-list-folder-exists client user)
+        folder (get-collaborator-list-folder-name client user)]
+    (->> (c/delete-group client user (format "%s:%s" folder name))
+         (format-collaborator-list folder))))

--- a/src/terrain/clients/iplant_groups.clj
+++ b/src/terrain/clients/iplant_groups.clj
@@ -114,3 +114,10 @@
     (ensure-collaborator-list-folder-exists client user)
     (->> (c/add-group client user (str folder ":" name) collaborator-list-group-type description)
          (format-collaborator-list folder))))
+
+(defn get-collaborator-list [user name]
+  (let [client (get-client)
+        _      (ensure-collaborator-list-folder-exists client user)
+        folder (get-collaborator-list-folder-name client user)]
+    (->> (c/get-group client user (format "%s:%s" folder name))
+         (format-collaborator-list folder))))

--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -20,7 +20,10 @@
      (service/success-response (cl/add-collaborator-list current-user (json/decode (slurp body) true))))
 
    (GET "/collaborator-lists/:name" [name]
-     (service/success-response (cl/get-collaborator-list current-user name)))))
+     (service/success-response (cl/get-collaborator-list current-user name)))
+
+   (DELETE "/collaborator-lists/:name" [name]
+     (service/success-response (cl/delete-collaborator-list current-user name)))))
 
 (defn secured-collaborator-routes
   []

--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -17,7 +17,10 @@
      (service/success-response (cl/get-collaborator-lists current-user params)))
 
    (POST "/collaborator-lists" [:as {:keys [body]}]
-     (service/success-response (cl/add-collaborator-list current-user (json/decode (slurp body) true))))))
+     (service/success-response (cl/add-collaborator-list current-user (json/decode (slurp body) true))))
+
+   (GET "/collaborator-lists/:name" [name]
+     (service/success-response (cl/get-collaborator-list current-user name)))))
 
 (defn secured-collaborator-routes
   []

--- a/src/terrain/services/collaborator_lists.clj
+++ b/src/terrain/services/collaborator_lists.clj
@@ -8,3 +8,6 @@
 
 (defn add-collaborator-list [{user :shortUsername} body]
   (ipg/add-collaborator-list user body))
+
+(defn get-collaborator-list [{user :shortUsername} name]
+  (ipg/get-collaborator-list user name))

--- a/src/terrain/services/collaborator_lists.clj
+++ b/src/terrain/services/collaborator_lists.clj
@@ -11,3 +11,6 @@
 
 (defn get-collaborator-list [{user :shortUsername} name]
   (ipg/get-collaborator-list user name))
+
+(defn delete-collaborator-list [{user :shortUsername} name]
+  (ipg/delete-collaborator-list user name))


### PR DESCRIPTION
This change adds `GET /collaborator-lists/:name` and `DELETE /collaborator-lists/:name` endpoints. It also changes the endpoints so that they don't try to create the Grouper folder that is used for collaborator lists unless that folder actually has to be present. For the time being, the only endpoint that has to ensure that the folder exists is the endpoint that adds a new collaborator list. I believe that this is the only endpoint that will have to ensure that the folder exists, but I'm not willing to commit to that statement completely at this time.

I'm hoping that preventing multiple endpoints from trying to create the folder will eliminate a concurrency issue that we were encountering when the listing and addition endpoints were called at about the same time. We may still encounter the same concurrency issue when there are two separate and nearly simultaneous calls to add a collaborator list for the same user when the collaborator-list folder hasn't been created yet. This situation should be rare enough not to cause significant problems for the time being. We may have to revisit this when the public API is exposed, though.