### PR TITLE
Collaborator List Permission Retention

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :description "Discovery Environment API gateway/API services catch-all project"
   :url "https://github.com/cyverse-de/terrain"
   :license {:name "BSD Standard License"
-            :url "http://www.iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
+            :url "http://www.cyverse.org/sites/default/files/iPLANT-LICENSE.txt"}
   :manifest {"Git-Ref" ~(git-ref)}
   :uberjar-name "terrain-standalone.jar"
   :dependencies [[org.clojure/clojure "1.8.0"]
@@ -34,13 +34,13 @@
                  [org.cyverse/clj-icat-direct "2.8.0"]
                  [org.cyverse/clj-jargon "2.8.3"]
                  [org.cyverse/clojure-commons "2.8.1"]
-                 [org.cyverse/cyverse-groups-client "0.1.2-SNAPSHOT"]
+                 [org.cyverse/cyverse-groups-client "0.1.2"]
                  [org.cyverse/tree-urls-client "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/kameleon "3.0.1"]
                  [org.cyverse/heuristomancer "2.8.0"]
-                 [org.cyverse/permissions-client "2.8.1-SNAPSHOT"]
+                 [org.cyverse/permissions-client "2.8.1"]
                  [org.cyverse/service-logging "2.8.0"]]
   :eastwood {:exclude-namespaces [terrain.util.jwt :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/kameleon "3.0.1"]
                  [org.cyverse/heuristomancer "2.8.0"]
-                 [org.cyverse/permissions-client "2.8.0"]
+                 [org.cyverse/permissions-client "2.8.1-SNAPSHOT"]
                  [org.cyverse/service-logging "2.8.0"]]
   :eastwood {:exclude-namespaces [terrain.util.jwt :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}

--- a/src/terrain/clients/permissions.clj
+++ b/src/terrain/clients/permissions.clj
@@ -16,3 +16,8 @@
    (c/delete-subject (get-client) external-id "group")
    (catch [:status 404] _))
   nil)
+
+(defn copy-permissions
+  "Copies permissions from one subject to one or more other subjects."
+  [source-type source-id dest-subjects]
+  (c/copy-permissions (get-client) source-type source-id dest-subjects))

--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -36,9 +36,9 @@
    (POST "/collaborator-lists/:name/members" [name :as {:keys [body]}]
      (service/success-response (cl/add-collaborator-list-members current-user name (service/decode-json body))))
 
-   (POST "/collaborator-lists/:name/members/deleter" [name :as {:keys [body]}]
+   (POST "/collaborator-lists/:name/members/deleter" [name :as {:keys [body params]}]
      (service/success-response
-      (cl/remove-collaborator-list-members current-user name (service/decode-json body))))))
+      (cl/remove-collaborator-list-members current-user name (service/decode-json body) params)))))
 
 (defn team-routes
   []

--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -27,8 +27,8 @@
    (PATCH "/collaborator-lists/:name" [name :as {:keys [body]}]
      (service/success-response (cl/update-collaborator-list current-user name (service/decode-json body))))
 
-   (DELETE "/collaborator-lists/:name" [name]
-     (service/success-response (cl/delete-collaborator-list current-user name)))
+   (DELETE "/collaborator-lists/:name" [name :as {:keys [params]}]
+     (service/success-response (cl/delete-collaborator-list current-user name params)))
 
    (GET "/collaborator-lists/:name/members" [name]
      (service/success-response (cl/get-collaborator-list-members current-user name)))

--- a/src/terrain/services/collaborator_lists.clj
+++ b/src/terrain/services/collaborator_lists.clj
@@ -16,20 +16,28 @@
 (defn update-collaborator-list [{user :shortUsername} name body]
   (ipg/update-collaborator-list user name body))
 
-(defn delete-collaborator-list [{user :shortUsername} name]
+(defn- perms-subject-for [{source-id :source_id :as subject}]
+  {:subject_type (if (= source-id "g:gsa") "group" "user")
+   :subject_id   ((some-fn :subject_id :id) subject)})
+
+(defn- delete-collaborator-list* [user name & [postproc-fn]]
   (let [{:keys [id] :as list} (ipg/delete-collaborator-list user name)]
-    (when id (perms-client/delete-group-subject id))
+    (when [id]
+      (when postproc-fn (postproc-fn id))
+      (perms-client/delete-group-subject id))
     list))
+
+(defn delete-collaborator-list [{user :shortUsername} name {retain-permissions? :retain-permissions}]
+  (if (Boolean/parseBoolean retain-permissions?)
+    (let [subjects (mapv perms-subject-for (:members (ipg/get-collaborator-list-members user name)))]
+      (delete-collaborator-list* user name (fn [group-id] (perms-client/copy-permissions "group" group-id subjects))))
+    (delete-collaborator-list* user name)))
 
 (defn get-collaborator-list-members [{user :shortUsername} name]
   (ipg/get-collaborator-list-members user name))
 
 (defn add-collaborator-list-members [{user :shortUsername} name {:keys [members]}]
   (ipg/add-collaborator-list-members user name members))
-
-(defn- perms-subject-for [{source-id :source_id subject-id :subject_id}]
-  {:subject_type (if (= source-id "g:gsa") "group" "user")
-   :subject_id   subject-id})
 
 (defn- copy-collaborator-list-permissions [user group-id {:keys [results]}]
   (when-let [subjects (seq (for [result results :when (:success result)] (perms-subject-for result)))]


### PR DESCRIPTION
This change allows users to grant the permissions that had been granted to a collaborator list directly to be granted to members that are removed from a collaborator list or to all collaborator list members if the collaborator list is being deleted.

Update: I had some other minor changes to the subject search endpoint that were finished shortly after I submitted this PR. Rather than create a new branch and a new PR, I just included these changes with this PR.