### PR TITLE
Check for tagged apps when renaming a community.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,6 +47,7 @@
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/kameleon "3.0.1"]
                  [org.cyverse/heuristomancer "2.8.0"]
+                 [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/permissions-client "2.8.1"]
                  [org.cyverse/service-logging "2.8.0"]]
   :eastwood {:exclude-namespaces [terrain.util.jwt :test-paths]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -121,10 +121,10 @@
                :follow-redirects false}))
 
 (defn admin-get-apps-in-community
-  [community-id]
+  [community-id  & {:keys [as] :or {as :stream}}]
   (client/get (apps-url "admin" "apps" "communities" community-id "apps")
               {:query-params     (secured-params)
-               :as               :stream
+               :as               as
                :follow-redirects false}))
 
 (defn search-apps

--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -107,8 +107,8 @@
    (GET "/communities/:name" [name]
      (service/success-response (communities/get-community current-user name)))
 
-   (PATCH "/communities/:name" [name :as {:keys [body]}]
-     (service/success-response (communities/update-community current-user name (service/decode-json body))))
+   (PATCH "/communities/:name" [name :as {:keys [params body]}]
+     (service/success-response (communities/update-community current-user name params (service/decode-json body))))
 
    (DELETE "/communities/:name" [name]
      (service/success-response (communities/delete-community current-user name)))
@@ -136,8 +136,8 @@
    (GET "/communities/:name" [name]
      (service/success-response (communities/admin-get-community name)))
 
-   (PATCH "/communities/:name" [name :as {:keys [body]}]
-     (service/success-response (communities/admin-update-community name (service/decode-json body))))
+   (PATCH "/communities/:name" [name :as {:keys [params body]}]
+     (service/success-response (communities/admin-update-community name params (service/decode-json body))))
 
    (DELETE "/communities/:name" [name]
      (service/success-response (communities/admin-delete-community name)))

--- a/src/terrain/services/communities.clj
+++ b/src/terrain/services/communities.clj
@@ -13,8 +13,8 @@
 (defn get-community [{user :shortUsername} name]
   (ipg/get-community user name))
 
-(defn update-community [{user :shortUsername} name body]
-  (ipg/update-community user name body))
+(defn update-community [{user :shortUsername} name {:keys [retag-apps force-rename]} body]
+  (ipg/update-community user name (Boolean/parseBoolean retag-apps) (Boolean/parseBoolean force-rename) body))
 
 (defn delete-community [{user :shortUsername} name]
   (let [{:keys [id] :as result} (ipg/delete-community user name)]
@@ -40,8 +40,8 @@
 (defn admin-get-community [name]
   (get-community {:shortUsername (config/grouper-user)} name))
 
-(defn admin-update-community [name body]
-  (update-community {:shortUsername (config/grouper-user)} name body))
+(defn admin-update-community [name params body]
+  (update-community {:shortUsername (config/grouper-user)} name params body))
 
 (defn admin-delete-community [name]
   (delete-community {:shortUsername (config/grouper-user)} name))

--- a/src/terrain/services/permanent_id_requests.clj
+++ b/src/terrain/services/permanent_id_requests.clj
@@ -208,7 +208,7 @@ For example, https://doi.org/10.7946/P2G596 links to the DOI 10.7946/P2G596.")
 (defn- publish-metadata
   [{:keys [id type]} publish-avus]
   (let [data-type (metadata/resolve-data-type type)]
-    (metadata/add-metadata-avus data-type id publish-avus)))
+    (metadata/update-avus data-type id publish-avus)))
 
 (defn- send-notification
   [user email subject contents request-id]

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -1,9 +1,8 @@
 (ns terrain.util.config
   (:use [slingshot.slingshot :only [throw+]])
-  (:require [clojure.string :as string]
-            [clojure-commons.config :as cc]
+  (:require [clojure-commons.config :as cc]
             [clojure-commons.error-codes :as ce]
-            [clojure.tools.logging :as log]))
+            [metadata-client.core :as metadata-client]))
 
 (def de-system-id "de")
 
@@ -398,6 +397,11 @@
   [props config-valid configs coge-enabled]
   "terrain.coge.user" "coge")
 
+(cc/defprop-optstr communities-metadata-attr
+  "The attr of an App Community tag AVU."
+  [props config-valid configs]
+  "terrain.communities.metadata.attr" "cyverse-community")
+
 (cc/defprop-optstr default-output-dir
   "The default name of the default job output directory."
   [props config-valid configs]
@@ -504,6 +508,9 @@
   "terrain.oauth.client-secret" "notprod")
 
 (defn tree-urls-attr [] "ipc-tree-urls")
+
+(def metadata-client
+  (memoize #(metadata-client/new-metadata-client (metadata-base-url))))
 
 (defn- validate-config
   "Validates the configuration settings after they've been loaded."


### PR DESCRIPTION
This PR will update `PATCH /(admin/)communities/{name}` to check for apps tagged in that community when the admin is renaming that community, by adding `retag-apps` and `force-rename` params to these endpoints, so that when these params are omitted (or set to `false`) when renaming the community, an `ERR_EXISTS` will be thrown if any apps are tagged. Otherwise, any app AVU tags will be updated with the new community name if the `retag-apps` param is set to `true`.

This PR also updates some `terrain.clients.metadata.raw` functions with cyverse-de/metadata-client@3.0.1 and an optional `terrain.communities.metadata.attr` config.