### PR TITLE
CORE-8699 Update /permanent-id-requests endpoints with DataCite client for DOI submissions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
   :uberjar-name "terrain-standalone.jar"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.codec "0.1.1"]
-                 [org.clojure/data.xml "0.0.8"]
+                 [org.clojure/data.xml "0.2.0-alpha5"]
                  [org.clojure/tools.nrepl "0.2.12"]
                  [cheshire "5.6.3"]
                  [clj-http "3.4.1"]

--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
   :uberjar-name "terrain-standalone.jar"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.codec "0.1.1"]
-                 [org.clojure/data.xml "0.2.0-alpha5"]
+                 [org.clojure/data.xml "0.0.8"]
                  [org.clojure/tools.nrepl "0.2.12"]
                  [cheshire "5.6.3"]
                  [clj-http "3.4.1"]

--- a/project.clj
+++ b/project.clj
@@ -21,6 +21,7 @@
   :uberjar-name "terrain-standalone.jar"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.codec "0.1.1"]
+                 [org.clojure/data.xml "0.0.8"]
                  [org.clojure/tools.nrepl "0.2.12"]
                  [cheshire "5.6.3"]
                  [clj-http "3.4.1"]

--- a/src/terrain/clients/datacite.clj
+++ b/src/terrain/clients/datacite.clj
@@ -1,0 +1,90 @@
+(ns terrain.clients.datacite
+  (:require [clojure.data.xml :as xml]))
+
+(def ^:private resource-xsi "http://www.w3.org/2001/XMLSchema-instance")
+(def ^:private resource-xmlns "http://datacite.org/schema/kernel-4")
+(def ^:private resource-schema-location
+  "http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4/metadata.xsd")
+
+(defn- merge-xml-attrs
+  [xml-attrs {:keys [attr value]}]
+  (if (empty? value)
+    xml-attrs
+    (assoc xml-attrs (keyword attr) value)))
+
+(defn- avu->xml-element
+  [attr {:keys [value avus]}]
+  (when-not (empty? value)
+    (xml/element attr (reduce merge-xml-attrs {} avus) value)))
+
+(defn- avus->xml-element-list
+  [avus]
+  (map #(avu->xml-element (:attr %) %) avus))
+
+(defn- xml-element-group
+  [group-attr xml-element-list]
+  (let [xml-element-list (remove nil? xml-element-list)]
+    (when-not (empty? xml-element-list)
+      (xml/element group-attr {} xml-element-list))))
+
+(defn- creator->xml-element
+  [{:keys [value avus]}]
+  (when-not (empty? value)
+    (xml/element :creator {}
+                 (xml/element :creatorName {} value)
+                 (avus->xml-element-list avus))))
+
+(defn- contributor->xml-element
+  [{:keys [value avus]}]
+  (when-not (empty? value)
+    (xml/element :contributor
+                 (reduce merge-xml-attrs {} (filter #(= "contributorType" (:attr %)) avus))
+                 (xml/element :contributorName {} value)
+                 (avus->xml-element-list (remove #(= "contributorType" (:attr %)) avus)))))
+
+(defn- geo-location->xml-element
+  [{:keys [avus]}]
+  (let [geo-places (filter (comp #{"geoLocationPlace"} :attr) avus)
+        geo-points (filter (comp #{"pointLatitude" "pointLongitude"} :attr) avus)
+        geo-bounds (filter (comp #{"northBoundLatitude"
+                                   "southBoundLatitude"
+                                   "eastBoundLongitude"
+                                   "westBoundLongitude"} :attr) avus)]
+    (xml/element :geoLocation {}
+                 (avus->xml-element-list geo-places)
+                 (xml-element-group :geoLocationPoint (avus->xml-element-list geo-points))
+                 (xml-element-group :geoLocationBox   (avus->xml-element-list geo-bounds)))))
+
+(defn- avus->xml-element
+  [attr avus]
+  (case attr
+    :creator     (xml-element-group :creators     (map creator->xml-element avus))
+    :contributor (xml-element-group :contributors (map contributor->xml-element avus))
+    :geoLocation (xml-element-group :geoLocations (map geo-location->xml-element avus))
+
+    :title               (xml-element-group :titles               (avus->xml-element-list avus))
+    :subject             (xml-element-group :subjects             (avus->xml-element-list avus))
+    :description         (xml-element-group :descriptions         (avus->xml-element-list avus))
+    :alternateIdentifier (xml-element-group :alternateIdentifiers (avus->xml-element-list avus))
+    :relatedIdentifier   (xml-element-group :relatedIdentifiers   (avus->xml-element-list avus))
+    :rights              (xml-element-group :rightsList           (avus->xml-element-list avus))
+
+    :identifier      (avus->xml-element-list avus)
+    :publisher       (avus->xml-element-list avus)
+    :publicationYear (avus->xml-element-list avus)
+    :resourceType    (avus->xml-element-list avus)
+
+    nil))
+
+(defn- append-metadata-group
+  [xml-element-list [attr avus]]
+  (conj xml-element-list (avus->xml-element attr avus)))
+
+(defn avus->datacite-xml
+  [avus]
+  (let [metadata (group-by (comp keyword :attr) avus)]
+    (xml/emit-str
+      (xml/element :resource {:xmlns:xsi          resource-xsi
+                              :xmlns              resource-xmlns
+                              :xsi:schemaLocation resource-schema-location}
+                   (reduce append-metadata-group [] metadata)))))

--- a/src/terrain/clients/datacite.clj
+++ b/src/terrain/clients/datacite.clj
@@ -13,13 +13,13 @@
     (assoc xml-attrs (keyword attr) value)))
 
 (defn- avu->xml-element
-  [attr {:keys [value avus]}]
+  [{:keys [attr value avus]}]
   (when-not (empty? value)
     (xml/element attr (reduce merge-xml-attrs {} avus) value)))
 
 (defn- avus->xml-element-list
   [avus]
-  (map #(avu->xml-element (:attr %) %) avus))
+  (map avu->xml-element avus))
 
 (defn- xml-element-group
   [group-attr xml-element-list]
@@ -30,9 +30,10 @@
 (defn- creator->xml-element
   [{:keys [value avus]}]
   (when-not (empty? value)
-    (xml/element :creator {}
+    (xml/element :creator
+                 (reduce merge-xml-attrs {} (filter #(= "nameType" (:attr %)) avus))
                  (xml/element :creatorName {} value)
-                 (avus->xml-element-list avus))))
+                 (avus->xml-element-list (remove #(= "nameType" (:attr %)) avus)))))
 
 (defn- contributor->xml-element
   [{:keys [value avus]}]
@@ -41,6 +42,11 @@
                  (reduce merge-xml-attrs {} (filter #(= "contributorType" (:attr %)) avus))
                  (xml/element :contributorName {} value)
                  (avus->xml-element-list (remove #(= "contributorType" (:attr %)) avus)))))
+
+(defn- fundingRef->xml-element
+  [{:keys [avus]}]
+  (xml/element :fundingReference {}
+               (avus->xml-element-list avus)))
 
 (defn- geo-location->xml-element
   [{:keys [avus]}]
@@ -58,9 +64,10 @@
 (defn- avus->xml-element
   [attr avus]
   (case attr
-    :creator     (xml-element-group :creators     (map creator->xml-element avus))
-    :contributor (xml-element-group :contributors (map contributor->xml-element avus))
-    :geoLocation (xml-element-group :geoLocations (map geo-location->xml-element avus))
+    :creator          (xml-element-group :creators          (map creator->xml-element avus))
+    :contributor      (xml-element-group :contributors      (map contributor->xml-element avus))
+    :geoLocation      (xml-element-group :geoLocations      (map geo-location->xml-element avus))
+    :fundingReference (xml-element-group :fundingReferences (map fundingRef->xml-element avus))
 
     :title               (xml-element-group :titles               (avus->xml-element-list avus))
     :subject             (xml-element-group :subjects             (avus->xml-element-list avus))
@@ -68,11 +75,15 @@
     :alternateIdentifier (xml-element-group :alternateIdentifiers (avus->xml-element-list avus))
     :relatedIdentifier   (xml-element-group :relatedIdentifiers   (avus->xml-element-list avus))
     :rights              (xml-element-group :rightsList           (avus->xml-element-list avus))
+    :size                (xml-element-group :sizes                (avus->xml-element-list avus))
+    :format              (xml-element-group :formats              (avus->xml-element-list avus))
 
     :identifier      (avus->xml-element-list avus)
     :publisher       (avus->xml-element-list avus)
     :publicationYear (avus->xml-element-list avus)
     :resourceType    (avus->xml-element-list avus)
+    :language        (avus->xml-element-list avus)
+    :version         (avus->xml-element-list avus)
 
     nil))
 

--- a/src/terrain/clients/ezid.clj
+++ b/src/terrain/clients/ezid.clj
@@ -68,7 +68,7 @@
 
 (defn mint-id
   "Mints a new permanent ID under the given shoulder with the given metadata.
-   http://ezid.cdlib.org/doc/apidoc.html#operation-mint-identifier"
+   https://support.datacite.org/v1.1/reference#mint-doi"
   [shoulder metadata]
   (try+
     (let [response (ezid-post metadata "shoulder" shoulder)

--- a/src/terrain/routes/permanent_id_requests.clj
+++ b/src/terrain/routes/permanent_id_requests.clj
@@ -42,5 +42,8 @@
     (POST "/permanent-id-requests/:request-id/ezid" [request-id]
       (service/success-response (create-permanent-id request-id)))
 
+    (GET "/permanent-id-requests/:request-id/preview-submission" [request-id]
+      (service/success-response (preview-datacite-xml request-id)))
+
     (POST "/permanent-id-requests/:request-id/status" [request-id :as {:keys [body]}]
       (service/success-response (update-permanent-id-request request-id body)))))

--- a/src/terrain/services/permanent_id_requests.clj
+++ b/src/terrain/services/permanent_id_requests.clj
@@ -6,6 +6,7 @@
             [clj-time.core :as time]
             [clojure.tools.logging :as log]
             [clojure-commons.file-utils :as ft]
+            [terrain.clients.datacite :as datacite]
             [terrain.clients.data-info :as data-info]
             [terrain.clients.data-info.raw :as data-info-client]
             [terrain.clients.ezid :as ezid]
@@ -43,18 +44,25 @@ For example, https://doi.org/10.7946/P2G596 links to the DOI 10.7946/P2G596.")
   [path]
   (str (ft/rm-last-slash (config/permanent-id-target-base-url)) (format-publish-path path)))
 
+(defn- find-attr-value
+  [avus attr]
+  (->> avus
+       (filter #(= attr (:attr %)))
+       first
+       :value))
+
 (defn- validate-ezid-metadata
-  [ezid-metadata]
-  (when (empty? ezid-metadata)
+  [avus]
+  (when (empty? avus)
     (throw+ {:type :clojure-commons.exception/bad-request
              :error "No metadata found for Permanent ID Request."}))
-  (let [identifier (get ezid-metadata (config/permanent-id-identifier-attr))]
+  (let [identifier (find-attr-value avus (config/permanent-id-identifier-attr))]
     (when-not (empty? identifier)
       (throw+ {:type :clojure-commons.exception/bad-request
                :error "The metadata already contains a Permanent Identifier attribute with a value."
                :attribute (config/permanent-id-identifier-attr)
                :identifier identifier})))
-  ezid-metadata)
+  avus)
 
 (defn- validate-request-for-completion
   [{:keys [folder original_path permanent_id]}]
@@ -234,14 +242,15 @@ For example, https://doi.org/10.7946/P2G596 links to the DOI 10.7946/P2G596.")
              :error "No EZID shoulder defined for this Permanent ID Request type."
              :request-type type})))
 
+(defn- format-avus
+  [{:keys [avus irods-avus]}]
+  (concat avus irods-avus [{:attr (config/permanent-id-date-attr) :value (str (time/year (time/now)))}]))
+
 (defn- parse-valid-ezid-metadata
-  [{:keys [path]} {:keys [avus irods-avus]}]
-  (let [format-avus #(vector (:attr %) (:value %))
-        ezid-metadata (into {} (concat (map format-avus irods-avus) (map format-avus avus)))]
-    (validate-ezid-metadata ezid-metadata)
-    (assoc ezid-metadata
-      ezid-target-attr (format-metadata-target-url path)
-      (config/permanent-id-date-attr) (str (time/year (time/now))))))
+  [{:keys [path]} avus]
+  (validate-ezid-metadata avus)
+  {ezid-target-attr (format-metadata-target-url path)
+   :datacite        (datacite/avus->datacite-xml avus)})
 
 (defn- get-validated-data-item
   "Gets data-info stat for the given ID and checks if the data item is valid for a Permanent ID request.
@@ -249,34 +258,23 @@ For example, https://doi.org/10.7946/P2G596 links to the DOI 10.7946/P2G596.")
   [user data-id]
   (let [data-item (->> (data-info/stat-by-uuid user data-id :filter-include "path,id,type,permission,file-count,dir-count") (validate-data-item user))
         metadata (data-info/get-metadata-json user data-id)]
-    (parse-valid-ezid-metadata data-item metadata)
+    (parse-valid-ezid-metadata data-item (format-avus metadata))
     data-item))
-
-(defn- format-alt-id-avus
-  "Formats metadata service AVUs from the alt-identifiers-map."
-  [alt-identifiers-map]
-  (mapcat (fn [[k v]] [{:attr (config/permanent-id-alt-identifier-attr)
-                        :value v
-                        :unit ""}
-                       {:attr (config/permanent-id-alt-identifier-type-attr)
-                        :value (name k)
-                        :unit ""}])
-          alt-identifiers-map))
 
 (defn- format-publish-avus
   "Formats AVUs containing completed request information for saving with the metadata service."
-  [ezid-metadata identifier alt-identifiers]
-  (let [publish-date (get ezid-metadata (config/permanent-id-date-attr))
-        alt-id-avus  (format-alt-id-avus alt-identifiers)]
+  [avus identifier identifier-type]
+  (let [publish-date (find-attr-value avus (config/permanent-id-date-attr))]
     {:avus
-     (concat
-       alt-id-avus
-       [{:attr  (config/permanent-id-identifier-attr)
-         :value identifier
-         :unit  ""}
-        {:attr  (config/permanent-id-date-attr)
-         :value publish-date
-         :unit  ""}])}))
+     [{:attr  (config/permanent-id-identifier-attr)
+       :value identifier
+       :unit  ""
+       :avus  [{:attr  (config/permanent-id-identifier-type-attr)
+                :value identifier-type
+                :unit  ""}]}
+      {:attr  (config/permanent-id-date-attr)
+       :value publish-date
+       :unit  ""}]}))
 
 (defn- format-folder-details
   [user folder-id]
@@ -378,11 +376,10 @@ For example, https://doi.org/10.7946/P2G596 links to the DOI 10.7946/P2G596.")
           folder          (validate-publish-dest folder)
           folder-id       (uuidify (:id folder))
           metadata        (data-info/get-metadata-json user folder-id)
-          ezid-metadata   (parse-valid-ezid-metadata folder metadata)
-          ezid-response   (ezid/mint-id shoulder ezid-metadata)
+          avus            (format-avus metadata)
+          ezid-response   (ezid/mint-id shoulder (parse-valid-ezid-metadata folder avus))
           identifier      (get ezid-response (keyword type))
-          alt-identifiers (dissoc ezid-response (keyword type))
-          publish-avus    (format-publish-avus ezid-metadata identifier alt-identifiers)
+          publish-avus    (format-publish-avus avus identifier type)
           publish-path    (publish-data-item user folder)]
       (email/send-permanent-id-request-complete type
                                                 publish-path
@@ -405,3 +402,12 @@ For example, https://doi.org/10.7946/P2G596 links to the DOI 10.7946/P2G596.")
     (update-permanent-id-request request-id (json/encode {:status       status-code-completion
                                                           :comments     comments
                                                           :permanent_id identifier}))))
+
+(defn preview-datacite-xml
+  [request-id]
+  (let [user      (:shortUsername current-user)
+        {:keys [folder]} (admin-get-permanent-id-request request-id)
+        folder-id (uuidify (:id folder))
+        metadata  (data-info/get-metadata-json user folder-id)
+        avus      (format-avus metadata)]
+    (parse-valid-ezid-metadata folder avus)))

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -441,7 +441,7 @@
 (cc/defprop-optstr ezid-base-url
   "The EZID API base URL."
   [props config-valid configs]
-  "terrain.permanent-id.ezid.base-url" "https://ez.datacite.org")
+  "terrain.permanent-id.ezid.base-url" "https://ez.test.datacite.org")
 
 (cc/defprop-optstr ezid-username
   "The EZID API account username."

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -426,27 +426,22 @@
 (cc/defprop-optstr permanent-id-identifier-attr
   "The metadata attribute where a new permanent ID is stored."
   [props config-valid configs]
-  "terrain.permanent-id.attr.identifier" "Identifier")
+  "terrain.permanent-id.attr.identifier" "identifier")
 
-(cc/defprop-optstr permanent-id-alt-identifier-attr
-  "The metadata attribute where a new permanent ID is stored."
+(cc/defprop-optstr permanent-id-identifier-type-attr
+  "The metadata attribute for the type of the `permanent-id-identifier-attr` AVU."
   [props config-valid configs]
-  "terrain.permanent-id.attr.alt-identifier" "AlternateIdentifier")
-
-(cc/defprop-optstr permanent-id-alt-identifier-type-attr
-  "The metadata attribute where a new permanent ID is stored."
-  [props config-valid configs]
-  "terrain.permanent-id.attr.alt-identifier-type" "alternateIdentifierType")
+  "terrain.permanent-id.attr.identifier-type" "identifierType")
 
 (cc/defprop-optstr permanent-id-date-attr
   "The metadata attribute where a permanent ID request's publication year is set."
   [props config-valid configs]
-  "terrain.permanent-id.attr.publication-year" "datacite.publicationyear")
+  "terrain.permanent-id.attr.publication-year" "publicationYear")
 
 (cc/defprop-optstr ezid-base-url
   "The EZID API base URL."
   [props config-valid configs]
-  "terrain.permanent-id.ezid.base-url" "https://ezid.cdlib.org")
+  "terrain.permanent-id.ezid.base-url" "https://ez.datacite.org")
 
 (cc/defprop-optstr ezid-username
   "The EZID API account username."


### PR DESCRIPTION
This PR will update the `/permanent-id-requests` endpoints with a DataCite client for DOI submissions in order to support duplicated and nested metadata AVUs.

Since EZID is being discontinued, these endpoints have also been updated for DOI submission requests to [DataCite's EZ API](https://support.datacite.org/docs/datacite-ez-api-guide) (also requires updating the endpoints and credentials in terrain's configs).

This PR also adds a `GET /permanent-id-requests/:request-id/preview-submission` endpoint for previewing the DataCite XML, generated from folder metadata, that would be submitted to DataCite for DOIs.

Note that `terrain.clients.datacite` was written before work was done for https://github.com/cyverse-de/metadata-files.

This PR contains the minimal required for generating DataCite XML from nested metadata in the DE and submitting the results to DataCite for creating DOIs, but it does not currently validate the generated XML before submission. During testing, the DataCite submission endpoint simply returned an `Internal server error` for XML that did not validate against their DataCite v4 schema.

The `/permanent-id-requests` endpoints should probably be updated with the `metadata-files` library once that can support generating DataCite XML from nested metadata, and these endpoints should validate the submission XML and return informative error messages to admins on XML schema validation failures.