### PR TITLE
CORE-8: switched back to eastisch version 2.2.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  [cheshire "5.8.1"]
                  [clj-http "3.9.1"]
                  [clj-time "0.15.1"]
-                 [clojurewerkz/elastisch "3.0.0"]
+                 [clojurewerkz/elastisch "2.2.0"]
                  [com.cemerick/url "0.1.1" :exclusions [com.cemerick/clojurescript.test]]
                  [compojure "1.6.1"]
                  [dire "0.5.4"]


### PR DESCRIPTION
Oops! I just realized that `lein eastwood` was reporting arity problems with elastisch version 3.0.0.