### PR TITLE
CORE-11 Add Swagger docs to /apps/pipelines endpoints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.10.5"]
+                 [org.cyverse/common-swagger-api "2.10.6-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/permissions-client "2.8.1"]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -394,35 +394,39 @@
 
 (defn add-pipeline
   [pipeline]
-  (client/post (apps-url "apps" "pipelines")
-               {:query-params     (secured-params)
-                :content-type     :json
-                :body             pipeline
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" "pipelines")
+                 {:query-params     (secured-params)
+                  :form-params      pipeline
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn update-pipeline
   [app-id pipeline]
-  (client/put (apps-url "apps" "pipelines" app-id)
-              {:query-params     (secured-params)
-               :content-type     :json
-               :body             pipeline
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/put (apps-url "apps" "pipelines" app-id)
+                {:query-params     (secured-params)
+                 :form-params      pipeline
+                 :content-type     :json
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn copy-pipeline
   [app-id]
-  (client/post (apps-url "apps" "pipelines" app-id "copy")
-               {:query-params     (secured-params)
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" "pipelines" app-id "copy")
+                 {:query-params     (secured-params)
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn edit-pipeline
   [app-id]
-  (client/get (apps-url "apps" "pipelines" app-id "ui")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" "pipelines" app-id "ui")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn list-jobs
   [params]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -9,6 +9,7 @@
         [terrain.middleware :only [wrap-context-path-adder wrap-query-param-remover]]
         [terrain.routes.admin]
         [terrain.routes.apps.elements]
+        [terrain.routes.apps.pipelines]
         [terrain.routes.data]
         [terrain.routes.permanent-id-requests]
         [terrain.routes.fileio]
@@ -60,6 +61,7 @@
    (app-ontology-routes)
    (app-community-routes)
    (app-elements-routes)
+   (app-pipeline-routes)
    (apps-routes)
    (analysis-routes)
    (coge-routes)
@@ -191,6 +193,7 @@
                                      {:name "admin-filesystem", :description "File System Administration Endpoints"}
                                      {:name "apps", :description, "Apps Endpoints"}
                                      {:name "app-element-types", :description, "App Element Endpoints"}
+                                     {:name "app-pipelines", :description "App Pipeline Endpoints"}
                                      {:name "coge", :description "CoGe Endpoints"}
                                      {:name "collaborator-lists", :description "Collaborator List Endpoints"}
                                      {:name "communities", :description "Community Endpoints"}

--- a/src/terrain/routes/apps/pipelines.clj
+++ b/src/terrain/routes/apps/pipelines.clj
@@ -1,0 +1,45 @@
+(ns terrain.routes.apps.pipelines
+  (:use [common-swagger-api.schema]
+        [common-swagger-api.schema.apps :only [AppIdParam]]
+        [common-swagger-api.schema.apps.pipeline]
+        [ring.util.http-response :only [ok]]
+        [terrain.util :only [optional-routes]])
+  (:require [terrain.clients.apps.raw :as apps]
+            [terrain.util.config :as config]))
+
+(defn app-pipeline-routes
+  []
+  (optional-routes
+    [config/app-routes-enabled]
+    
+    (context "/apps/pipelines" []
+      :tags ["app-pipelines"]
+
+      (POST "/" []
+            :body [body PipelineCreateRequest]
+            :return Pipeline
+            :summary PipelineCreateSummary
+            :description PipelineCreateDocs
+            (ok (apps/add-pipeline body)))
+
+      (context "/:app-id" []
+        :path-params [app-id :- AppIdParam]
+
+        (PUT "/" []
+             :body [body PipelineUpdateRequest]
+             :return Pipeline
+             :summary PipelineUpdateSummary
+             :description PipelineUpdateDocs
+             (ok (apps/update-pipeline app-id body)))
+
+        (POST "/copy" []
+              :return Pipeline
+              :summary PipelineCopySummary
+              :description PipelineCopyDocs
+              (ok (apps/copy-pipeline app-id)))
+
+        (GET "/ui" []
+             :return Pipeline
+             :summary PipelineEditingViewSummary
+             :description PipelineEditingViewDocs
+             (ok (apps/edit-pipeline app-id)))))))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -188,18 +188,6 @@
            :description-file "docs/apps/apps-listing.md"
            (ok (apps/search-apps params)))
 
-      (POST "/pipelines" [:as {:keys [body]}]
-            (service/success-response (apps/add-pipeline body)))
-
-      (PUT "/pipelines/:app-id" [app-id :as {:keys [body]}]
-           (service/success-response (apps/update-pipeline app-id body)))
-
-      (POST "/pipelines/:app-id/copy" [app-id]
-            (service/success-response (apps/copy-pipeline app-id)))
-
-      (GET "/pipelines/:app-id/ui" [app-id]
-           (service/success-response (apps/edit-pipeline app-id)))
-
       (POST "/shredder" []
             :body [body schema/AppDeletionRequest]
             :summary schema/AppsShredderSummary


### PR DESCRIPTION
This PR will add the Swagger docs migrated in cyverse-de/apps#155 and cyverse-de/common-swagger-api#16 to terrain's `/apps/pipelines` endpoints.