### PR TITLE
Analyses facade

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,6 +29,7 @@
                  [dire "0.5.4"]
                  [me.raynes/fs "1.4.6"]
                  [medley "0.8.4"]
+                 [proto-repl "0.3.1"]
                  [org.apache.tika/tika-core "1.14"]      ; provides org.apache.tika
                  [ring/ring-jetty-adapter "1.5.0"]
                  [slingshot "0.12.2"]

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -26,13 +26,11 @@
   (:body (http/put (analyses-url ["badges" id])
                    {:content-type  :json
                     :as            :json
-                    :form-params   submission-info})
-         {:id id :submission submission-info}))
+                    :form-params   submission-info})))
 
 (defn add-badge
   [submission-info]
   (:body (http/post (analyses-url ["badges"])
                     {:content-type :json
                      :as           :json
-                     :form-params  submission-info})
-         {:submission submission-info}))
+                     :form-params  submission-info})))

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -2,8 +2,7 @@
   (:require [terrain.util.config :refer [analyses-base-uri]]
             [clj-http.client :as http]
             [cemerick.url :refer [url]]
-            [terrain.auth.user-attributes :refer [current-user]]
-            [slingshot.slingshot :refer [throw+]]))
+            [terrain.auth.user-attributes :refer [current-user]]))
 
 
 (defn analyses-url

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -9,7 +9,7 @@
   ([components]
    (analyses-url components {}))
   ([components query]
-   (-> (apply url (cons (analyses-base-uri) components))
+   (-> (apply url (analyses-base-uri) components)
        (assoc :query (assoc query :user (:username current-user)))
        (str))))
 
@@ -19,8 +19,7 @@
 
 (defn delete-badge
   [id]
-  (http/delete (analyses-url ["badges" id]) {:as :json}) {:id id}
-  {:id id})
+  (:body (http/delete (analyses-url ["badges" id]) {:as :json})) {:id id})
 
 (defn update-badge
   [id submission-info]

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -1,0 +1,59 @@
+(ns terrain.clients.analyses
+  (:require [terrain.util.config :refer [analyses-base-uri]]
+            [terrain.util.transformers :refer [add-current-user-to-map]]
+            [clj-http.client :as http]
+            [clojure-commons.client :refer [build-url-with-query]]
+            [clojure-commons.error-codes :refer [ERR_NOT_FOUND
+                                                 ERR_BAD_REQUEST
+                                                 ERR_UNCHECKED_EXCEPTION]]
+            [slingshot.slingshot :refer [throw+]]))
+
+
+(defn analyses-url
+  ([relative-url]
+   (analyses-url relative-url {}))
+  ([relative-url query]
+   (build-url-with-query (analyses-base-uri)
+                         (add-current-user-to-map query) relative-url)))
+
+(defn process-response
+  [resp err-data]
+  (cond
+    (= (:status resp) 404)
+    (throw+ (merge {:error_code ERR_NOT_FOUND} err-data {:msg (:body resp)}))
+
+    (= (:status resp) 400)
+    (throw+ (merge {:error_code ERR_BAD_REQUEST} err-data {:msg (:body resp)}))
+
+    (= (:status resp) 500)
+    (throw+ (merge {:error_code ERR_UNCHECKED_EXCEPTION} err-data {:msg (:body resp)}))
+
+    (not (<= 200 (:status resp) 299))
+    (throw+ (merge {:error_code ERR_UNCHECKED_EXCEPTION} err-data {:msg (:body resp)}))
+
+    :else
+    (:body resp)))
+
+(defn get-badge
+  [id]
+  (process-response (http/get (analyses-url "/badges" id) {:as :json}) {:id id}))
+
+(defn delete-badge
+  [id]
+  (process-response (http/delete (analyses-url "/badges" id) {:as :json}) {:id id}))
+
+(defn update-badge
+  [id submission-info]
+  (process-response (http/put (analyses-url "/badges" id)
+                              {:content-type  :json
+                               :as            :json
+                               :body          submission-info})
+                    {:id id :submission submission-info}))
+
+(defn create-badge
+  [id submission-info]
+  (process-response (http/post (analyses-url "/badges")
+                               {:content-type :json
+                                :as           :json
+                                :body         submission-info})
+                    {:id id :submission submission-info}))

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -10,22 +10,17 @@
                                                  ERR_UNCHECKED_EXCEPTION]]
             [cemerick.url :refer [url]]
             [medley.core :refer [mapply]]
