### PR TITLE
CORE-11 Add Swagger docs from apps.routes.app to terrain.routes.metadata

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.10.4"]
+                 [org.cyverse/common-swagger-api "2.10.5-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/permissions-client "2.8.1"]

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.10.5-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "2.10.5"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/permissions-client "2.8.1"]

--- a/src/terrain/clients/apps.clj
+++ b/src/terrain/clients/apps.clj
@@ -3,12 +3,6 @@
             [terrain.clients.apps.raw :as raw]
             [terrain.util.service :as service]))
 
-(defn get-app
-  [system-id app-id]
-  (->> (raw/get-app system-id app-id)
-       (:body)
-       (service/decode-json)))
-
 (defn get-app-details
   [system-id app-id]
   (->> (raw/get-app-details system-id app-id)
@@ -35,12 +29,6 @@
   [submission]
   (raw/submit-job (cheshire/encode submission)))
 
-(defn get-users-by-id
-  [ids]
-  (-> (raw/get-users-by-id (cheshire/encode {:ids ids}))
-      (:body)
-      (service/decode-json)))
-
 (defn get-authenticated-user
   []
   (-> (raw/get-authenticated-user)
@@ -57,12 +45,6 @@
   [ip-address login-time]
   (raw/record-logout ip-address login-time)
   nil)
-
-(defn get-auth-redirect-uris
-  []
-  (-> (raw/get-oauth-redirect-uris)
-      :body
-      service/decode-json))
 
 (defn bootstrap
   []

--- a/src/terrain/clients/apps.clj
+++ b/src/terrain/clients/apps.clj
@@ -3,12 +3,6 @@
             [terrain.clients.apps.raw :as raw]
             [terrain.util.service :as service]))
 
-(defn get-app-details
-  [system-id app-id]
-  (->> (raw/get-app-details system-id app-id)
-       (:body)
-       (service/decode-json)))
-
 (defn admin-list-tool-requests
   [params]
   (->> (raw/admin-list-tool-requests params)

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -725,10 +725,11 @@
 
 (defn get-tools-in-app
   [system-id app-id]
-  (client/get (apps-url "apps" system-id app-id "tools")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" system-id app-id "tools")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn admin-list-tools
   [params]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -207,10 +207,11 @@
 
 (defn delete-app
   [system-id app-id]
-  (client/delete (apps-url "apps" system-id app-id)
-                 {:query-params     (secured-params)
-                  :as               :stream
-                  :follow-redirects false}))
+  (:body
+    (client/delete (apps-url "apps" system-id app-id)
+                   {:query-params     (secured-params)
+                    :as               :json
+                    :follow-redirects false})))
 
 (defn relabel-app
   [system-id app-id relabel-request]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -360,10 +360,11 @@
 
 (defn delete-rating
   [system-id app-id]
-  (client/delete (apps-url "apps" system-id app-id "rating")
-                 {:query-params     (secured-params)
-                  :as               :stream
-                  :follow-redirects false}))
+  (:body
+    (client/delete (apps-url "apps" system-id app-id "rating")
+                   {:query-params     (secured-params)
+                    :as               :json
+                    :follow-redirects false})))
 
 (defn rate-app
   [system-id app-id rating]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -609,12 +609,13 @@
 
 (defn edit-app-docs
   [system-id app-id docs]
-  (client/patch (apps-url "apps" system-id app-id "documentation")
-                {:query-params     (secured-params)
-                 :content-type     :json
-                 :body             docs
-                 :as               :stream
-                 :follow-redirects false}))
+  (:body
+    (client/patch (apps-url "apps" system-id app-id "documentation")
+                  {:query-params     (secured-params)
+                   :form-params      docs
+                   :content-type     :json
+                   :as               :json
+                   :follow-redirects false})))
 
 (defn add-app-docs
   [system-id app-id docs]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -235,10 +235,11 @@
 
 (defn copy-app
   [system-id app-id]
-  (client/post (apps-url "apps" system-id app-id "copy")
-               {:query-params     (secured-params)
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" system-id app-id "copy")
+                 {:query-params     (secured-params)
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn get-admin-app-details
   [system-id app-id]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -199,10 +199,11 @@
 
 (defn get-app
   [system-id app-id]
-  (client/get (apps-url "apps" system-id app-id)
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" system-id app-id)
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn delete-app
   [system-id app-id]
@@ -862,15 +863,6 @@
                  {:query-params     (secured-params params [:permanent])
                   :as               :stream
                   :follow-redirects false}))
-
-(defn get-users-by-id
-  [body]
-  (client/post (apps-url "users" "by-id")
-               {:query-params     (secured-params)
-                :as               :stream
-                :body             body
-                :content-type     :json
-                :follow-redirects false}))
 
 (defn get-authenticated-user
   []

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -139,12 +139,13 @@
 
 (defn create-app
   [system-id app]
-  (client/post (apps-url "apps" system-id)
-               {:query-params     (secured-params)
-                :body             app
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" system-id)
+                 {:query-params     (secured-params)
+                  :form-params      app
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn preview-args
   [system-id app]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -601,10 +601,11 @@
 
 (defn get-app-docs
   [system-id app-id]
-  (client/get (apps-url "apps" system-id app-id "documentation")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" system-id app-id "documentation")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn edit-app-docs
   [system-id app-id docs]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -938,10 +938,11 @@
 
 (defn get-app-integration-data
   [system-id app-id]
-  (client/get (apps-url "apps" system-id app-id "integration-data")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" system-id app-id "integration-data")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn get-tool-integration-data
   [tool-id]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -619,12 +619,13 @@
 
 (defn add-app-docs
   [system-id app-id docs]
-  (client/post (apps-url "apps" system-id app-id "documentation")
-               {:query-params     (secured-params)
-                :content-type     :json
-                :body             docs
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" system-id app-id "documentation")
+                 {:query-params     (secured-params)
+                  :form-params      docs
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn admin-edit-app-docs
   [system-id app-id docs]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -266,10 +266,11 @@
 
 (defn add-favorite-app
   [system-id app-id]
-  (client/put (apps-url "apps" system-id app-id "favorite")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/put (apps-url "apps" system-id app-id "favorite")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn app-publishable?
   [system-id app-id]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -215,12 +215,13 @@
 
 (defn relabel-app
   [system-id app-id relabel-request]
-  (client/patch (apps-url "apps" system-id app-id)
-                {:query-params     (secured-params)
-                 :body             relabel-request
-                 :content-type     :json
-                 :as               :stream
-                 :follow-redirects false}))
+  (:body
+    (client/patch (apps-url "apps" system-id app-id)
+                  {:query-params     (secured-params)
+                   :form-params      relabel-request
+                   :content-type     :json
+                   :as               :json
+                   :follow-redirects false})))
 
 (defn update-app
   [system-id app-id update-request]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -250,10 +250,11 @@
 
 (defn get-app-details
   [system-id app-id]
-  (client/get (apps-url "apps" system-id app-id "details")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" system-id app-id "details")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn remove-favorite-app
   [system-id app-id]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -378,10 +378,11 @@
 
 (defn list-app-tasks
   [system-id app-id]
-  (client/get (apps-url "apps" system-id app-id "tasks")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" system-id app-id "tasks")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn get-app-ui
   [system-id app-id]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -386,10 +386,11 @@
 
 (defn get-app-ui
   [system-id app-id]
-  (client/get (apps-url "apps" system-id app-id "ui")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" system-id app-id "ui")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn add-pipeline
   [pipeline]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -149,12 +149,13 @@
 
 (defn preview-args
   [system-id app]
-  (client/post (apps-url "apps" system-id "arg-preview")
-               {:query-params     (secured-params)
-                :body             app
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" system-id "arg-preview")
+                 {:query-params     (secured-params)
+                  :form-params      app
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn delete-apps
   [deletion-request]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -274,10 +274,11 @@
 
 (defn app-publishable?
   [system-id app-id]
-  (client/get (apps-url "apps" system-id app-id "is-publishable")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" system-id app-id "is-publishable")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn remove-app-from-communities
   [app-id body]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -350,12 +350,13 @@
 
 (defn make-app-public
   [system-id app-id app]
-  (client/post (apps-url "apps" system-id app-id "publish")
-               {:query-params     (secured-params)
-                :body             app
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" system-id app-id "publish")
+                 {:query-params     (secured-params)
+                  :form-params      app
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn delete-rating
   [system-id app-id]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -368,12 +368,13 @@
 
 (defn rate-app
   [system-id app-id rating]
-  (client/post (apps-url "apps" system-id app-id "rating")
-               {:query-params     (secured-params)
-                :body             rating
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" system-id app-id "rating")
+                 {:query-params     (secured-params)
+                  :form-params      rating
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn list-app-tasks
   [system-id app-id]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -225,12 +225,13 @@
 
 (defn update-app
   [system-id app-id update-request]
-  (client/put (apps-url "apps" system-id app-id)
-              {:query-params     (secured-params)
-               :body             update-request
-               :content-type     :json
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/put (apps-url "apps" system-id app-id)
+                {:query-params     (secured-params)
+                 :form-params      update-request
+                 :content-type     :json
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn copy-app
   [system-id app-id]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -258,10 +258,11 @@
 
 (defn remove-favorite-app
   [system-id app-id]
-  (client/delete (apps-url "apps" system-id app-id "favorite")
-                 {:query-params     (secured-params)
-                  :as               :stream
-                  :follow-redirects false}))
+  (:body
+    (client/delete (apps-url "apps" system-id app-id "favorite")
+                   {:query-params     (secured-params)
+                    :as               :json
+                    :follow-redirects false})))
 
 (defn add-favorite-app
   [system-id app-id]

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -8,6 +8,9 @@
                 AppDeletionRequest
                 AppListing
                 AppListingSummary
+                AppPreviewDocs
+                AppPreviewRequest
+                AppPreviewSummary
                 AppsShredderDocs
                 AppsShredderSummary
                 SystemId]]
@@ -246,8 +249,11 @@
               :description AppCreateDocs
               (ok (apps/create-app system-id body)))
 
-        (POST "/arg-preview" [:as {:keys [body]}]
-              (service/success-response (apps/preview-args system-id body)))
+        (POST "/arg-preview" []
+              :body [body AppPreviewRequest]
+              :summary AppPreviewSummary
+              :description AppPreviewDocs
+              (ok (apps/preview-args system-id body)))
 
         (GET "/:app-id" [app-id]
              (service/success-response (apps/get-app system-id app-id)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -20,6 +20,8 @@
                 AppDocumentationSummary
                 AppDocumentationUpdateDocs
                 AppDocumentationUpdateSummary
+                AppFavoriteAddDocs
+                AppFavoriteAddSummary
                 AppFavoriteDeleteDocs
                 AppFavoriteDeleteSummary
                 AppJobView
@@ -345,7 +347,9 @@
                   (ok (apps/remove-favorite-app system-id app-id)))
 
           (PUT "/favorite" []
-               (service/success-response (apps/add-favorite-app system-id app-id)))
+               :summary AppFavoriteAddSummary
+               :description AppFavoriteAddDocs
+               (ok (apps/add-favorite-app system-id app-id)))
 
           (GET "/integration-data" []
                (service/success-response (apps/get-app-integration-data system-id app-id)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -1,65 +1,5 @@
 (ns terrain.routes.metadata
   (:use [common-swagger-api.schema]
-        [common-swagger-api.schema.apps
-         :only [App
-                AppCopyDocs
-                AppCopySummary
-                AppCreateDocs
-                AppCreateRequest
-                AppCreateSummary
-                AppDeleteDocs
-                AppDeleteSummary
-                AppDeletionRequest
-                AppDetails
-                AppDetailsSummary
-                AppDocumentation
-                AppDocumentationAddDocs
-                AppDocumentationAddSummary
-                AppDocumentationDocs
-                AppDocumentationRequest
-                AppDocumentationSummary
-                AppDocumentationUpdateDocs
-                AppDocumentationUpdateSummary
-                AppEditingViewDocs
-                AppEditingViewSummary
-                AppFavoriteAddDocs
-                AppFavoriteAddSummary
-                AppFavoriteDeleteDocs
-                AppFavoriteDeleteSummary
-                AppIntegrationDataDocs
-                AppIntegrationDataSummary
-                AppJobView
-                AppJobViewDocs
-                AppJobViewSummary
-                AppLabelUpdateRequest
-                AppLabelUpdateSummary
-                AppListing
-                AppListingSummary
-                AppPreviewDocs
-                AppPreviewRequest
-                AppPreviewSummary
-                AppPublishableDocs
-                AppPublishableResponse
-                AppPublishableSummary
-                AppRatingDeleteDocs
-                AppRatingDeleteSummary
-                AppRatingDocs
-                AppRatingSummary
-                AppsShredderDocs
-                AppsShredderSummary
-                AppTaskListing
-                AppTaskListingDocs
-                AppTaskListingSummary
-                AppToolListing
-                AppToolListingDocs
-                AppToolListingSummary
-                AppUpdateRequest
-                AppUpdateSummary
-                PublishAppDocs
-                PublishAppRequest
-                PublishAppSummary
-                StringAppIdParam
-                SystemId]]
         [common-swagger-api.schema.apps.permission
          :only [AppPermissionListing
                 AppPermissionListingDocs
@@ -82,6 +22,7 @@
         [terrain.services.bootstrap]
         [terrain.util])
   (:require [common-swagger-api.routes]                     ;; Required for :description-file
+            [common-swagger-api.schema.apps :as schema]
             [terrain.clients.apps.raw :as apps]
             [terrain.clients.metadata :as metadata]
             [terrain.clients.metadata.raw :as metadata-client]
@@ -242,8 +183,8 @@
 
       (GET "/" []
            :query [params AppSearchParams]
-           :return AppListing
-           :summary AppListingSummary
+           :return schema/AppListing
+           :summary schema/AppListingSummary
            :description-file "docs/apps/apps-listing.md"
            (ok (apps/search-apps params)))
 
@@ -260,9 +201,9 @@
            (service/success-response (apps/edit-pipeline app-id)))
 
       (POST "/shredder" []
-            :body [body AppDeletionRequest]
-            :summary AppsShredderSummary
-            :description AppsShredderDocs
+            :body [body schema/AppDeletionRequest]
+            :summary schema/AppsShredderSummary
+            :description schema/AppsShredderDocs
             (ok (apps/delete-apps body)))
 
       (POST "/permission-lister" []
@@ -288,138 +229,138 @@
             (ok (apps/unshare body)))
 
       (context "/:system-id" []
-        :path-params [system-id :- SystemId]
+        :path-params [system-id :- schema/SystemId]
 
         (POST "/" []
-              :body [body AppCreateRequest]
-              :return App
-              :summary AppCreateSummary
-              :description AppCreateDocs
+              :body [body schema/AppCreateRequest]
+              :return schema/App
+              :summary schema/AppCreateSummary
+              :description schema/AppCreateDocs
               (ok (apps/create-app system-id body)))
 
         (POST "/arg-preview" []
-              :body [body AppPreviewRequest]
-              :summary AppPreviewSummary
-              :description AppPreviewDocs
+              :body [body schema/AppPreviewRequest]
+              :summary schema/AppPreviewSummary
+              :description schema/AppPreviewDocs
               (ok (apps/preview-args system-id body)))
 
         (context "/:app-id" []
-          :path-params [app-id :- StringAppIdParam]
+          :path-params [app-id :- schema/StringAppIdParam]
 
           (GET "/" []
-               :summary AppJobViewSummary
-               :return AppJobView
-               :description AppJobViewDocs
+               :summary schema/AppJobViewSummary
+               :return schema/AppJobView
+               :description schema/AppJobViewDocs
                (ok (apps/get-app system-id app-id)))
 
           (DELETE "/" []
-                  :summary AppDeleteSummary
-                  :description AppDeleteDocs
+                  :summary schema/AppDeleteSummary
+                  :description schema/AppDeleteDocs
                   (ok (apps/delete-app system-id app-id)))
 
           (PATCH "/" []
-                 :body [body AppLabelUpdateRequest]
-                 :return App
-                 :summary AppLabelUpdateSummary
+                 :body [body schema/AppLabelUpdateRequest]
+                 :return schema/App
+                 :summary schema/AppLabelUpdateSummary
                  :description-file "docs/apps/app-label-update.md"
                  (ok (apps/relabel-app system-id app-id body)))
 
           (PUT "/" []
-               :body [body AppUpdateRequest]
-               :return App
-               :summary AppUpdateSummary
+               :body [body schema/AppUpdateRequest]
+               :return schema/App
+               :summary schema/AppUpdateSummary
                :description-file "docs/apps/app-update.md"
                (ok (apps/update-app system-id app-id body)))
 
           (POST "/copy" []
-                :return App
-                :summary AppCopySummary
-                :description AppCopyDocs
+                :return schema/App
+                :summary schema/AppCopySummary
+                :description schema/AppCopyDocs
                 (ok (apps/copy-app system-id app-id)))
 
           (GET "/details" []
-               :return AppDetails
-               :summary AppDetailsSummary
+               :return schema/AppDetails
+               :summary schema/AppDetailsSummary
                :description-file "docs/apps/app-details.md"
                (ok (apps/get-app-details system-id app-id)))
 
           (GET "/documentation" []
-               :return AppDocumentation
-               :summary AppDocumentationSummary
-               :description AppDocumentationDocs
+               :return schema/AppDocumentation
+               :summary schema/AppDocumentationSummary
+               :description schema/AppDocumentationDocs
                (ok (apps/get-app-docs system-id app-id)))
 
           (PATCH "/documentation" []
-                 :body [body AppDocumentationRequest]
-                 :return AppDocumentation
-                 :summary AppDocumentationUpdateSummary
-                 :description AppDocumentationUpdateDocs
+                 :body [body schema/AppDocumentationRequest]
+                 :return schema/AppDocumentation
+                 :summary schema/AppDocumentationUpdateSummary
+                 :description schema/AppDocumentationUpdateDocs
                  (ok (apps/edit-app-docs system-id app-id body)))
 
           (POST "/documentation" []
-                :body [body AppDocumentationRequest]
-                :return AppDocumentation
-                :summary AppDocumentationAddSummary
-                :description AppDocumentationAddDocs
+                :body [body schema/AppDocumentationRequest]
+                :return schema/AppDocumentation
+                :summary schema/AppDocumentationAddSummary
+                :description schema/AppDocumentationAddDocs
                 (ok (apps/add-app-docs system-id app-id body)))
 
           (DELETE "/favorite" []
-                  :summary AppFavoriteDeleteSummary
-                  :description AppFavoriteDeleteDocs
+                  :summary schema/AppFavoriteDeleteSummary
+                  :description schema/AppFavoriteDeleteDocs
                   (ok (apps/remove-favorite-app system-id app-id)))
 
           (PUT "/favorite" []
-               :summary AppFavoriteAddSummary
-               :description AppFavoriteAddDocs
+               :summary schema/AppFavoriteAddSummary
+               :description schema/AppFavoriteAddDocs
                (ok (apps/add-favorite-app system-id app-id)))
 
           (GET "/integration-data" []
                :return IntegrationData
-               :summary AppIntegrationDataSummary
-               :description AppIntegrationDataDocs
+               :summary schema/AppIntegrationDataSummary
+               :description schema/AppIntegrationDataDocs
                (ok (apps/get-app-integration-data system-id app-id)))
 
           (GET "/is-publishable" []
-               :return AppPublishableResponse
-               :summary AppPublishableSummary
-               :description AppPublishableDocs
+               :return schema/AppPublishableResponse
+               :summary schema/AppPublishableSummary
+               :description schema/AppPublishableDocs
                (ok (apps/app-publishable? system-id app-id)))
 
           (POST "/publish" []
-                :body [body PublishAppRequest]
-                :summary PublishAppSummary
-                :description PublishAppDocs
+                :body [body schema/PublishAppRequest]
+                :summary schema/PublishAppSummary
+                :description schema/PublishAppDocs
                 (ok (apps/make-app-public system-id app-id body)))
 
           (DELETE "/rating" []
                   :return RatingResponse
-                  :summary AppRatingDeleteSummary
-                  :description AppRatingDeleteDocs
+                  :summary schema/AppRatingDeleteSummary
+                  :description schema/AppRatingDeleteDocs
                   (ok (apps/delete-rating system-id app-id)))
 
           (POST "/rating" []
                 :body [body RatingRequest]
                 :return RatingResponse
-                :summary AppRatingSummary
-                :description AppRatingDocs
+                :summary schema/AppRatingSummary
+                :description schema/AppRatingDocs
                 (ok (apps/rate-app system-id app-id body)))
 
           (GET "/tasks" []
-               :return AppTaskListing
-               :summary AppTaskListingSummary
-               :description AppTaskListingDocs
+               :return schema/AppTaskListing
+               :summary schema/AppTaskListingSummary
+               :description schema/AppTaskListingDocs
                (ok (apps/list-app-tasks system-id app-id)))
 
           (GET "/tools" []
-               :return AppToolListing
-               :summary AppToolListingSummary
-               :description AppToolListingDocs
+               :return schema/AppToolListing
+               :summary schema/AppToolListingSummary
+               :description schema/AppToolListingDocs
                (ok (apps/get-tools-in-app system-id app-id)))
 
           (GET "/ui" []
-               :return App
-               :summary AppEditingViewSummary
-               :description AppEditingViewDocs
+               :return schema/App
+               :summary schema/AppEditingViewSummary
+               :description schema/AppEditingViewDocs
                (ok (apps/get-app-ui system-id app-id))))))))
 
 (defn admin-app-avu-routes

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -20,6 +20,8 @@
                 AppDocumentationSummary
                 AppDocumentationUpdateDocs
                 AppDocumentationUpdateSummary
+                AppEditingViewDocs
+                AppEditingViewSummary
                 AppFavoriteAddDocs
                 AppFavoriteAddSummary
                 AppFavoriteDeleteDocs
@@ -415,7 +417,10 @@
                (ok (apps/get-tools-in-app system-id app-id)))
 
           (GET "/ui" []
-               (service/success-response (apps/get-app-ui system-id app-id))))))))
+               :return App
+               :summary AppEditingViewSummary
+               :description AppEditingViewDocs
+               (ok (apps/get-app-ui system-id app-id))))))))
 
 (defn admin-app-avu-routes
   []

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -20,6 +20,8 @@
                 AppPreviewSummary
                 AppsShredderDocs
                 AppsShredderSummary
+                AppUpdateRequest
+                AppUpdateSummary
                 StringAppIdParam
                 SystemId]]
         [common-swagger-api.schema.apps.permission
@@ -284,8 +286,12 @@
                  :description-file "docs/apps/app-label-update.md"
                  (ok (apps/relabel-app system-id app-id body)))
 
-          (PUT "/" [:as {:keys [body]}]
-               (service/success-response (apps/update-app system-id app-id body)))
+          (PUT "/" []
+               :body [body AppUpdateRequest]
+               :return App
+               :summary AppUpdateSummary
+               :description-file "docs/apps/app-update.md"
+               (ok (apps/update-app system-id app-id body)))
 
           (POST "/copy" []
                 (service/success-response (apps/copy-app system-id app-id)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -2,6 +2,8 @@
   (:use [common-swagger-api.schema]
         [common-swagger-api.schema.apps
          :only [App
+                AppCopyDocs
+                AppCopySummary
                 AppCreateDocs
                 AppCreateRequest
                 AppCreateSummary
@@ -294,7 +296,10 @@
                (ok (apps/update-app system-id app-id body)))
 
           (POST "/copy" []
-                (service/success-response (apps/copy-app system-id app-id)))
+                :return App
+                :summary AppCopySummary
+                :description AppCopyDocs
+                (ok (apps/copy-app system-id app-id)))
 
           (GET "/details" []
                (service/success-response (apps/get-app-details system-id app-id)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -39,6 +39,8 @@
                 AppPublishableDocs
                 AppPublishableResponse
                 AppPublishableSummary
+                AppRatingDeleteDocs
+                AppRatingDeleteSummary
                 AppsShredderDocs
                 AppsShredderSummary
                 AppUpdateRequest
@@ -62,6 +64,7 @@
                 AppUnsharingResponse
                 AppUnsharingSummary
                 PermissionListerQueryParams]]
+        [common-swagger-api.schema.apps.rating]
         [common-swagger-api.schema.integration-data :only [IntegrationData]]
         [ring.util.http-response :only [ok]]
         [terrain.routes.schemas.apps]
@@ -379,7 +382,10 @@
                 (ok (apps/make-app-public system-id app-id body)))
 
           (DELETE "/rating" []
-                  (service/success-response (apps/delete-rating system-id app-id)))
+                  :return RatingResponse
+                  :summary AppRatingDeleteSummary
+                  :description AppRatingDeleteDocs
+                  (ok (apps/delete-rating system-id app-id)))
 
           (POST "/rating" [:as {body :body}]
                 (service/success-response (apps/rate-app system-id app-id body)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -48,6 +48,9 @@
                 AppTaskListing
                 AppTaskListingDocs
                 AppTaskListingSummary
+                AppToolListing
+                AppToolListingDocs
+                AppToolListingSummary
                 AppUpdateRequest
                 AppUpdateSummary
                 PublishAppDocs
@@ -406,7 +409,10 @@
                (ok (apps/list-app-tasks system-id app-id)))
 
           (GET "/tools" []
-               (service/success-response (apps/get-tools-in-app system-id app-id)))
+               :return AppToolListing
+               :summary AppToolListingSummary
+               :description AppToolListingDocs
+               (ok (apps/get-tools-in-app system-id app-id)))
 
           (GET "/ui" []
                (service/success-response (apps/get-app-ui system-id app-id))))))))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -11,6 +11,8 @@
                 AppJobView
                 AppJobViewDocs
                 AppJobViewSummary
+                AppLabelUpdateRequest
+                AppLabelUpdateSummary
                 AppListing
                 AppListingSummary
                 AppPreviewDocs
@@ -275,8 +277,12 @@
                   :description AppDeleteDocs
                   (ok (apps/delete-app system-id app-id)))
 
-          (PATCH "/" [:as {:keys [body]}]
-                 (service/success-response (apps/relabel-app system-id app-id body)))
+          (PATCH "/" []
+                 :body [body AppLabelUpdateRequest]
+                 :return App
+                 :summary AppLabelUpdateSummary
+                 :description-file "docs/apps/app-label-update.md"
+                 (ok (apps/relabel-app system-id app-id body)))
 
           (PUT "/" [:as {:keys [body]}]
                (service/success-response (apps/update-app system-id app-id body)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -24,6 +24,8 @@
                 AppFavoriteAddSummary
                 AppFavoriteDeleteDocs
                 AppFavoriteDeleteSummary
+                AppIntegrationDataDocs
+                AppIntegrationDataSummary
                 AppJobView
                 AppJobViewDocs
                 AppJobViewSummary
@@ -54,6 +56,7 @@
                 AppUnsharingResponse
                 AppUnsharingSummary
                 PermissionListerQueryParams]]
+        [common-swagger-api.schema.integration-data :only [IntegrationData]]
         [ring.util.http-response :only [ok]]
         [terrain.routes.schemas.apps]
         [terrain.services.metadata.apps]
@@ -352,7 +355,10 @@
                (ok (apps/add-favorite-app system-id app-id)))
 
           (GET "/integration-data" []
-               (service/success-response (apps/get-app-integration-data system-id app-id)))
+               :return IntegrationData
+               :summary AppIntegrationDataSummary
+               :description AppIntegrationDataDocs
+               (ok (apps/get-app-integration-data system-id app-id)))
 
           (GET "/is-publishable" []
                (service/success-response (apps/app-publishable? system-id app-id)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -12,6 +12,9 @@
                 AppDeletionRequest
                 AppDetails
                 AppDetailsSummary
+                AppDocumentation
+                AppDocumentationDocs
+                AppDocumentationSummary
                 AppJobView
                 AppJobViewDocs
                 AppJobViewSummary
@@ -310,7 +313,10 @@
                (ok (apps/get-app-details system-id app-id)))
 
           (GET "/documentation" []
-               (service/success-response (apps/get-app-docs system-id app-id)))
+               :return AppDocumentation
+               :summary AppDocumentationSummary
+               :description AppDocumentationDocs
+               (ok (apps/get-app-docs system-id app-id)))
 
           (POST "/documentation" [:as {:keys [body]}]
                 (service/success-response (apps/add-app-docs system-id app-id body)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -13,6 +13,8 @@
                 AppDetails
                 AppDetailsSummary
                 AppDocumentation
+                AppDocumentationAddDocs
+                AppDocumentationAddSummary
                 AppDocumentationDocs
                 AppDocumentationRequest
                 AppDocumentationSummary
@@ -328,8 +330,12 @@
                  :description AppDocumentationUpdateDocs
                  (ok (apps/edit-app-docs system-id app-id body)))
 
-          (POST "/documentation" [:as {:keys [body]}]
-                (service/success-response (apps/add-app-docs system-id app-id body)))
+          (POST "/documentation" []
+                :body [body AppDocumentationRequest]
+                :return AppDocumentation
+                :summary AppDocumentationAddSummary
+                :description AppDocumentationAddDocs
+                (ok (apps/add-app-docs system-id app-id body)))
 
           (DELETE "/favorite" []
                   (service/success-response (apps/remove-favorite-app system-id app-id)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -41,6 +41,8 @@
                 AppPublishableSummary
                 AppRatingDeleteDocs
                 AppRatingDeleteSummary
+                AppRatingDocs
+                AppRatingSummary
                 AppsShredderDocs
                 AppsShredderSummary
                 AppUpdateRequest
@@ -387,8 +389,12 @@
                   :description AppRatingDeleteDocs
                   (ok (apps/delete-rating system-id app-id)))
 
-          (POST "/rating" [:as {body :body}]
-                (service/success-response (apps/rate-app system-id app-id body)))
+          (POST "/rating" []
+                :body [body RatingRequest]
+                :return RatingResponse
+                :summary AppRatingSummary
+                :description AppRatingDocs
+                (ok (apps/rate-app system-id app-id body)))
 
           (GET "/tasks" []
                (service/success-response (apps/list-app-tasks system-id app-id)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -14,7 +14,10 @@
                 AppDetailsSummary
                 AppDocumentation
                 AppDocumentationDocs
+                AppDocumentationRequest
                 AppDocumentationSummary
+                AppDocumentationUpdateDocs
+                AppDocumentationUpdateSummary
                 AppJobView
                 AppJobViewDocs
                 AppJobViewSummary
@@ -318,11 +321,15 @@
                :description AppDocumentationDocs
                (ok (apps/get-app-docs system-id app-id)))
 
+          (PATCH "/documentation" []
+                 :body [body AppDocumentationRequest]
+                 :return AppDocumentation
+                 :summary AppDocumentationUpdateSummary
+                 :description AppDocumentationUpdateDocs
+                 (ok (apps/edit-app-docs system-id app-id body)))
+
           (POST "/documentation" [:as {:keys [body]}]
                 (service/success-response (apps/add-app-docs system-id app-id body)))
-
-          (PATCH "/documentation" [:as {:keys [body]}]
-                 (service/success-response (apps/edit-app-docs system-id app-id body)))
 
           (DELETE "/favorite" []
                   (service/success-response (apps/remove-favorite-app system-id app-id)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -36,6 +36,9 @@
                 AppPreviewDocs
                 AppPreviewRequest
                 AppPreviewSummary
+                AppPublishableDocs
+                AppPublishableResponse
+                AppPublishableSummary
                 AppsShredderDocs
                 AppsShredderSummary
                 AppUpdateRequest
@@ -361,7 +364,10 @@
                (ok (apps/get-app-integration-data system-id app-id)))
 
           (GET "/is-publishable" []
-               (service/success-response (apps/app-publishable? system-id app-id)))
+               :return AppPublishableResponse
+               :summary AppPublishableSummary
+               :description AppPublishableDocs
+               (ok (apps/app-publishable? system-id app-id)))
 
           (POST "/publish" [:as {:keys [body]}]
                 (service/success-response (apps/make-app-public system-id app-id body)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -10,6 +10,8 @@
                 AppDeleteDocs
                 AppDeleteSummary
                 AppDeletionRequest
+                AppDetails
+                AppDetailsSummary
                 AppJobView
                 AppJobViewDocs
                 AppJobViewSummary
@@ -302,7 +304,10 @@
                 (ok (apps/copy-app system-id app-id)))
 
           (GET "/details" []
-               (service/success-response (apps/get-app-details system-id app-id)))
+               :return AppDetails
+               :summary AppDetailsSummary
+               :description-file "docs/apps/app-details.md"
+               (ok (apps/get-app-details system-id app-id)))
 
           (GET "/documentation" []
                (service/success-response (apps/get-app-docs system-id app-id)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -1,24 +1,30 @@
 (ns terrain.routes.metadata
   (:use [common-swagger-api.schema]
-        [common-swagger-api.schema.apps :only [AppDeletionRequest
-                                               AppListing
-                                               AppListingSummary
-                                               AppsShredderDocs
-                                               AppsShredderSummary
-                                               SystemId]]
-        [common-swagger-api.schema.apps.permission :only [AppPermissionListing
-                                                          AppPermissionListingDocs
-                                                          AppPermissionListingRequest
-                                                          AppPermissionListingSummary
-                                                          AppSharingDocs
-                                                          AppSharingRequest
-                                                          AppSharingResponse
-                                                          AppSharingSummary
-                                                          AppUnsharingDocs
-                                                          AppUnsharingRequest
-                                                          AppUnsharingResponse
-                                                          AppUnsharingSummary
-                                                          PermissionListerQueryParams]]
+        [common-swagger-api.schema.apps
+         :only [App
+                AppCreateDocs
+                AppCreateRequest
+                AppCreateSummary
+                AppDeletionRequest
+                AppListing
+                AppListingSummary
+                AppsShredderDocs
+                AppsShredderSummary
+                SystemId]]
+        [common-swagger-api.schema.apps.permission
+         :only [AppPermissionListing
+                AppPermissionListingDocs
+                AppPermissionListingRequest
+                AppPermissionListingSummary
+                AppSharingDocs
+                AppSharingRequest
+                AppSharingResponse
+                AppSharingSummary
+                AppUnsharingDocs
+                AppUnsharingRequest
+                AppUnsharingResponse
+                AppUnsharingSummary
+                PermissionListerQueryParams]]
         [ring.util.http-response :only [ok]]
         [terrain.routes.schemas.apps]
         [terrain.services.metadata.apps]
@@ -216,82 +222,89 @@
             :description AppPermissionListingDocs
             (ok (apps/list-permissions body params)))
 
-      (POST "/sharing" [:as {:keys [body]}]
+      (POST "/sharing" []
             :body [body AppSharingRequest]
             :return AppSharingResponse
             :summary AppSharingSummary
             :description AppSharingDocs
             (ok (apps/share body)))
 
-      (POST "/unsharing" [:as {:keys [body]}]
+      (POST "/unsharing" []
             :body [body AppUnsharingRequest]
             :return AppUnsharingResponse
             :summary AppUnsharingSummary
             :description AppUnsharingDocs
             (ok (apps/unshare body)))
 
-      (POST "/:system-id" [system-id :as {:keys [body]}]
-            (service/success-response (apps/create-app system-id body)))
+      (context "/:system-id" []
+        :path-params [system-id :- SystemId]
 
-      (POST "/:system-id/arg-preview" [system-id :as {:keys [body]}]
-            (service/success-response (apps/preview-args system-id body)))
+        (POST "/" []
+              :body [body AppCreateRequest]
+              :return App
+              :summary AppCreateSummary
+              :description AppCreateDocs
+              (ok (apps/create-app system-id body)))
 
-      (GET "/:system-id/:app-id" [system-id app-id]
-           (service/success-response (apps/get-app system-id app-id)))
+        (POST "/arg-preview" [:as {:keys [body]}]
+              (service/success-response (apps/preview-args system-id body)))
 
-      (DELETE "/:system-id/:app-id" [system-id app-id]
-              (service/success-response (apps/delete-app system-id app-id)))
+        (GET "/:app-id" [app-id]
+             (service/success-response (apps/get-app system-id app-id)))
 
-      (PATCH "/:system-id/:app-id" [system-id app-id :as {:keys [body]}]
-             (service/success-response (apps/relabel-app system-id app-id body)))
+        (DELETE "/:app-id" [app-id]
+                (service/success-response (apps/delete-app system-id app-id)))
 
-      (PUT "/:system-id/:app-id" [system-id app-id :as {:keys [body]}]
-           (service/success-response (apps/update-app system-id app-id body)))
+        (PATCH "/:app-id" [app-id :as {:keys [body]}]
+               (service/success-response (apps/relabel-app system-id app-id body)))
 
-      (POST "/:system-id/:app-id/copy" [system-id app-id]
-            (service/success-response (apps/copy-app system-id app-id)))
+        (PUT "/:app-id" [app-id :as {:keys [body]}]
+             (service/success-response (apps/update-app system-id app-id body)))
 
-      (GET "/:system-id/:app-id/details" [system-id app-id]
-           (service/success-response (apps/get-app-details system-id app-id)))
+        (POST "/:app-id/copy" [app-id]
+              (service/success-response (apps/copy-app system-id app-id)))
 
-      (GET "/:system-id/:app-id/documentation" [system-id app-id]
-           (service/success-response (apps/get-app-docs system-id app-id)))
+        (GET "/:app-id/details" [app-id]
+             (service/success-response (apps/get-app-details system-id app-id)))
 
-      (POST "/:system-id/:app-id/documentation" [system-id app-id :as {:keys [body]}]
-            (service/success-response (apps/add-app-docs system-id app-id body)))
+        (GET "/:app-id/documentation" [app-id]
+             (service/success-response (apps/get-app-docs system-id app-id)))
 
-      (PATCH "/:system-id/:app-id/documentation" [system-id app-id :as {:keys [body]}]
-             (service/success-response (apps/edit-app-docs system-id app-id body)))
+        (POST "/:app-id/documentation" [app-id :as {:keys [body]}]
+              (service/success-response (apps/add-app-docs system-id app-id body)))
 
-      (DELETE "/:system-id/:app-id/favorite" [system-id app-id]
-              (service/success-response (apps/remove-favorite-app system-id app-id)))
+        (PATCH "/:app-id/documentation" [app-id :as {:keys [body]}]
+               (service/success-response (apps/edit-app-docs system-id app-id body)))
 
-      (PUT "/:system-id/:app-id/favorite" [system-id app-id]
-           (service/success-response (apps/add-favorite-app system-id app-id)))
+        (DELETE "/:app-id/favorite" [app-id]
+                (service/success-response (apps/remove-favorite-app system-id app-id)))
 
-      (GET "/:system-id/:app-id/integration-data" [system-id app-id]
-           (service/success-response (apps/get-app-integration-data system-id app-id)))
+        (PUT "/:app-id/favorite" [app-id]
+             (service/success-response (apps/add-favorite-app system-id app-id)))
 
-      (GET "/:system-id/:app-id/is-publishable" [system-id app-id]
-           (service/success-response (apps/app-publishable? system-id app-id)))
+        (GET "/:app-id/integration-data" [app-id]
+             (service/success-response (apps/get-app-integration-data system-id app-id)))
 
-      (POST "/:system-id/:app-id/publish" [system-id app-id :as {:keys [body]}]
-            (service/success-response (apps/make-app-public system-id app-id body)))
+        (GET "/:app-id/is-publishable" [app-id]
+             (service/success-response (apps/app-publishable? system-id app-id)))
 
-      (DELETE "/:system-id/:app-id/rating" [system-id app-id]
-              (service/success-response (apps/delete-rating system-id app-id)))
+        (POST "/:app-id/publish" [app-id :as {:keys [body]}]
+              (service/success-response (apps/make-app-public system-id app-id body)))
 
-      (POST "/:system-id/:app-id/rating" [system-id app-id :as {body :body}]
-            (service/success-response (apps/rate-app system-id app-id body)))
+        (DELETE "/:app-id/rating" [app-id]
+                (service/success-response (apps/delete-rating system-id app-id)))
 
-      (GET "/:system-id/:app-id/tasks" [system-id app-id]
-           (service/success-response (apps/list-app-tasks system-id app-id)))
+        (POST "/:app-id/rating" [app-id :as {body :body}]
+              (service/success-response (apps/rate-app system-id app-id body)))
 
-      (GET "/:system-id/:app-id/tools" [system-id app-id]
-           (service/success-response (apps/get-tools-in-app system-id app-id)))
+        (GET "/:app-id/tasks" [app-id]
+             (service/success-response (apps/list-app-tasks system-id app-id)))
 
-      (GET "/:system-id/:app-id/ui" [system-id app-id]
-           (service/success-response (apps/get-app-ui system-id app-id))))))
+        (GET "/:app-id/tools" [app-id]
+             (service/success-response (apps/get-tools-in-app system-id app-id)))
+
+        (GET "/:app-id/ui" [app-id]
+             (service/success-response (apps/get-app-ui system-id app-id)))))))
 
 (defn admin-app-avu-routes
   []

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -43,6 +43,9 @@
                 AppsShredderSummary
                 AppUpdateRequest
                 AppUpdateSummary
+                PublishAppDocs
+                PublishAppRequest
+                PublishAppSummary
                 StringAppIdParam
                 SystemId]]
         [common-swagger-api.schema.apps.permission
@@ -369,8 +372,11 @@
                :description AppPublishableDocs
                (ok (apps/app-publishable? system-id app-id)))
 
-          (POST "/publish" [:as {:keys [body]}]
-                (service/success-response (apps/make-app-public system-id app-id body)))
+          (POST "/publish" []
+                :body [body PublishAppRequest]
+                :summary PublishAppSummary
+                :description PublishAppDocs
+                (ok (apps/make-app-public system-id app-id body)))
 
           (DELETE "/rating" []
                   (service/success-response (apps/delete-rating system-id app-id)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -6,6 +6,9 @@
                 AppCreateRequest
                 AppCreateSummary
                 AppDeletionRequest
+                AppJobView
+                AppJobViewDocs
+                AppJobViewSummary
                 AppListing
                 AppListingSummary
                 AppPreviewDocs
@@ -13,6 +16,7 @@
                 AppPreviewSummary
                 AppsShredderDocs
                 AppsShredderSummary
+                StringAppIdParam
                 SystemId]]
         [common-swagger-api.schema.apps.permission
          :only [AppPermissionListing
@@ -255,62 +259,68 @@
               :description AppPreviewDocs
               (ok (apps/preview-args system-id body)))
 
-        (GET "/:app-id" [app-id]
-             (service/success-response (apps/get-app system-id app-id)))
+        (context "/:app-id" []
+          :path-params [app-id :- StringAppIdParam]
 
-        (DELETE "/:app-id" [app-id]
-                (service/success-response (apps/delete-app system-id app-id)))
+          (GET "/" []
+               :summary AppJobViewSummary
+               :return AppJobView
+               :description AppJobViewDocs
+               (ok (apps/get-app system-id app-id)))
 
-        (PATCH "/:app-id" [app-id :as {:keys [body]}]
-               (service/success-response (apps/relabel-app system-id app-id body)))
+          (DELETE "/" []
+                  (service/success-response (apps/delete-app system-id app-id)))
 
-        (PUT "/:app-id" [app-id :as {:keys [body]}]
-             (service/success-response (apps/update-app system-id app-id body)))
+          (PATCH "/" [:as {:keys [body]}]
+                 (service/success-response (apps/relabel-app system-id app-id body)))
 
-        (POST "/:app-id/copy" [app-id]
-              (service/success-response (apps/copy-app system-id app-id)))
+          (PUT "/" [:as {:keys [body]}]
+               (service/success-response (apps/update-app system-id app-id body)))
 
-        (GET "/:app-id/details" [app-id]
-             (service/success-response (apps/get-app-details system-id app-id)))
+          (POST "/copy" []
+                (service/success-response (apps/copy-app system-id app-id)))
 
-        (GET "/:app-id/documentation" [app-id]
-             (service/success-response (apps/get-app-docs system-id app-id)))
+          (GET "/details" []
+               (service/success-response (apps/get-app-details system-id app-id)))
 
-        (POST "/:app-id/documentation" [app-id :as {:keys [body]}]
-              (service/success-response (apps/add-app-docs system-id app-id body)))
+          (GET "/documentation" []
+               (service/success-response (apps/get-app-docs system-id app-id)))
 
-        (PATCH "/:app-id/documentation" [app-id :as {:keys [body]}]
-               (service/success-response (apps/edit-app-docs system-id app-id body)))
+          (POST "/documentation" [:as {:keys [body]}]
+                (service/success-response (apps/add-app-docs system-id app-id body)))
 
-        (DELETE "/:app-id/favorite" [app-id]
-                (service/success-response (apps/remove-favorite-app system-id app-id)))
+          (PATCH "/documentation" [:as {:keys [body]}]
+                 (service/success-response (apps/edit-app-docs system-id app-id body)))
 
-        (PUT "/:app-id/favorite" [app-id]
-             (service/success-response (apps/add-favorite-app system-id app-id)))
+          (DELETE "/favorite" []
+                  (service/success-response (apps/remove-favorite-app system-id app-id)))
 
-        (GET "/:app-id/integration-data" [app-id]
-             (service/success-response (apps/get-app-integration-data system-id app-id)))
+          (PUT "/favorite" []
+               (service/success-response (apps/add-favorite-app system-id app-id)))
 
-        (GET "/:app-id/is-publishable" [app-id]
-             (service/success-response (apps/app-publishable? system-id app-id)))
+          (GET "/integration-data" []
+               (service/success-response (apps/get-app-integration-data system-id app-id)))
 
-        (POST "/:app-id/publish" [app-id :as {:keys [body]}]
-              (service/success-response (apps/make-app-public system-id app-id body)))
+          (GET "/is-publishable" []
+               (service/success-response (apps/app-publishable? system-id app-id)))
 
-        (DELETE "/:app-id/rating" [app-id]
-                (service/success-response (apps/delete-rating system-id app-id)))
+          (POST "/publish" [:as {:keys [body]}]
+                (service/success-response (apps/make-app-public system-id app-id body)))
 
-        (POST "/:app-id/rating" [app-id :as {body :body}]
-              (service/success-response (apps/rate-app system-id app-id body)))
+          (DELETE "/rating" []
+                  (service/success-response (apps/delete-rating system-id app-id)))
 
-        (GET "/:app-id/tasks" [app-id]
-             (service/success-response (apps/list-app-tasks system-id app-id)))
+          (POST "/rating" [:as {body :body}]
+                (service/success-response (apps/rate-app system-id app-id body)))
 
-        (GET "/:app-id/tools" [app-id]
-             (service/success-response (apps/get-tools-in-app system-id app-id)))
+          (GET "/tasks" []
+               (service/success-response (apps/list-app-tasks system-id app-id)))
 
-        (GET "/:app-id/ui" [app-id]
-             (service/success-response (apps/get-app-ui system-id app-id)))))))
+          (GET "/tools" []
+               (service/success-response (apps/get-tools-in-app system-id app-id)))
+
+          (GET "/ui" []
+               (service/success-response (apps/get-app-ui system-id app-id))))))))
 
 (defn admin-app-avu-routes
   []

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -20,6 +20,8 @@
                 AppDocumentationSummary
                 AppDocumentationUpdateDocs
                 AppDocumentationUpdateSummary
+                AppFavoriteDeleteDocs
+                AppFavoriteDeleteSummary
                 AppJobView
                 AppJobViewDocs
                 AppJobViewSummary
@@ -338,7 +340,9 @@
                 (ok (apps/add-app-docs system-id app-id body)))
 
           (DELETE "/favorite" []
-                  (service/success-response (apps/remove-favorite-app system-id app-id)))
+                  :summary AppFavoriteDeleteSummary
+                  :description AppFavoriteDeleteDocs
+                  (ok (apps/remove-favorite-app system-id app-id)))
 
           (PUT "/favorite" []
                (service/success-response (apps/add-favorite-app system-id app-id)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -5,6 +5,8 @@
                 AppCreateDocs
                 AppCreateRequest
                 AppCreateSummary
+                AppDeleteDocs
+                AppDeleteSummary
                 AppDeletionRequest
                 AppJobView
                 AppJobViewDocs
@@ -269,7 +271,9 @@
                (ok (apps/get-app system-id app-id)))
 
           (DELETE "/" []
-                  (service/success-response (apps/delete-app system-id app-id)))
+                  :summary AppDeleteSummary
+                  :description AppDeleteDocs
+                  (ok (apps/delete-app system-id app-id)))
 
           (PATCH "/" [:as {:keys [body]}]
                  (service/success-response (apps/relabel-app system-id app-id body)))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -45,6 +45,9 @@
                 AppRatingSummary
                 AppsShredderDocs
                 AppsShredderSummary
+                AppTaskListing
+                AppTaskListingDocs
+                AppTaskListingSummary
                 AppUpdateRequest
                 AppUpdateSummary
                 PublishAppDocs
@@ -397,7 +400,10 @@
                 (ok (apps/rate-app system-id app-id body)))
 
           (GET "/tasks" []
-               (service/success-response (apps/list-app-tasks system-id app-id)))
+               :return AppTaskListing
+               :summary AppTaskListingSummary
+               :description AppTaskListingDocs
+               (ok (apps/list-app-tasks system-id app-id)))
 
           (GET "/tools" []
                (service/success-response (apps/get-tools-in-app system-id app-id)))

--- a/src/terrain/services/metadata/comments.clj
+++ b/src/terrain/services/metadata/comments.clj
@@ -4,11 +4,9 @@
             [clojure-commons.validators :as validators]
             [terrain.auth.user-attributes :as user]
             [terrain.clients.data-info :as data]
-            [terrain.clients.apps :as apps]
+            [terrain.clients.apps.raw :as apps]
             [terrain.clients.metadata.raw :as metadata]
-            [terrain.services.filesystem.uuids :as data-uuids]
-            [terrain.util.config :as config]
-            [terrain.util.validators :as valid]))
+            [terrain.util.config :as config]))
 
 (defn- validate-entry-id-accessible
   [user entry-id]

--- a/src/terrain/services/metadata/internal_jobs.clj
+++ b/src/terrain/services/metadata/internal_jobs.clj
@@ -3,6 +3,7 @@
         [terrain.auth.user-attributes :only [current-user]])
   (:require [clojure-commons.error-codes :as ce]
             [terrain.clients.apps :as apps]
+            [terrain.clients.apps.raw :as apps-client]
             [terrain.clients.user-prefs :as prefs]
             [terrain.util.config :as config]))
 
@@ -14,7 +15,7 @@
 
 (defn- load-param-map
   [app-id]
-  (->> (apps/get-app config/de-system-id app-id)
+  (->> (apps-client/get-app config/de-system-id app-id)
        (:groups)
        (mapcat :parameters)
        (map (juxt :label :id))


### PR DESCRIPTION
This PR will add the Swagger docs from endpoints in `apps.routes.app` (migrated in cyverse-de/apps#154) to endpoints in `terrain.routes.metadata`.