### PR TITLE
CORE-11 Add Swagger docs to /apps/{app-id}/communities endpoints

### DIFF
--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -289,21 +289,23 @@
 
 (defn remove-app-from-communities
   [app-id body]
-  (client/delete (apps-url "apps" app-id "communities")
-                 {:query-params     (secured-params)
-                  :body             body
-                  :content-type     :json
-                  :as               :stream
-                  :follow-redirects false}))
+  (:body
+    (client/delete (apps-url "apps" app-id "communities")
+                   {:query-params     (secured-params)
+                    :form-params      body
+                    :content-type     :json
+                    :as               :json
+                    :follow-redirects false})))
 
 (defn update-app-communities
   [app-id body]
-  (client/post (apps-url "apps" app-id "communities")
-               {:query-params     (secured-params)
-                :body             body
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "apps" app-id "communities")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn admin-list-avus
   [app-id]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -9,6 +9,7 @@
         [terrain.middleware :only [wrap-context-path-adder wrap-query-param-remover]]
         [terrain.routes.admin]
         [terrain.routes.apps.categories]
+        [terrain.routes.apps.communities]
         [terrain.routes.apps.elements]
         [terrain.routes.apps.metadata]
         [terrain.routes.apps.pipelines]
@@ -198,6 +199,7 @@
                                      {:name "apps", :description, "Apps Endpoints"}
                                      {:name "app-categories", :description "App Category Endpoints"}
                                      {:name "app-communities", :description "App Community Endpoints"}
+                                     {:name "app-community-tags", :description "App Community Tag Endpoints"}
                                      {:name "app-hierarchies", :description "App Hierarchy Endpoints"}
                                      {:name "app-element-types", :description, "App Element Endpoints"}
                                      {:name "app-metadata", :description "App Metadata Endpoints"}

--- a/src/terrain/routes/apps/communities.clj
+++ b/src/terrain/routes/apps/communities.clj
@@ -1,0 +1,35 @@
+(ns terrain.routes.apps.communities
+  (:use [common-swagger-api.schema]
+        [common-swagger-api.schema.apps
+         :only [AppCategoryMetadataAddRequest
+                AppCategoryMetadataDeleteRequest
+                AppIdParam]]
+        [common-swagger-api.schema.metadata :only [AvuList]]
+        [ring.util.http-response :only [ok]]
+        [terrain.util :only [optional-routes]])
+  (:require [common-swagger-api.schema.apps.communities :as schema]
+            [terrain.clients.apps.raw :as apps]
+            [terrain.util.config :as config]))
+
+(defn app-community-tag-routes
+  []
+  (optional-routes
+    [#(and (config/app-routes-enabled)
+           (config/metadata-routes-enabled))]
+
+    (context "/apps/:app-id/communities" []
+      :tags ["app-community-tags"]
+      :path-params [app-id :- AppIdParam]
+
+      (DELETE "/" []
+              :body [body AppCategoryMetadataDeleteRequest]
+              :summary schema/AppCommunityMetadataDeleteSummary
+              :description schema/AppCommunityMetadataDeleteDocs
+              (ok (apps/remove-app-from-communities app-id body)))
+
+      (POST "/" []
+            :body [body AppCategoryMetadataAddRequest]
+            :return AvuList
+            :summary schema/AppCommunityMetadataAddSummary
+            :description schema/AppCommunityMetadataAddDocs
+            (ok (apps/update-app-communities app-id body))))))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -87,18 +87,6 @@
    (GET "/ontologies/:ontology-version/:root-iri/unclassified" [ontology-version root-iri :as {params :params}]
      (service/success-response (apps/get-unclassified-app-listing ontology-version root-iri params)))))
 
-(defn app-community-tag-routes
-  []
-  (optional-routes
-    [#(and (config/app-routes-enabled)
-           (config/metadata-routes-enabled))]
-
-    (DELETE "/apps/:app-id/communities" [app-id :as {:keys [body]}]
-      (service/success-response (apps/remove-app-from-communities app-id body)))
-
-    (POST "/apps/:app-id/communities" [app-id :as {:keys [body]}]
-      (service/success-response (apps/update-app-communities app-id body)))))
-
 (defn admin-app-community-routes
   []
   (optional-routes


### PR DESCRIPTION
This PR will add Swagger docs added by cyverse-de/common-swagger-api#22 to `/apps/{app-id}/communities` endpoints.