### PR TITLE
Team Membership Endpoints

### DIFF
--- a/src/terrain/clients/iplant_groups.clj
+++ b/src/terrain/clients/iplant_groups.clj
@@ -242,15 +242,19 @@
 (defn update-team [user name updates]
   (let [client  (get-client)
         folder  (get-team-folder-name client)
-        creator (first (string/split name #":" 2))]
+        creator (first (string/split name #":" 2))
+        group   (full-group-name name folder)]
+    (verify-group-exists client user group)
     (->> (update (select-keys updates [:name :description]) :name
                  full-group-name (get-team-folder-name client creator))
          (remove-vals nil?)
-         (c/update-group client user (full-group-name name folder))
+         (c/update-group client user group)
          (format-group folder))))
 
 (defn delete-team [user name]
   (let [client (get-client)
-        folder (get-team-folder-name client)]
-    (->> (c/delete-group client user (full-group-name name folder))
+        folder (get-team-folder-name client)
+        group  (full-group-name name folder)]
+    (verify-group-exists client user group)
+    (->> (c/delete-group client user group)
          (format-group folder))))

--- a/src/terrain/clients/iplant_groups.clj
+++ b/src/terrain/clients/iplant_groups.clj
@@ -272,3 +272,10 @@
         group  (full-group-name name folder)]
     (verify-group-exists client user group)
     (c/add-group-members client user group members)))
+
+(defn remove-team-members [user name members]
+  (let [client (get-client)
+        folder (get-team-folder-name client)
+        group  (full-group-name name folder)]
+    (verify-group-exists client user group)
+    (c/remove-group-members client user group members)))

--- a/src/terrain/clients/iplant_groups.clj
+++ b/src/terrain/clients/iplant_groups.clj
@@ -258,3 +258,10 @@
     (verify-group-exists client user group)
     (->> (c/delete-group client user group)
          (format-group folder))))
+
+(defn get-team-members [user name]
+  (let [client (get-client)
+        folder (get-team-folder-name client)
+        group  (full-group-name name folder)]
+    (verify-group-exists client user group)
+    (c/list-group-members client user group)))

--- a/src/terrain/clients/iplant_groups.clj
+++ b/src/terrain/clients/iplant_groups.clj
@@ -265,3 +265,10 @@
         group  (full-group-name name folder)]
     (verify-group-exists client user group)
     (c/list-group-members client user group)))
+
+(defn add-team-members [user name members]
+  (let [client (get-client)
+        folder (get-team-folder-name client)
+        group  (full-group-name name folder)]
+    (verify-group-exists client user group)
+    (c/add-group-members client user group members)))

--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -64,7 +64,10 @@
      (service/success-response (teams/get-team-members current-user name)))
 
    (POST "/teams/:name/members" [name :as {:keys [body]}]
-     (service/success-response (teams/add-team-members current-user name (service/decode-json body))))))
+     (service/success-response (teams/add-team-members current-user name (service/decode-json body))))
+
+   (POST "/teams/:name/members/deleter" [name :as {:keys [body]}]
+     (service/success-response (teams/remove-team-members current-user name (service/decode-json body))))))
 
 (defn subject-routes
   []

--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -58,7 +58,10 @@
      (service/success-response (teams/update-team current-user name (service/decode-json body))))
 
    (DELETE "/teams/:name" [name]
-     (service/success-response (teams/delete-team current-user name)))))
+     (service/success-response (teams/delete-team current-user name)))
+
+   (GET "/teams/:name/members" [name]
+     (service/success-response (teams/get-team-members current-user name)))))
 
 (defn subject-routes
   []

--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -61,7 +61,10 @@
      (service/success-response (teams/delete-team current-user name)))
 
    (GET "/teams/:name/members" [name]
-     (service/success-response (teams/get-team-members current-user name)))))
+     (service/success-response (teams/get-team-members current-user name)))
+
+   (POST "/teams/:name/members" [name :as {:keys [body]}]
+     (service/success-response (teams/add-team-members current-user name (service/decode-json body))))))
 
 (defn subject-routes
   []

--- a/src/terrain/services/teams.clj
+++ b/src/terrain/services/teams.clj
@@ -16,3 +16,6 @@
 
 (defn delete-team [{user :shortUsername} name]
   (ipg/delete-team user name))
+
+(defn get-team-members [{user :shortUsername} name]
+  (ipg/get-team-members user name))

--- a/src/terrain/services/teams.clj
+++ b/src/terrain/services/teams.clj
@@ -19,3 +19,6 @@
 
 (defn get-team-members [{user :shortUsername} name]
   (ipg/get-team-members user name))
+
+(defn add-team-members [{user :shortUsername} name {:keys [members]}]
+  (ipg/add-team-members user name members))

--- a/src/terrain/services/teams.clj
+++ b/src/terrain/services/teams.clj
@@ -22,3 +22,6 @@
 
 (defn add-team-members [{user :shortUsername} name {:keys [members]}]
   (ipg/add-team-members user name members))
+
+(defn remove-team-members [{user :shortUsername} name {:keys [members]}]
+  (ipg/remove-team-members user name members))


### PR DESCRIPTION
This change adds endpoints to add, remove, and list team members. It also adds an extra validation step to several existing endpoints to ensure that a 404 is returned if someone tries to update a team that doesn't exist.
