### PR TITLE
Added endpoints to create and list teams.

### DIFF
--- a/src/terrain/clients/iplant_groups.clj
+++ b/src/terrain/clients/iplant_groups.clj
@@ -220,3 +220,9 @@
           group     (c/add-group client user full-name team-group-type description)]
       (dorun (map (partial c/grant-group-privilege client user full-name c/public-user) public_privileges))
       (format-group (get-team-folder-name client) group))))
+
+(defn get-team [user name]
+  (let [client (get-client)
+        folder (get-team-folder-name client)]
+    (->> (c/get-group client user (format "%s:%s" folder name))
+         (format-group folder))))

--- a/src/terrain/core.clj
+++ b/src/terrain/core.clj
@@ -137,6 +137,7 @@
     (analysis-routes)
     (coge-routes)
     (collaborator-list-routes)
+    (team-routes)
     (subject-routes)
     (reference-genomes-routes)
     (tool-routes)

--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -6,6 +6,7 @@
             [terrain.clients.apps.raw :as apps]
             [terrain.services.collaborator-lists :as cl]
             [terrain.services.subjects :as subjects]
+            [terrain.services.teams :as teams]
             [terrain.util.config :as config]
             [terrain.util.service :as service]))
 
@@ -38,6 +39,17 @@
    (POST "/collaborator-lists/:name/members/deleter" [name :as {:keys [body]}]
      (service/success-response
       (cl/remove-collaborator-list-members current-user name (service/decode-json body))))))
+
+(defn team-routes
+  []
+  (optional-routes
+   [config/collaborator-routes-enabled]
+
+   (GET "/teams" [:as {:keys [params]}]
+     (service/success-response (teams/get-teams current-user params)))
+
+   (POST "/teams" [:as {:keys [body]}]
+     (service/success-response (teams/add-team current-user (service/decode-json body))))))
 
 (defn subject-routes
   []

--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -49,7 +49,10 @@
      (service/success-response (teams/get-teams current-user params)))
 
    (POST "/teams" [:as {:keys [body]}]
-     (service/success-response (teams/add-team current-user (service/decode-json body))))))
+     (service/success-response (teams/add-team current-user (service/decode-json body))))
+
+   (GET "/teams/:name" [name]
+     (service/success-response (teams/get-team current-user name)))))
 
 (defn subject-routes
   []

--- a/src/terrain/services/teams.clj
+++ b/src/terrain/services/teams.clj
@@ -1,0 +1,12 @@
+(ns terrain.services.teams
+  (:require [terrain.clients.iplant-groups :as ipg]
+            [terrain.clients.permissions :as perms-client]))
+
+(defn get-teams [{user :shortUsername} {:keys [search]}]
+  (if-not search
+    (ipg/get-teams user)
+    (ipg/get-teams user search)))
+
+
+(defn add-team [{user :shortUsername} body]
+  (ipg/add-team user body))

--- a/src/terrain/services/teams.clj
+++ b/src/terrain/services/teams.clj
@@ -2,11 +2,8 @@
   (:require [terrain.clients.iplant-groups :as ipg]
             [terrain.clients.permissions :as perms-client]))
 
-(defn get-teams [{user :shortUsername} {:keys [search]}]
-  (if-not search
-    (ipg/get-teams user)
-    (ipg/get-teams user search)))
-
+(defn get-teams [{user :shortUsername} params]
+  (ipg/get-teams user (select-keys params [:search :creator :member])))
 
 (defn add-team [{user :shortUsername} body]
   (ipg/add-team user body))

--- a/src/terrain/services/teams.clj
+++ b/src/terrain/services/teams.clj
@@ -7,3 +7,6 @@
 
 (defn add-team [{user :shortUsername} body]
   (ipg/add-team user body))
+
+(defn get-team [{user :shortUsername} name]
+  (ipg/get-team user name))


### PR DESCRIPTION
Example team creation:

```
$ curl -sH "$AUTH_HEADER" -H "Content-Type: application/json" -d '{"name":"aqua-team","description":"mah team description","public_privileges":["view","optin"]}' "http://localhost:8080/teams" | jq .
{
  "description": "mah team description",
  "name": "dennis:aqua-team",
  "type": "group",
  "extension": "aqua-team",
  "id": "230705b9ee8a40fa80c12bc2a1ba2efc",
  "display_extension": "aqua-team",
  "display_name": "iplant:de:de-2:teams:dennis:aqua-team",
  "id_index": "11104"
}
```

Team listings can be filtered by `creator` (the username of the user who created the team), `member` (the username of a member of the group--only groups containing that user will be listed), and `search` (a partial group name search). Grouper doesn't provide a group name search when searching for groups containing a member, so the `search` parameter is approximated in terrain for this case.