### PR TITLE
CORE-11 Add Swagger docs to /apps/{app-id}/metadata endpoints

### DIFF
--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -332,28 +332,31 @@
 
 (defn list-avus
   [app-id]
-  (client/get (apps-url "apps" app-id "metadata")
-            {:query-params     (secured-params)
-             :as               :stream
-             :follow-redirects false}))
+  (:body
+    (client/get (apps-url "apps" app-id "metadata")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn set-avus
   [app-id body]
-  (client/put (apps-url "apps" app-id "metadata")
-              {:query-params     (secured-params)
-               :body             body
-               :content-type     :json
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/put (apps-url "apps" app-id "metadata")
+                {:query-params     (secured-params)
+                 :form-params      body
+                 :content-type     :json
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn update-avus
   [app-id body]
-  (client/post (apps-url "apps" app-id "metadata")
-               {:query-params     (secured-params)
-                :body             body
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" app-id "metadata")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn make-app-public
   [system-id app-id app]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -10,6 +10,7 @@
         [terrain.routes.admin]
         [terrain.routes.apps.categories]
         [terrain.routes.apps.elements]
+        [terrain.routes.apps.metadata]
         [terrain.routes.apps.pipelines]
         [terrain.routes.data]
         [terrain.routes.permanent-id-requests]
@@ -198,6 +199,7 @@
                                      {:name "app-communities", :description "App Community Endpoints"}
                                      {:name "app-hierarchies", :description "App Hierarchy Endpoints"}
                                      {:name "app-element-types", :description, "App Element Endpoints"}
+                                     {:name "app-metadata", :description "App Metadata Endpoints"}
                                      {:name "app-pipelines", :description "App Pipeline Endpoints"}
                                      {:name "coge", :description "CoGe Endpoints"}
                                      {:name "collaborator-lists", :description "Collaborator List Endpoints"}

--- a/src/terrain/routes/apps/metadata.clj
+++ b/src/terrain/routes/apps/metadata.clj
@@ -1,0 +1,42 @@
+(ns terrain.routes.apps.metadata
+  (:use [common-swagger-api.schema]
+        [common-swagger-api.schema.apps :only [AppIdParam]]
+        [common-swagger-api.schema.metadata
+         :only [AvuList
+                AvuListRequest
+                SetAvuRequest]]
+        [ring.util.http-response :only [ok]]
+        [terrain.util :only [optional-routes]])
+  (:require [common-swagger-api.schema.apps.metadata :as schema]
+            [terrain.clients.apps.raw :as apps]
+            [terrain.util.config :as config]))
+
+(defn app-avu-routes
+  []
+  (optional-routes
+    [#(and (config/app-routes-enabled)
+           (config/metadata-routes-enabled))]
+
+    (context "/apps/:app-id/metadata" []
+      :tags ["app-metadata"]
+      :path-params [app-id :- AppIdParam]
+
+      (GET "/" []
+           :return AvuList
+           :summary schema/AppMetadataListingSummary
+           :description schema/AppMetadataListingDocs
+           (ok (apps/list-avus app-id)))
+
+      (POST "/" []
+            :body [body AvuListRequest]
+            :return AvuList
+            :summary schema/AppMetadataUpdateSummary
+            :description schema/AppMetadataUpdateDocs
+            (ok (apps/update-avus app-id body)))
+
+      (PUT "/" []
+           :body [body SetAvuRequest]
+           :return AvuList
+           :summary schema/AppMetadataSetSummary
+           :description schema/AppMetadataSetDocs
+           (ok (apps/set-avus app-id body))))))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -335,21 +335,6 @@
    (PUT "/apps/:app-id/metadata" [app-id :as {:keys [body]}]
      (service/success-response (apps/admin-set-avus app-id body)))))
 
-(defn app-avu-routes
-  []
-  (optional-routes
-   [#(and (config/app-routes-enabled)
-          (config/metadata-routes-enabled))]
-
-   (GET "/apps/:app-id/metadata" [app-id]
-     (service/success-response (apps/list-avus app-id)))
-
-   (POST "/apps/:app-id/metadata" [app-id :as {:keys [body]}]
-     (service/success-response (apps/update-avus app-id body)))
-
-   (PUT "/apps/:app-id/metadata" [app-id :as {:keys [body]}]
-     (service/success-response (apps/set-avus app-id body)))))
-
 (defn analysis-routes
   []
   (optional-routes


### PR DESCRIPTION
This PR will add Swagger docs and schemas added by cyverse-de/common-swagger-api#21 to `/apps/{app-id}/metadata` endpoints.