### PR TITLE
CORE-11 Add Swagger docs to /apps/hierarchies endpoints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.10.6-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "2.10.6"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/permissions-client "2.8.1"]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -65,17 +65,19 @@
                 :as               :stream
                 :follow-redirects false}))
   ([root-iri params]
-   (client/get (apps-url-encoded "apps" "hierarchies" root-iri)
-               {:query-params     (secured-params params [:attr])
-                :as               :stream
-                :follow-redirects false})))
+   (:body
+     (client/get (apps-url-encoded "apps" "hierarchies" root-iri)
+                 {:query-params     (secured-params params [:attr])
+                  :as               :json
+                  :follow-redirects false}))))
 
 (defn get-app-category-hierarchies
   []
-  (client/get (apps-url "apps" "hierarchies")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" "hierarchies")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn get-hierarchy-app-listing
   ([ontology-version root-iri params]
@@ -84,10 +86,11 @@
                 :as               :stream
                 :follow-redirects false}))
   ([root-iri params]
-   (client/get (apps-url-encoded "apps" "hierarchies" root-iri "apps")
-               {:query-params     (secured-params params apps-hierarchy-sort-params)
-                :as               :stream
-                :follow-redirects false})))
+   (:body
+     (client/get (apps-url-encoded "apps" "hierarchies" root-iri "apps")
+                 {:query-params     (secured-params params apps-hierarchy-sort-params)
+                  :as               :json
+                  :follow-redirects false}))))
 
 (defn get-unclassified-app-listing
   ([ontology-version root-iri params]
@@ -96,10 +99,11 @@
                 :as               :stream
                 :follow-redirects false}))
   ([root-iri params]
-   (client/get (apps-url-encoded "apps" "hierarchies" root-iri "unclassified")
-               {:query-params     (secured-params params apps-hierarchy-sort-params)
-                :as               :stream
-                :follow-redirects false})))
+   (:body
+     (client/get (apps-url-encoded "apps" "hierarchies" root-iri "unclassified")
+                 {:query-params     (secured-params params apps-hierarchy-sort-params)
+                  :as               :json
+                  :follow-redirects false}))))
 
 (defn get-app-categories
   [params]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -194,6 +194,7 @@
                                      {:name "admin-filesystem", :description "File System Administration Endpoints"}
                                      {:name "apps", :description, "Apps Endpoints"}
                                      {:name "app-categories", :description "App Category Endpoints"}
+                                     {:name "app-hierarchies", :description "App Hierarchy Endpoints"}
                                      {:name "app-element-types", :description, "App Element Endpoints"}
                                      {:name "app-pipelines", :description "App Pipeline Endpoints"}
                                      {:name "coge", :description "CoGe Endpoints"}

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -50,24 +50,6 @@
    (PATCH "/apps/categories/:system-id/:category-id" [system-id category-id :as {:keys [body]}]
      (service/success-response (apps/update-category system-id category-id body)))))
 
-(defn app-ontology-routes
-  []
-  (optional-routes
-   [#(and (config/app-routes-enabled)
-          (config/metadata-routes-enabled))]
-
-   (GET "/apps/hierarchies" []
-     (service/success-response (apps/get-app-category-hierarchies)))
-
-   (GET "/apps/hierarchies/:root-iri" [root-iri :as {params :params}]
-     (service/success-response (apps/get-app-category-hierarchy root-iri params)))
-
-   (GET "/apps/hierarchies/:root-iri/apps" [root-iri :as {params :params}]
-     (service/success-response (apps/get-hierarchy-app-listing root-iri params)))
-
-   (GET "/apps/hierarchies/:root-iri/unclassified" [root-iri :as {params :params}]
-     (service/success-response (apps/get-unclassified-app-listing root-iri params)))))
-
 (defn admin-ontology-routes
   []
   (optional-routes

--- a/src/terrain/routes/schemas/categories.clj
+++ b/src/terrain/routes/schemas/categories.clj
@@ -1,12 +1,20 @@
 (ns terrain.routes.schemas.categories
   (:use [common-swagger-api.schema]
         [schema.core :only [defschema enum]])
-  (:require [common-swagger-api.schema.apps :as apps-schema]))
+  (:require [common-swagger-api.schema.apps :as apps-schema]
+            [common-swagger-api.schema.apps.categories :as categories-schema]))
 
 ;; Convert the keywords in AppListingValidSortFields to strings,
 ;; so that the correct param format is passed through to the apps service.
+(def AppListingValidSortFieldStrings
+  {SortFieldOptionalKey
+   (describe (apply enum (map name apps-schema/AppListingValidSortFields))
+             SortFieldDocs)})
+
 (defschema AppListingPagingParams
   (merge apps-schema/AppListingPagingParams
-         {SortFieldOptionalKey
-          (describe (apply enum (map name apps-schema/AppListingValidSortFields))
-                    SortFieldDocs)}))
+         AppListingValidSortFieldStrings))
+
+(defschema OntologyAppListingPagingParams
+  (merge categories-schema/OntologyAppListingPagingParams
+         AppListingValidSortFieldStrings))


### PR DESCRIPTION
This PR will add Swagger docs to `/apps/hierarchies` endpoints with the docs and schemas migrated in cyverse-de/common-swagger-api#18.