### PR TITLE
CORE-8986: allow administrative users to remove themselves from a team

### DIFF
--- a/src/terrain/clients/iplant_groups.clj
+++ b/src/terrain/clients/iplant_groups.clj
@@ -304,14 +304,15 @@
          (mapv :subject)
          (remove (comp (partial = (config/grouper-user)) :id)))))
 
-(defn- format-privilege-updates [subject-ids privileges]
-  {:updates (vec (for [subject-id subject-ids] {:subject_id subject-id :privileges privileges}))})
+(defn- format-privilege-updates [user subject-ids privileges]
+  {:updates (vec (for [subject-id subject-ids :when (not= user subject-id)]
+                   {:subject_id subject-id :privileges privileges}))})
 
 (defn- grant-optout-privileges [client user group members]
-  (c/update-group-privileges client user group (format-privilege-updates members ["optout"]) {:replace false}))
+  (c/update-group-privileges client user group (format-privilege-updates user members ["optout"]) {:replace false}))
 
 (defn- revoke-optout-privileges [client user group members]
-  (c/revoke-group-privileges client user group (format-privilege-updates members ["optout"])))
+  (c/revoke-group-privileges client user group (format-privilege-updates user members ["optout"])))
 
 (defn add-team-members [user name members]
   (let [client (get-client)


### PR DESCRIPTION
This change only applies if a team administrator tries to remove themselves using the POST /teams/:team-name/members/deleter endpoint. The POST /teams/:team-name/leave endpoint will still work because it uses the configured Grouper admin user to update the team privileges.
