### PR TITLE
CORE-148: added the GET /analyses/:analysis-id/history endpoint

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,7 @@
                  [org.cyverse/service-logging "2.8.0"]]
   :eastwood {:exclude-namespaces [terrain.util.jwt :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
-  :plugins [[lein-ring "0.9.2" :exclusions [org.clojure/clojure]]
+  :plugins [[lein-ring "0.12.5" :exclusions [org.clojure/clojure]]
             [swank-clojure "1.4.2" :exclusions [org.clojure/clojure]]
             [test2junit "1.2.2"]
             [jonase/eastwood "0.3.5"]]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -500,6 +500,13 @@
                 :as               :stream
                 :follow-redirects false}))
 
+(defn get-job-history
+  [analysis-id]
+  (client/get (apps-url "analyses" analysis-id "history")
+              {:query-params      (secured-params)
+               :as                :stream
+               :follow-redirecrts false}))
+
 (defn admin-get-apps
   [params]
   (client/get (apps-url "admin" "apps")

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -321,6 +321,9 @@
    (POST "/analyses/shredder" [:as {:keys [body]}]
      (service/success-response (apps/delete-jobs body)))
 
+   (GET "/analyses/:analysis-id/history" [analysis-id]
+     (service/success-response (apps/get-job-history analysis-id)))
+
    (GET "/analyses/:analysis-id/parameters" [analysis-id]
      (service/success-response (apps/get-job-params analysis-id)))
 
@@ -331,10 +334,7 @@
      (service/success-response (apps/list-job-steps analysis-id)))
 
    (POST "/analyses/:analysis-id/stop" [analysis-id :as {:keys [params]}]
-     (service/success-response (apps/stop-job analysis-id params)))
-
-   (GET "/analyses/:analysis-id/history" [analysis-id]
-     (service/success-response (apps/get-job-history analysis-id)))))
+     (service/success-response (apps/stop-job analysis-id params)))))
 
 (defn admin-reference-genomes-routes
   []

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -331,7 +331,10 @@
      (service/success-response (apps/list-job-steps analysis-id)))
 
    (POST "/analyses/:analysis-id/stop" [analysis-id :as {:keys [params]}]
-     (service/success-response (apps/stop-job analysis-id params)))))
+     (service/success-response (apps/stop-job analysis-id params)))
+
+   (GET "/analyses/:analysis-id/history" [analysis-id]
+     (service/success-response (apps/get-job-history analysis-id)))))
 
 (defn admin-reference-genomes-routes
   []


### PR DESCRIPTION
I decided not to add Swagger docs to terrain for this endpoint just yet because that would probably involve a switch to compojure-api version 1.1.12, which would take more time.