### PR TITLE
CORE-11 Add some /apps endpoint swagger docs.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,8 +24,6 @@
                  [clojurewerkz/elastisch "2.2.0"]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
                  [compojure "1.5.1"]
-                 [metosin/compojure-api "1.1.8"]   ; should be held to the same version as the one
-                                                   ; used by org.iplantc/clojure-commons
                  [dire "0.5.4"]
                  [me.raynes/fs "1.4.6"]
                  [medley "0.8.4"]

--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.10.3"]
+                 [org.cyverse/common-swagger-api "2.10.4"]
                  [org.cyverse/kameleon "3.0.1"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/permissions-client "2.8.1"]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -160,7 +160,7 @@
   (:body
     (client/post (apps-url "apps" "shredder")
                  {:query-params     (secured-params)
-                  :body             deletion-request
+                  :form-params      deletion-request
                   :content-type     :json
                   :as               :json
                   :follow-redirects false})))
@@ -170,7 +170,7 @@
   (:body
     (client/post (apps-url "apps" "permission-lister")
                  {:query-params     (secured-params params)
-                  :body             body
+                  :form-params      body
                   :content-type     :json
                   :as               :json
                   :follow-redirects false})))
@@ -180,7 +180,7 @@
   (:body
     (client/post (apps-url "apps" "sharing")
                  {:query-params     (secured-params)
-                  :body             body
+                  :form-params      body
                   :content-type     :json
                   :as               :json
                   :follow-redirects false})))
