### PR TITLE
CORE-11 Add Swagger docs to /apps/categories endpoints

### DIFF
--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -103,17 +103,19 @@
 
 (defn get-app-categories
   [params]
-  (client/get (apps-url "apps" "categories")
-              {:query-params     (secured-params params [:public])
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" "categories")
+                {:query-params     (secured-params params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn apps-in-category
   [system-id category-id params]
-  (client/get (apps-url "apps" "categories" system-id category-id)
-              {:query-params     (secured-params params apps-sort-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" "categories" system-id category-id)
+                {:query-params     (secured-params params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn apps-in-community
   [community-id]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -8,6 +8,7 @@
         [terrain.auth.user-attributes]
         [terrain.middleware :only [wrap-context-path-adder wrap-query-param-remover]]
         [terrain.routes.admin]
+        [terrain.routes.apps.categories]
         [terrain.routes.apps.elements]
         [terrain.routes.apps.pipelines]
         [terrain.routes.data]
@@ -192,6 +193,7 @@
                                      {:name "admin-communities", :description "Community Administration Endpoints"}
                                      {:name "admin-filesystem", :description "File System Administration Endpoints"}
                                      {:name "apps", :description, "Apps Endpoints"}
+                                     {:name "app-categories", :description "App Category Endpoints"}
                                      {:name "app-element-types", :description, "App Element Endpoints"}
                                      {:name "app-pipelines", :description "App Pipeline Endpoints"}
                                      {:name "coge", :description "CoGe Endpoints"}

--- a/src/terrain/routes/apps/categories.clj
+++ b/src/terrain/routes/apps/categories.clj
@@ -1,0 +1,35 @@
+(ns terrain.routes.apps.categories
+  (:use [common-swagger-api.schema]
+        [common-swagger-api.schema.apps :only [AppIdParam]]
+        [common-swagger-api.schema.apps.pipeline]
+        [ring.util.http-response :only [ok]]
+        [terrain.routes.schemas.categories :only [AppListingPagingParams]]
+        [terrain.util :only [optional-routes]])
+  (:require [common-swagger-api.schema.apps :as apps-schema]
+            [common-swagger-api.schema.apps.categories :as schema]
+            [terrain.clients.apps.raw :as apps]
+            [terrain.util.config :as config]))
+
+(defn app-category-routes
+  []
+  (optional-routes
+    [config/app-routes-enabled]
+
+    (context "/apps/categories" []
+      :tags ["app-categories"]
+
+      (GET "/" []
+           :query [params schema/CategoryListingParams]
+           :return schema/AppCategoryListing
+           :summary schema/AppCategoryListingSummary
+           :description schema/AppCategoryListingDocs
+           (ok (apps/get-app-categories params)))
+
+      (GET "/:system-id/:category-id" []
+           :path-params [system-id :- apps-schema/SystemId
+                         category-id :- apps-schema/AppCategoryIdPathParam]
+           :query [params AppListingPagingParams]
+           :return schema/AppCategoryAppListing
+           :summary schema/AppCategoryAppListingSummary
+           :description schema/AppCategoryAppListingDocs
+           (ok (apps/apps-in-category system-id category-id params))))))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -29,17 +29,6 @@
             [terrain.util.config :as config]
             [terrain.util.service :as service]))
 
-(defn app-category-routes
-  []
-  (optional-routes
-   [config/app-routes-enabled]
-
-   (GET "/apps/categories" [:as {params :params}]
-     (service/success-response (apps/get-app-categories params)))
-
-   (GET "/apps/categories/:system-id/:category-id" [system-id category-id :as {params :params}]
-     (service/success-response (apps/apps-in-category system-id category-id params)))))
-
 (defn admin-category-routes
   []
   (optional-routes

--- a/src/terrain/routes/schemas/categories.clj
+++ b/src/terrain/routes/schemas/categories.clj
@@ -1,0 +1,12 @@
+(ns terrain.routes.schemas.categories
+  (:use [common-swagger-api.schema]
+        [schema.core :only [defschema enum]])
+  (:require [common-swagger-api.schema.apps :as apps-schema]))
+
+;; Convert the keywords in AppListingValidSortFields to strings,
+;; so that the correct param format is passed through to the apps service.
+(defschema AppListingPagingParams
+  (merge apps-schema/AppListingPagingParams
+         {SortFieldOptionalKey
+          (describe (apply enum (map name apps-schema/AppListingValidSortFields))
+                    SortFieldDocs)}))


### PR DESCRIPTION
This PR will add Swagger docs to `/apps/categories` endpoints with the schemas and docs from cyverse-de/common-swagger-api#17