+            [terrain.auth.user-attributes :refer [current-user]]
             [slingshot.slingshot :refer [throw+]]))
 
-(defn- fix-user
-  [{:keys [user] :as user-map}]
-  (-> user-map
-    (assoc :user (str user "@iplantcollaborative.org"))
-    (dissoc :first-name :last-name :email)))
 
 (defn analyses-url
   ([components]
    (analyses-url components {}))
   ([components query]
-   (let [user-map (fix-user (add-current-user-to-map query))]
-     (-> (apply url (cons (analyses-base-uri) components))
-        (assoc :query user-map)
-        (str)))))
+   (-> (apply url (cons (analyses-base-uri) components))
+       (assoc :query (assoc query :user (:username current-user)))
+       (str))))
 
 (defn process-response
   [resp err-data]

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -1,6 +1,5 @@
 (ns terrain.clients.analyses
   (:require [terrain.util.config :refer [analyses-base-uri]]
-            [cheshire.core :refer [generate-string]]
             [clj-http.client :as http]
             [cemerick.url :refer [url]]
             [terrain.auth.user-attributes :refer [current-user]]
@@ -29,7 +28,7 @@
   (:body (http/put (analyses-url ["badges" id])
                    {:content-type  :json
                     :as            :json
-                    :body          (generate-string submission-info)})
+                    :form-params   submission-info})
          {:id id :submission submission-info}))
 
 (defn add-badge
@@ -37,5 +36,5 @@
   (:body (http/post (analyses-url ["badges"])
                     {:content-type :json
                      :as           :json
-                     :body         (generate-string submission-info)})
+                     :form-params  submission-info})
          {:submission submission-info}))

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -50,10 +50,10 @@
                                :body          submission-info})
                     {:id id :submission submission-info}))
 
-(defn create-badge
-  [id submission-info]
+(defn add-badge
+  [submission-info]
   (process-response (http/post (analyses-url "/badges")
                                {:content-type :json
                                 :as           :json
                                 :body         submission-info})
-                    {:id id :submission submission-info}))
+                    {:submission submission-info}))

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -1,23 +1,35 @@
 (ns terrain.clients.analyses
   (:require [terrain.util.config :refer [analyses-base-uri]]
+            [cheshire.core :refer [generate-string]]
+            [clojure.tools.logging :as log]
             [terrain.util.transformers :refer [add-current-user-to-map]]
             [clj-http.client :as http]
             [clojure-commons.client :refer [build-url-with-query]]
             [clojure-commons.error-codes :refer [ERR_NOT_FOUND
                                                  ERR_BAD_REQUEST
                                                  ERR_UNCHECKED_EXCEPTION]]
+            [cemerick.url :refer [url]]
+            [medley.core :refer [mapply]]
             [slingshot.slingshot :refer [throw+]]))
 
