### PR TITLE
CORE-11 Add /apps/elements swagger docs.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.10.1"]
+                 [org.cyverse/common-swagger-api "2.10.2-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.1"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/permissions-client "2.8.1"]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -23,17 +23,19 @@
 
 (defn get-all-workflow-elements
   [params]
-  (client/get (apps-url "apps" "elements")
-              {:query-params     (secured-params params [:include-hidden])
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" "elements")
+                {:query-params     (secured-params params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn get-workflow-elements
   [element-type params]
-  (client/get (apps-url "apps" "elements" element-type)
-              {:query-params     (secured-params params [:include-hidden])
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" "elements" element-type)
+                {:query-params     (secured-params params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn list-ontologies
   []

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -8,6 +8,7 @@
         [terrain.auth.user-attributes]
         [terrain.middleware :only [wrap-context-path-adder wrap-query-param-remover]]
         [terrain.routes.admin]
+        [terrain.routes.apps.elements]
         [terrain.routes.data]
         [terrain.routes.permanent-id-requests]
         [terrain.routes.fileio]
@@ -58,6 +59,7 @@
    (app-comment-routes)
    (app-ontology-routes)
    (app-community-routes)
+   (app-elements-routes)
    (apps-routes)
    (analysis-routes)
    (coge-routes)
@@ -188,6 +190,7 @@
                                      {:name "admin-communities", :description "Community Administration Endpoints"}
                                      {:name "admin-filesystem", :description "File System Administration Endpoints"}
                                      {:name "apps", :description, "Apps Endpoints"}
+                                     {:name "app-element-types", :description, "App Element Endpoints"}
                                      {:name "coge", :description "CoGe Endpoints"}
                                      {:name "collaborator-lists", :description "Collaborator List Endpoints"}
                                      {:name "communities", :description "Community Endpoints"}

--- a/src/terrain/routes/apps/elements.clj
+++ b/src/terrain/routes/apps/elements.clj
@@ -1,0 +1,65 @@
+(ns terrain.routes.apps.elements
+  (:use [common-swagger-api.schema]
+        [common-swagger-api.schema.apps :only [IncludeHiddenParams]]
+        [common-swagger-api.schema.apps.elements]
+        [ring.util.http-response :only [ok]]
+        [terrain.util])
+  (:require [terrain.clients.apps.raw :as apps]
+            [terrain.util.config :as config]))
+
+(defn app-elements-routes
+  []
+  (optional-routes
+    [config/app-routes-enabled]
+
+    (context "/apps/elements" []
+      :tags ["app-element-types"]
+
+      (GET "/" []
+           :query [params IncludeHiddenParams]
+           :summary AppElementsListingSummary
+           :description AppElementsListingDocs
+           (ok (apps/get-all-workflow-elements params)))
+
+      (GET "/data-sources" []
+           :return DataSourceListing
+           :summary AppElementsDataSourceListingSummary
+           :description AppElementsDataSourceListingDocs
+           (ok (apps/get-workflow-elements "data-sources" nil)))
+
+      (GET "/file-formats" []
+           :return FileFormatListing
+           :summary AppElementsFileFormatListingSummary
+           :description AppElementsFileFormatListingDocs
+           (ok (apps/get-workflow-elements "file-formats" nil)))
+
+      (GET "/info-types" []
+           :return InfoTypeListing
+           :summary AppElementsInfoTypeListingSummary
+           :description AppElementsInfoTypeListingDocs
+           (ok (apps/get-workflow-elements "info-types" nil)))
+
+      (GET "/parameter-types" []
+           :query [params AppParameterTypeParams]
+           :return ParameterTypeListing
+           :summary AppElementsParameterTypeListingSummary
+           :description AppElementsParameterTypeListingDocs
+           (ok (apps/get-workflow-elements "parameter-types" params)))
+
+      (GET "/rule-types" []
+           :return RuleTypeListing
+           :summary AppElementsRuleTypeListingSummary
+           :description AppElementsRuleTypeListingDocs
+           (ok (apps/get-workflow-elements "rule-types" nil)))
+
+      (GET "/tool-types" []
+           :return ToolTypeListing
+           :summary AppElementsToolTypeListingSummary
+           :description AppElementsToolTypeListingDocs
+           (ok (apps/get-workflow-elements "tool-types" nil)))
+
+      (GET "/value-types" []
+           :return ValueTypeListing
+           :summary AppElementsValueTypeListingSummary
+           :description AppElementsValueTypeListingDocs
+           (ok (apps/get-workflow-elements "value-types" nil))))))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -169,16 +169,10 @@
 
       (GET "/" []
            :query [params AppSearchParams]
-           :summary AppListingSummary
            :return AppListing
+           :summary AppListingSummary
            :description-file "docs/apps/apps-listing.md"
            (ok (apps/search-apps params)))
-
-      (GET "/elements" [:as {:keys [params]}]
-           (service/success-response (apps/get-all-workflow-elements params)))
-
-      (GET "/elements/:element-type" [element-type :as {:keys [params]}]
-           (service/success-response (apps/get-workflow-elements element-type params)))
 
       (POST "/pipelines" [:as {:keys [body]}]
             (service/success-response (apps/add-pipeline body)))


### PR DESCRIPTION
Added `terrain.routes.apps.elements`, which is basically the same as `apps.routes.apps.elements`, except the potentially obsolete `GET /apps/elements/tools` endpoint has been omitted for now.