### PR TITLE
CORE-11 Add Swagger docs to /tools endpoints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.10.7"]
+                 [org.cyverse/common-swagger-api "2.11.0"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -805,76 +805,85 @@
 
 (defn list-tools
   [params]
-  (client/get (apps-url "tools")
-              {:query-params     (secured-params params tools-search-params)
-               :as               :stream
-               :follow-redirects :false}))
+  (:body
+    (client/get (apps-url "tools")
+                {:query-params     (secured-params params)
+                 :as               :json
+                 :follow-redirects :false})))
 
 (defn create-private-tool
   [body]
-  (client/post (apps-url "tools")
-               {:query-params     (secured-params)
-                :body             body
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "tools")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn list-tool-permissions
   [body params]
-  (client/post (apps-url "tools" "permission-lister")
-               {:query-params     (secured-params params permission-lister-params)
-                :body             body
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "tools" "permission-lister")
+                 {:query-params     (secured-params params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn share-tool
   [body]
-  (client/post (apps-url "tools" "sharing")
-               {:query-params     (secured-params)
-                :body             body
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "tools" "sharing")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn unshare-tool
   [body]
-  (client/post (apps-url "tools" "unsharing")
-               {:query-params     (secured-params)
-                :body             body
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "tools" "unsharing")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn delete-private-tool
   [tool-id params]
-  (client/delete (apps-url "tools" tool-id)
-                 {:query-params     (secured-params params [:force-delete])
-                  :as               :stream
-                  :follow-redirects false}))
+  (:body
+    (client/delete (apps-url "tools" tool-id)
+                   {:query-params     (secured-params params)
+                    :as               :json
+                    :follow-redirects false})))
 
 (defn get-tool
   [tool-id]
-  (client/get (apps-url "tools" tool-id)
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "tools" tool-id)
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn update-private-tool
-  [tool-id tool]
-  (client/patch (apps-url "tools" tool-id)
-                {:query-params     (secured-params)
-                 :as               :stream
-                 :body             tool
-                 :content-type     :json
-                 :follow-redirects false}))
+  [tool-id body]
+  (:body
+    (client/patch (apps-url "tools" tool-id)
+                  {:query-params     (secured-params)
+                   :form-params      body
+                   :as               :json
+                   :content-type     :json
+                   :follow-redirects false})))
 
 (defn get-apps-by-tool
   [tool-id]
-  (client/get (apps-url "tools" tool-id "apps")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "tools" tool-id "apps")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn list-reference-genomes
   [params]
@@ -969,10 +978,11 @@
 
 (defn get-tool-integration-data
   [tool-id]
-  (client/get (apps-url "tools" tool-id "integration-data")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "tools" tool-id "integration-data")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn update-app-integration-data
   [system-id app-id integration-data-id]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -13,6 +13,7 @@
         [terrain.routes.apps.elements]
         [terrain.routes.apps.metadata]
         [terrain.routes.apps.pipelines]
+        [terrain.routes.apps.tools]
         [terrain.routes.data]
         [terrain.routes.permanent-id-requests]
         [terrain.routes.fileio]
@@ -75,6 +76,7 @@
    (subject-routes)
    (reference-genomes-routes)
    (tool-routes)
+   (tool-request-routes)
    (permanent-id-request-routes)
    (webhook-routes)
    (misc-metadata-routes)
@@ -212,6 +214,7 @@
                                      {:name "filesystem", :description "Filesystem Endpoints"}
                                      {:name "subjects", :description "Subject Endpoints"}
                                      {:name "teams", :description "Team Endpoints"}
+                                     {:name "tools", :description "Tool Endpoints"}
                                      {:name "token", :description "OAuth Tokens"}]
                :securityDefinitions security-definitions}})
   (middleware

--- a/src/terrain/routes/apps/elements.clj
+++ b/src/terrain/routes/apps/elements.clj
@@ -1,6 +1,6 @@
 (ns terrain.routes.apps.elements
   (:use [common-swagger-api.schema]
-        [common-swagger-api.schema.apps :only [IncludeHiddenParams]]
+        [common-swagger-api.schema.common :only [IncludeHiddenParams]]
         [common-swagger-api.schema.apps.elements]
         [ring.util.http-response :only [ok]]
         [terrain.util])

--- a/src/terrain/routes/apps/tools.clj
+++ b/src/terrain/routes/apps/tools.clj
@@ -1,0 +1,92 @@
+(ns terrain.routes.apps.tools
+  (:use [common-swagger-api.schema]
+        [common-swagger-api.schema.apps :only [AppListing ToolAppListingResponses]]
+        [common-swagger-api.schema.integration-data :only [IntegrationData]]
+        [ring.util.http-response :only [ok]]
+        [terrain.util])
+  (:require [common-swagger-api.routes]                     ;; for :description-file
+            [common-swagger-api.schema.apps.permission :as perm-schema]
+            [common-swagger-api.schema.tools :as schema]
+            [compojure.api.middleware :as middleware]
+            [terrain.clients.apps.raw :as apps]
+            [terrain.util.config :as config]))
+
+(defn tool-routes
+  []
+  (optional-routes
+    [config/app-routes-enabled]
+
+    (context "/tools" []
+      :tags ["tools"]
+
+      (GET "/" []
+           :query [params schema/ToolSearchParams]
+           :return schema/ToolListing
+           :summary schema/ToolListingSummary
+           :description schema/ToolListingDocs
+           (ok (apps/list-tools params)))
+
+      (POST "/" []
+            :body [body schema/PrivateToolImportRequest]
+            :responses schema/PrivateToolImportResponses
+            :summary schema/ToolAddSummary
+            :description-file "docs/tools/tool-add.md"
+            (ok (apps/create-private-tool body)))
+
+      (POST "/permission-lister" []
+            :query [params perm-schema/PermissionListerQueryParams]
+            :body [body perm-schema/ToolIdList]
+            :responses perm-schema/ToolPermissionsListingResponses
+            :summary schema/ToolPermissionsListingSummary
+            :description schema/ToolPermissionsListingDocs
+            (ok (apps/list-tool-permissions body params)))
+
+      (POST "/sharing" []
+            :body [body perm-schema/ToolSharingRequest]
+            :return perm-schema/ToolSharingResponse
+            :summary perm-schema/ToolSharingSummary
+            :description perm-schema/ToolSharingDocs
+            (ok (apps/share-tool body)))
+
+      (POST "/unsharing" []
+            :body [body perm-schema/ToolUnsharingRequest]
+            :return perm-schema/ToolUnsharingResponse
+            :summary perm-schema/ToolUnsharingSummary
+            :description perm-schema/ToolUnsharingDocs
+            (ok (apps/unshare-tool body)))
+
+      (context "/:tool-id" []
+        :path-params [tool-id :- schema/ToolIdParam]
+
+        (DELETE "/" []
+                :query [params schema/PrivateToolDeleteParams]
+                :coercion middleware/no-response-coercion
+                :responses schema/ToolDeleteResponses
+                :summary schema/ToolDeleteSummary
+                :description schema/ToolDeleteDocs
+                (ok (apps/delete-private-tool tool-id params)))
+
+        (GET "/" []
+             :responses schema/ToolDetailsResponses
+             :summary schema/ToolDetailsSummary
+             :description schema/ToolDetailsDocs
+             (ok (apps/get-tool tool-id)))
+
+        (PATCH "/" []
+               :body [body schema/PrivateToolUpdateRequest]
+               :responses schema/ToolUpdateResponses
+               :summary schema/ToolUpdateSummary
+               :description-file "docs/tools/tool-update.md"
+               (ok (apps/update-private-tool tool-id body)))
+
+        (GET "/apps" []
+             :responses ToolAppListingResponses
+             :summary schema/ToolAppListingSummary
+             :description schema/ToolAppListingDocs
+             (ok (apps/get-apps-by-tool tool-id)))
+
+        (GET "/integration-data" []
+             :return IntegrationData
+             :summary schema/ToolIntegrationDataListingSummary
+             :description schema/ToolIntegrationDataListingDocs
+             (ok (apps/get-tool-integration-data tool-id)))))))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -438,40 +438,10 @@
    (POST "/tool-requests/:request-id/status" [request-id :as req]
      (update-tool-request req request-id))))
 
-(defn tool-routes
+(defn tool-request-routes
   []
   (optional-routes
    [config/app-routes-enabled]
-
-   (GET "/tools" [:as {:keys [params]}]
-     (service/success-response (apps/list-tools params)))
-
-   (POST "/tools" [:as {:keys [body]}]
-     (service/success-response (apps/create-private-tool body)))
-
-   (POST "/tools/permission-lister" [:as {:keys [body params]}]
-     (service/success-response (apps/list-tool-permissions body params)))
-
-   (POST "/tools/sharing" [:as {:keys [body]}]
-     (service/success-response (apps/share-tool body)))
-
-   (POST "/tools/unsharing" [:as {:keys [body]}]
-     (service/success-response (apps/unshare-tool body)))
-
-   (DELETE "/tools/:tool-id" [tool-id :as {:keys [params]}]
-     (apps/delete-private-tool tool-id params))
-
-   (GET "/tools/:tool-id" [tool-id]
-     (service/success-response (apps/get-tool tool-id)))
-
-   (PATCH "/tools/:tool-id" [tool-id :as {:keys [body]}]
-     (apps/update-private-tool tool-id body))
-
-   (GET "/tools/:tool-id/apps" [tool-id]
-     (service/success-response (apps/get-apps-by-tool tool-id)))
-
-   (GET "/tools/:tool-id/integration-data" [tool-id]
-     (service/success-response (apps/get-tool-integration-data tool-id)))
 
    (GET "/tool-requests" []
      (list-tool-requests))


### PR DESCRIPTION
This PR will add the Swagger docs added by cyverse-de/common-swagger-api#23 to the `/tools` endpoints.