+(defn- fix-user
+  [{:keys [user] :as user-map}]
+  (-> user-map
+    (assoc :user (str user "@iplantcollaborative.org"))
+    (dissoc :first-name :last-name :email)))
 
 (defn analyses-url
-  ([relative-url]
-   (analyses-url relative-url {}))
-  ([relative-url query]
-   (build-url-with-query (analyses-base-uri)
-                         (add-current-user-to-map query) relative-url)))
+  ([components]
+   (analyses-url components {}))
+  ([components query]
+   (let [user-map (fix-user (add-current-user-to-map query))]
+     (-> (apply url (cons (analyses-base-uri) components))
+        (assoc :query user-map)
+        (str)))))
 
 (defn process-response
   [resp err-data]
+  (log/warn resp)
   (cond
     (= (:status resp) 404)
     (throw+ (merge {:error_code ERR_NOT_FOUND} err-data {:msg (:body resp)}))
@@ -36,24 +48,27 @@
 
 (defn get-badge
   [id]
-  (process-response (http/get (analyses-url "/badges" id) {:as :json}) {:id id}))
+  (let [u (analyses-url ["badges" id])]
+    (log/info u)
+    (process-response (http/get u {:as :json}) {:id id})))
 
 (defn delete-badge
   [id]
-  (process-response (http/delete (analyses-url "/badges" id) {:as :json}) {:id id}))
+  (process-response (http/delete (analyses-url ["badges" id]) {:as :json}) {:id id})
+  {:id id})
 
 (defn update-badge
   [id submission-info]
-  (process-response (http/put (analyses-url "/badges" id)
+  (process-response (http/put (analyses-url ["badges" id])
                               {:content-type  :json
                                :as            :json
-                               :body          submission-info})
+                               :body          (generate-string submission-info)})
                     {:id id :submission submission-info}))
 
 (defn add-badge
   [submission-info]
-  (process-response (http/post (analyses-url "/badges")
+  (process-response (http/post (analyses-url ["badges"])
                                {:content-type :json
                                 :as           :json
-                                :body         submission-info})
+                                :body         (generate-string submission-info)})
                     {:submission submission-info}))

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -1,15 +1,8 @@
 (ns terrain.clients.analyses
   (:require [terrain.util.config :refer [analyses-base-uri]]
             [cheshire.core :refer [generate-string]]
-            [clojure.tools.logging :as log]
-            [terrain.util.transformers :refer [add-current-user-to-map]]
             [clj-http.client :as http]
-            [clojure-commons.client :refer [build-url-with-query]]
-            [clojure-commons.error-codes :refer [ERR_NOT_FOUND
-                                                 ERR_BAD_REQUEST
-                                                 ERR_UNCHECKED_EXCEPTION]]
             [cemerick.url :refer [url]]
-            [medley.core :refer [mapply]]
             [terrain.auth.user-attributes :refer [current-user]]
             [slingshot.slingshot :refer [throw+]]))
 
@@ -22,48 +15,27 @@
        (assoc :query (assoc query :user (:username current-user)))
        (str))))
 
