### PR TITLE
Add public optin privileges when creating a community

### DIFF
--- a/src/terrain/services/communities.clj
+++ b/src/terrain/services/communities.clj
@@ -8,7 +8,7 @@
   (ipg/get-communities user (select-keys params [:search :creator :member])))
 
 (defn add-community [{user :shortUsername} body]
-  (ipg/add-community user (assoc body :public_privileges ["read"])))
+  (ipg/add-community user (assoc body :public_privileges ["read","optin"])))
 
 (defn get-community [{user :shortUsername} name]
   (ipg/get-community user name))


### PR DESCRIPTION
Was wondering why I couldn't join any communities where I wasn't an admin 😄 I _think_ this is the only spot where it's needed.