### PR TITLE
CORE-9169 Email data admins when DOI data folder could not be moved.

### DIFF
--- a/src/terrain/util/email.clj
+++ b/src/terrain/util/email.clj
@@ -54,6 +54,19 @@
       "permanent_id_request"
       template-values)))
 
+(defn send-permanent-id-request-data-move-error
+  "Sends an email message informing data curators that a Permanent ID Request data folder could not be moved to the
+   commons repo folder."
+  [path dest-path {:keys [commonName]} error-msg]
+  (send-permanent-id-request
+    "Could not move Permanent ID Request data folder"
+    "permanent_id_request_move_error"
+    {:username      commonName
+     :environment   (config/environment-name)
+     :path          path
+     :dest          dest-path
+     :error_message error-msg}))
+
 (defn send-permanent-id-request-complete
   "Sends an email message informing data curators of a Permanent ID Request completion."
   [request-type path identifiers]


### PR DESCRIPTION
This PR will update the DOI request and creation functions so that errors from the `data-info` service will now be caught, data admins will be emailed about the error, and the DOI request/creation process can continue successfully.

This PR depends on cyverse-de/iplant-email#5