-(defn process-response
-  [resp err-data]
-  (log/warn resp)
-  (cond
-    (= (:status resp) 404)
-    (throw+ (merge {:error_code ERR_NOT_FOUND} err-data {:msg (:body resp)}))
-
-    (= (:status resp) 400)
-    (throw+ (merge {:error_code ERR_BAD_REQUEST} err-data {:msg (:body resp)}))
-
-    (= (:status resp) 500)
-    (throw+ (merge {:error_code ERR_UNCHECKED_EXCEPTION} err-data {:msg (:body resp)}))
-
-    (not (<= 200 (:status resp) 299))
-    (throw+ (merge {:error_code ERR_UNCHECKED_EXCEPTION} err-data {:msg (:body resp)}))
-
-    :else
-    (:body resp)))
-
 (defn get-badge
   [id]
-  (let [u (analyses-url ["badges" id])]
-    (log/info u)
-    (process-response (http/get u {:as :json}) {:id id})))
+  (:body (http/get (analyses-url ["badges" id]) {:as :json})))
 
 (defn delete-badge
   [id]
-  (process-response (http/delete (analyses-url ["badges" id]) {:as :json}) {:id id})
+  (http/delete (analyses-url ["badges" id]) {:as :json}) {:id id}
   {:id id})
 
 (defn update-badge
   [id submission-info]
-  (process-response (http/put (analyses-url ["badges" id])
-                              {:content-type  :json
-                               :as            :json
-                               :body          (generate-string submission-info)})
-                    {:id id :submission submission-info}))
+  (:body (http/put (analyses-url ["badges" id])
+                   {:content-type  :json
+                    :as            :json
+                    :body          (generate-string submission-info)})
+         {:id id :submission submission-info}))
 
 (defn add-badge
   [submission-info]
-  (process-response (http/post (analyses-url ["badges"])
-                               {:content-type :json
-                                :as           :json
-                                :body         (generate-string submission-info)})
-                    {:submission submission-info}))
+  (:body (http/post (analyses-url ["badges"])
+                    {:content-type :json
+                     :as           :json
+                     :body         (generate-string submission-info)})
+         {:submission submission-info}))

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -19,7 +19,7 @@
 
 (defn delete-badge
   [id]
-  (:body (http/delete (analyses-url ["badges" id]) {:as :json})) {:id id})
+  (:body (http/delete (analyses-url ["badges" id]) {:as :json})))
 
 (defn update-badge
   [id submission-info]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -28,6 +28,7 @@
         [terrain.routes.token]
         [terrain.routes.webhooks]
         [terrain.routes.comments]
+        [terrain.routes.analyses]
         [terrain.util :as util]
         [terrain.util.transformers :as transform])
   (:require [cemerick.url :as curl]
@@ -75,6 +76,7 @@
 (defn secured-routes
   []
   (util/flagged-routes
+    (secured-analyses-routes)
     (secured-notification-routes)
     (secured-metadata-routes)
     (secured-pref-routes)

--- a/src/terrain/routes/analyses.clj
+++ b/src/terrain/routes/analyses.clj
@@ -1,0 +1,53 @@
+(ns terrain.routes.analyses
+  (:require [compojure.api.sweet :refer [describe]]
+            [common-swagger-api.schema :refer [context GET PUT POST DELETE]]
+            [common-swagger-api.schema.badges :refer [Badge NewBadge]]
+            [common-swagger-api.schema.apps :refer [AnalysisSubmission]]
+            [ring.util.http-response :refer [ok]]
+            [terrain.util :refer [optional-routes]]
+            [schema.core :as s]
+            [terrain.util.config :as config]
+            [terrain.clients.analyses :as analyses])
+  (:import [java.util UUID]))
+
+(s/defschema DeletionResponse
+  {:id (describe UUID "The UUID of the resource that was deleted")})
+
+(defn secured-analyses-routes
+  "The routes for accessing analyses information. Currently limited to badges."
+  []
+  (optional-routes [config/app-routes-enabled])
+
+  (context "/badges" []
+    :tags ["analyses"]
+
+    (GET "/:id" [id]
+      :summary "Get badge information by its UUID."
+      :description "Gets badge information, including the UUID, the name of
+      the user that owns it, and the submission JSON"
+      :return  Badge
+      (ok (analyses/get-badge id)))
+
+    (PUT "/:id" [id]
+      :body         [badge NewBadge]
+      :return       Badge
+      :summary      "Modifies an existing badge"
+      :description  "Modifies an existing badge, allowing the caller to change
+      owners and the contents of the submission JSON"
+      (ok (analyses/update-badge id badge)))
+
+    (POST "/" []
+      :body         [submission AnalysisSubmission]
+      :return       Badge
+      :summary      "Adds a badge to the database"
+      :description  "Adds a badge and corresponding submission information to the
+      database. The username passed in should already exist. A new UUID will be
+      assigned and returned."
+      (ok (analyses/add-badge submission)))
+
+    (DELETE "/:id" [id]
+      :return        DeletionResponse
+      :summary      "Deletes a badge"
+      :description  "Deletes a badge from the database. Will returns a success
+      even if called on a badge that has either already been deleted or never
+      existed in the first place")))

--- a/src/terrain/routes/analyses.clj
+++ b/src/terrain/routes/analyses.clj
@@ -50,4 +50,5 @@
       :summary      "Deletes a badge"
       :description  "Deletes a badge from the database. Will returns a success
       even if called on a badge that has either already been deleted or never
-      existed in the first place")))
+      existed in the first place"
+      (ok (analyses/delete-badge id)))))

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -493,6 +493,11 @@
   [props config-valid configs]
   "terrain.oauth.client-secret" "notprod")
 
+(cc/defprop-optstr analyses-base-uri
+  "The base URI for the analyses service."
+  [props config-valid configs]
+  "terrain.analyses.base-uri" "https://analyses")
+
 (def metadata-client
   (memoize #(metadata-client/new-metadata-client (metadata-base-url))))
 

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -496,7 +496,7 @@
 (cc/defprop-optstr analyses-base-uri
   "The base URI for the analyses service."
   [props config-valid configs]
-  "terrain.analyses.base-uri" "https://analyses")
+  "terrain.analyses.base-uri" "http://analyses")
 
 (def metadata-client
   (memoize #(metadata-client/new-metadata-client (metadata-base-url))))


### PR DESCRIPTION
Adds the secured facade endpoints for the new analyses service. All of the endpoints are swaggerized.

A new configuration option `terrain.analyses.base-uri` has been added with a sane default that should work inside our kubernetes clusters.