@@ -190,7 +190,7 @@
   (:body
     (client/post (apps-url "apps" "unsharing")
                  {:query-params     (secured-params)
-                  :body             body
+                  :form-params      body
                   :content-type     :json
                   :as               :json
                   :follow-redirects false})))

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -157,39 +157,43 @@
 
 (defn delete-apps
   [deletion-request]
-  (client/post (apps-url "apps" "shredder")
-               {:query-params     (secured-params)
-                :body             deletion-request
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" "shredder")
+                 {:query-params     (secured-params)
+                  :body             deletion-request
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn list-permissions
   [body params]
-  (client/post (apps-url "apps" "permission-lister")
-               {:query-params     (secured-params params permission-lister-params)
-                :body             body
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" "permission-lister")
+                 {:query-params     (secured-params params)
+                  :body             body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn share
   [body]
-  (client/post (apps-url "apps" "sharing")
-               {:query-params     (secured-params)
-                :body             body
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" "sharing")
+                 {:query-params     (secured-params)
+                  :body             body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn unshare
   [body]
-  (client/post (apps-url "apps" "unsharing")
-               {:query-params     (secured-params)
-                :body             body
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" "unsharing")
+                 {:query-params     (secured-params)
+                  :body             body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn get-app
   [system-id app-id]

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -25,7 +25,6 @@
         [terrain.services.bootstrap]
         [terrain.util])
   (:require [common-swagger-api.routes]                     ;; Required for :description-file
-            [cheshire.core :as json]
             [terrain.clients.apps.raw :as apps]
             [terrain.clients.metadata :as metadata]
             [terrain.clients.metadata.raw :as metadata-client]
@@ -207,7 +206,7 @@
             :body [body AppDeletionRequest]
             :summary AppsShredderSummary
             :description AppsShredderDocs
-            (ok (apps/delete-apps (json/encode body))))
+            (ok (apps/delete-apps body)))
 
       (POST "/permission-lister" []
             :query [params PermissionListerQueryParams]
@@ -215,21 +214,21 @@
             :return AppPermissionListing
             :summary AppPermissionListingSummary
             :description AppPermissionListingDocs
-            (ok (apps/list-permissions (json/encode body) params)))
+            (ok (apps/list-permissions body params)))
 
       (POST "/sharing" [:as {:keys [body]}]
             :body [body AppSharingRequest]
             :return AppSharingResponse
             :summary AppSharingSummary
             :description AppSharingDocs
-            (ok (apps/share (json/encode body))))
+            (ok (apps/share body)))
 
       (POST "/unsharing" [:as {:keys [body]}]
             :body [body AppUnsharingRequest]
             :return AppUnsharingResponse
             :summary AppUnsharingSummary
             :description AppUnsharingDocs
-            (ok (apps/unshare (json/encode body))))
+            (ok (apps/unshare body)))
 
       (POST "/:system-id" [system-id :as {:keys [body]}]
             (service/success-response (apps/create-app system-id body)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -1,14 +1,31 @@
 (ns terrain.routes.metadata
   (:use [common-swagger-api.schema]
-        [common-swagger-api.schema.apps :only [AppListing
+        [common-swagger-api.schema.apps :only [AppDeletionRequest
+                                               AppListing
                                                AppListingSummary
+                                               AppsShredderDocs
+                                               AppsShredderSummary
                                                SystemId]]
+        [common-swagger-api.schema.apps.permission :only [AppPermissionListing
+                                                          AppPermissionListingDocs
+                                                          AppPermissionListingRequest
+                                                          AppPermissionListingSummary
+                                                          AppSharingDocs
+                                                          AppSharingRequest
+                                                          AppSharingResponse
+                                                          AppSharingSummary
+                                                          AppUnsharingDocs
+                                                          AppUnsharingRequest
+                                                          AppUnsharingResponse
+                                                          AppUnsharingSummary
+                                                          PermissionListerQueryParams]]
         [ring.util.http-response :only [ok]]
         [terrain.routes.schemas.apps]
         [terrain.services.metadata.apps]
         [terrain.services.bootstrap]
         [terrain.util])
   (:require [common-swagger-api.routes]                     ;; Required for :description-file
+            [cheshire.core :as json]
             [terrain.clients.apps.raw :as apps]
             [terrain.clients.metadata :as metadata]
             [terrain.clients.metadata.raw :as metadata-client]
@@ -186,17 +203,33 @@
       (GET "/pipelines/:app-id/ui" [app-id]
            (service/success-response (apps/edit-pipeline app-id)))
 
-      (POST "/shredder" [:as {:keys [body]}]
-            (service/success-response (apps/delete-apps body)))
+      (POST "/shredder" []
+            :body [body AppDeletionRequest]
+            :summary AppsShredderSummary
+            :description AppsShredderDocs
+            (ok (apps/delete-apps (json/encode body))))
 
-      (POST "/permission-lister" [:as {:keys [body params]}]
-            (service/success-response (apps/list-permissions body params)))
+      (POST "/permission-lister" []
+            :query [params PermissionListerQueryParams]
+            :body [body AppPermissionListingRequest]
+            :return AppPermissionListing
+            :summary AppPermissionListingSummary
+            :description AppPermissionListingDocs
+            (ok (apps/list-permissions (json/encode body) params)))
 
       (POST "/sharing" [:as {:keys [body]}]
-            (service/success-response (apps/share body)))
+            :body [body AppSharingRequest]
+            :return AppSharingResponse
+            :summary AppSharingSummary
+            :description AppSharingDocs
+            (ok (apps/share (json/encode body))))
 
       (POST "/unsharing" [:as {:keys [body]}]
-            (service/success-response (apps/unshare body)))
+            :body [body AppUnsharingRequest]
+            :return AppUnsharingResponse
+            :summary AppUnsharingSummary
+            :description AppUnsharingDocs
+            (ok (apps/unshare (json/encode body))))
 
       (POST "/:system-id" [system-id :as {:keys [body]}]
             (service/success-response (apps/create-app system-id body)))


### PR DESCRIPTION
Added swagger docs for `/apps/shredder`, `permission-lister`, `sharing`, and `unsharing` endpoints.

Note that this PR can't be merged until the `common-swagger-api.schema.badges` schemas are replaced with `common-swagger-api.schema.quicklaunches` schemas from `common-swagger-api` v2.10.3.

Then the changes in cyverse-de/common-swagger-api#14 can be versioned on top of `common-swagger-api` v2.10.3, and this PR will be updated with that newer version.