### PR TITLE
Add `/communities/:name/members`, `join`, and `leave` endpoints.

### DIFF
--- a/src/terrain/routes/collaborator.clj
+++ b/src/terrain/routes/collaborator.clj
@@ -120,7 +120,16 @@
      (service/success-response (communities/add-community-admins current-user name (service/decode-json body))))
 
    (POST "/communities/:name/admins/deleter" [name :as {:keys [body]}]
-     (service/success-response (communities/remove-community-admins current-user name (service/decode-json body))))))
+     (service/success-response (communities/remove-community-admins current-user name (service/decode-json body))))
+
+   (GET "/communities/:name/members" [name]
+     (service/success-response (communities/get-community-members current-user name)))
+
+   (POST "/communities/:name/join" [name]
+     (service/success-response (communities/join current-user name)))
+
+   (POST "/communities/:name/leave" [name]
+     (service/success-response (communities/leave current-user name)))))
 
 (defn admin-community-routes
   []

--- a/src/terrain/services/communities.clj
+++ b/src/terrain/services/communities.clj
@@ -34,6 +34,15 @@
 (defn remove-community-admins [{user :shortUsername} name {:keys [members]}]
   (ipg/remove-community-admins user name members))
 
+(defn get-community-members [{user :shortUsername} name]
+  (ipg/get-community-members user name))
+
+(defn join [{user :shortUsername} name]
+  (ipg/join-community user name))
+
+(defn leave [{user :shortUsername} name]
+  (ipg/leave-community user name))
+
 (defn admin-get-communities [params]
   (get-communities {:shortUsername (config/grouper-user)} params))
 


### PR DESCRIPTION
This PR will add `/communities/:name/members`, `/communities/:name/join`, and `/communities/:name/leave` endpoints.

The `/communities/:name` endpoint already supports the `?member=username` query param.

The current plan for these endpoints is to allow a user to "favorite" a community by becoming a member, and have only their "favorite" communities listed in the Apps window by the UI (via the `/communities/:name?member=username` endpoint).