### PR TITLE
CORE-11 Remove `Delegates to metadata service` sections from apps docs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.10.6"]
+                 [org.cyverse/common-swagger-api "2.10.7-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/permissions-client "2.8.1"]

--- a/src/terrain/routes/apps/categories.clj
+++ b/src/terrain/routes/apps/categories.clj
@@ -3,7 +3,9 @@
         [common-swagger-api.schema.apps :only [AppIdParam AppListing]]
         [common-swagger-api.schema.apps.pipeline]
         [common-swagger-api.schema.ontologies :only [OntologyClassIRIParam
-                                                     OntologyHierarchyFilterParams]]
+                                                     OntologyHierarchy
+                                                     OntologyHierarchyFilterParams
+                                                     OntologyHierarchyList]]
         [ring.util.http-response :only [ok]]
         [terrain.routes.schemas.categories]
         [terrain.util :only [optional-routes]])
@@ -47,8 +49,9 @@
       :tags ["app-hierarchies"]
 
       (GET "/" []
+           :return OntologyHierarchyList
            :summary schema/AppHierarchiesListingSummary
-           :description-file "docs/apps/categories/hierarchies-listing.md"
+           :description schema/AppHierarchiesListingDocs
            (ok (apps/get-app-category-hierarchies)))
 
       (context "/:root-iri" []
@@ -56,20 +59,21 @@
 
         (GET "/" []
              :query [params OntologyHierarchyFilterParams]
+             :return OntologyHierarchy
              :summary schema/AppCategoryHierarchyListingSummary
-             :description-file "docs/apps/categories/category-hierarchy-listing.md"
+             :description schema/AppCategoryHierarchyListingDocs
              (ok (apps/get-app-category-hierarchy root-iri params)))
 
         (GET "/apps" []
              :query [params OntologyAppListingPagingParams]
              :return AppListing
              :summary schema/AppCategoryAppListingSummary
-             :description-file "docs/apps/categories/hierarchy-app-listing.md"
+             :description schema/AppHierarchyAppListingDocs
              (ok (apps/get-hierarchy-app-listing root-iri params)))
 
         (GET "/unclassified" []
              :query [params OntologyAppListingPagingParams]
              :return AppListing
              :summary schema/AppHierarchyUnclassifiedListingSummary
-             :description-file "docs/apps/categories/hierarchy-unclassified-app-listing.md"
+             :description schema/AppHierarchyUnclassifiedListingDocs
              (ok (apps/get-unclassified-app-listing root-iri params)))))))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -156,7 +156,7 @@
            :query [params AppSearchParams]
            :return schema/AppListing
            :summary schema/AppListingSummary
-           :description-file "docs/apps/apps-listing.md"
+           :description schema/AppListingDocs
            (ok (apps/search-apps params)))
 
       (POST "/shredder" []
@@ -228,7 +228,7 @@
                :body [body schema/AppUpdateRequest]
                :return schema/App
                :summary schema/AppUpdateSummary
-               :description-file "docs/apps/app-update.md"
+               :description schema/AppUpdateDocs
                (ok (apps/update-app system-id app-id body)))
 
           (POST "/copy" []
@@ -240,7 +240,7 @@
           (GET "/details" []
                :return schema/AppDetails
                :summary schema/AppDetailsSummary
-               :description-file "docs/apps/app-details.md"
+               :description schema/AppDetailsDocs
                (ok (apps/get-app-details system-id app-id)))
 
           (GET "/documentation" []


### PR DESCRIPTION
This PR will use `common-swagger-api` v2.10.7 doc strings that replaced markdown docs, and `common-swagger-api.schema.ontologies` response schemas added by cyverse-de/common-swagger-api#19.
