### PR TITLE
Team notification updates.

### DIFF
--- a/src/terrain/clients/notifications.clj
+++ b/src/terrain/clients/notifications.clj
@@ -76,7 +76,7 @@
   [user team-name]
   (send-notification {:type "team"
                       :user (:id user)
-                      :subject (str "Added to team")
+                      :subject "Added to team"
                       :email true
                       :email_template "added_to_team"
                       :payload {:email_address (:email user)

--- a/src/terrain/clients/notifications.clj
+++ b/src/terrain/clients/notifications.clj
@@ -70,6 +70,17 @@
                                 :team_name team-name
                                 :admin_message message}}))
 
+(defn send-team-add-notification
+  "Sends a notification indicating that the userhas been added to a team."
+  [user team-name]
+  (send-notification {:type "team"
+                      :user (:id user)
+                      :subject (str "Added to team")
+                      :email true
+                      :email_template "added_to_team"
+                      :payload {:email_address (:email user)
+                                :team_name team-name}}))
+
 (defn mark-all-notifications-seen
   []
   (raw/mark-all-notifications-seen (cheshire/encode (add-current-user-to-map {}))))

--- a/src/terrain/clients/notifications.clj
+++ b/src/terrain/clients/notifications.clj
@@ -46,13 +46,14 @@
 
 (defn send-team-join-notification
   "Sends a notification indicating that a user has requested to join a team."
-  [user-name user-email team-name admin message]
+  [user user-name user-email team-name admin message]
   (send-notification {:type "team"
                       :user (:id admin)
                       :subject (str user-name " has requested to join team \"" team-name "\"")
                       :email true
                       :email_template "team_join_request"
                       :payload {:email_address (:email admin)
+                                :requester_id user
                                 :requester_name user-name
                                 :requester_email user-email
                                 :requester_message message

--- a/src/terrain/services/teams.clj
+++ b/src/terrain/services/teams.clj
@@ -23,7 +23,10 @@
   (ipg/get-team-members user name))
 
 (defn add-team-members [{user :shortUsername} name {:keys [members]}]
-  (ipg/add-team-members user name members))
+  (let [response (ipg/add-team-members user name members)]
+    (doseq [member members]
+      (cn/send-team-add-notification (ipg/lookup-subject user member) name))
+    response))
 
 (defn remove-team-members [{user :shortUsername} name {:keys [members]}]
   (ipg/remove-team-members user name members))

--- a/src/terrain/services/teams.clj
+++ b/src/terrain/services/teams.clj
@@ -25,7 +25,9 @@
 (defn add-team-members [{user :shortUsername} name {:keys [members]}]
   (let [response (ipg/add-team-members user name members)]
     (doseq [member members]
-      (cn/send-team-add-notification (ipg/lookup-subject user member) name))
+      (let [member-info (ipg/lookup-subject user member)]
+        (when-not (= (:source_id member-info) "g:gsa")
+          (cn/send-team-add-notification member-info name))))
     response))
 
 (defn remove-team-members [{user :shortUsername} name {:keys [members]}]

--- a/src/terrain/services/teams.clj
+++ b/src/terrain/services/teams.clj
@@ -42,7 +42,7 @@
 
 (defn join-request [{user :shortUsername user-name :commonName email :email} name message]
   (let [admin (first (ipg/get-team-admins user name))]
-    (cn/send-team-join-notification user-name email name admin message)))
+    (cn/send-team-join-notification user user-name email name admin message)))
 
 (defn deny-join-request [{user :shortUsername} name requester message]
   (ipg/verify-team-exists user name)


### PR DESCRIPTION
The primary purpose of this PR is to notify users when they have been added to a team. A minor modification to the team join request notification was also required.