### PR TITLE
Add `/admin/communities` endpoints for admin App Community management.

### DIFF
--- a/src/terrain/core.clj
+++ b/src/terrain/core.clj
@@ -183,6 +183,7 @@
     (admin-app-comment-routes)
     (admin-app-community-routes)
     (admin-comment-routes)
+    (admin-community-routes)
     (admin-filesystem-metadata-routes)
     (admin-groups-routes)
     (admin-notification-routes)

--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -122,6 +122,35 @@
    (POST "/communities/:name/admins/deleter" [name :as {:keys [body]}]
      (service/success-response (communities/remove-community-admins current-user name (service/decode-json body))))))
 
+(defn admin-community-routes
+  []
+  (optional-routes
+   [config/collaborator-routes-enabled]
+
+   (GET "/communities" [:as {:keys [params]}]
+     (service/success-response (communities/admin-get-communities params)))
+
+   (POST "/communities" [:as {:keys [body]}]
+     (service/success-response (communities/add-community current-user (service/decode-json body))))
+
+   (GET "/communities/:name" [name]
+     (service/success-response (communities/admin-get-community name)))
+
+   (PATCH "/communities/:name" [name :as {:keys [body]}]
+     (service/success-response (communities/admin-update-community name (service/decode-json body))))
+
+   (DELETE "/communities/:name" [name]
+     (service/success-response (communities/admin-delete-community name)))
+
+   (GET "/communities/:name/admins" [name]
+     (service/success-response (communities/admin-get-community-admins name)))
+
+   (POST "/communities/:name/admins" [name :as {:keys [body]}]
+     (service/success-response (communities/admin-add-community-admins name (service/decode-json body))))
+
+   (POST "/communities/:name/admins/deleter" [name :as {:keys [body]}]
+     (service/success-response (communities/admin-remove-community-admins name (service/decode-json body))))))
+
 (defn subject-routes
   []
   (optional-routes

--- a/src/terrain/services/communities.clj
+++ b/src/terrain/services/communities.clj
@@ -1,7 +1,8 @@
 (ns terrain.services.communities
   (:require [terrain.clients.iplant-groups :as ipg]
             [terrain.clients.permissions :as perms-client]
-            [terrain.clients.notifications :as cn]))
+            [terrain.clients.notifications :as cn]
+            [terrain.util.config :as config]))
 
 (defn get-communities [{user :shortUsername} params]
   (ipg/get-communities user (select-keys params [:search :creator :member])))
@@ -32,3 +33,24 @@
 
 (defn remove-community-admins [{user :shortUsername} name {:keys [members]}]
   (ipg/remove-community-admins user name members))
+
+(defn admin-get-communities [params]
+  (get-communities {:shortUsername (config/grouper-user)} params))
+
+(defn admin-get-community [name]
+  (get-community {:shortUsername (config/grouper-user)} name))
+
+(defn admin-update-community [name body]
+  (update-community {:shortUsername (config/grouper-user)} name body))
+
+(defn admin-delete-community [name]
+  (delete-community {:shortUsername (config/grouper-user)} name))
+
+(defn admin-get-community-admins [name]
+  (get-community-admins {:shortUsername (config/grouper-user)} name))
+
+(defn admin-add-community-admins [name params]
+  (add-community-admins {:shortUsername (config/grouper-user)} name params))
+
+(defn admin-remove-community-admins [name params]
+  (remove-community-admins {:shortUsername (config/grouper-user)} name params))


### PR DESCRIPTION
This PR will add `/admin/communities` endpoints for admin App Community management for #71.

These admin endpoints just reuse the regular functions used by the `/communities` endpoints, except they act as the DE grouper user to ensure they always have admin permissions for each action.

The 1 exception to this is `POST /admin/communities`, which will still add the new community as the requesting user, automatically adding them as an admin to that community.