### PR TITLE
CORE-11 Add Swagger docs to /analyses endpoints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.0"]
+                 [org.cyverse/common-swagger-api "2.11.1"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -6,12 +6,10 @@
 
 (def apps-sort-params [:limit :offset :sort-field :sort-dir :app-type])
 (def base-search-params (conj apps-sort-params :search))
-(def apps-analysis-listing-params (conj apps-sort-params :include-hidden :filter))
 (def apps-search-params (conj base-search-params :start_date :end_date))
 (def admin-apps-search-params (conj apps-search-params :app-subset))
 (def apps-hierarchy-sort-params (conj apps-sort-params :attr))
 (def tools-search-params (conj base-search-params :include-hidden :public))
-(def permission-lister-params [:full-listing])
 
 (defn- apps-url
   [& components]
@@ -442,106 +440,119 @@
 
 (defn list-jobs
   [params]
-  (client/get (apps-url "analyses")
-              {:query-params     (secured-params params apps-analysis-listing-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "analyses")
+                {:query-params     (secured-params params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn list-job-permissions
   [body params]
-  (client/post (apps-url "analyses" "permission-lister")
-               {:query-params     (secured-params params permission-lister-params)
-                :content-type     :json
-                :body             body
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "analyses" "permission-lister")
+                 {:query-params     (secured-params params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn share-jobs
   [body]
-  (client/post (apps-url "analyses" "sharing")
-               {:query-params     (secured-params)
-                :content-type     :json
-                :body             body
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "analyses" "sharing")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn unshare-jobs
   [body]
-  (client/post (apps-url "analyses" "unsharing")
-               {:query-params     (secured-params)
-                :content-type     :json
-                :body             body
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "analyses" "unsharing")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn submit-job
-  [submission]
-  (client/post (apps-url "analyses")
-               {:query-params     (secured-params)
-                :content-type     :json
-                :body             submission
-                :as               :stream
-                :follow-redirects false}))
+  [body]
+  (:body
+    (client/post (apps-url "analyses")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn update-job
   [analysis-id body]
-  (client/patch (apps-url "analyses" analysis-id)
-                {:query-params     (secured-params)
-                 :content-type     :json
-                 :body             body
-                 :as               :stream
-                 :follow-redirects false}))
+  (:body
+    (client/patch (apps-url "analyses" analysis-id)
+                  {:query-params     (secured-params)
+                   :form-params      body
+                   :content-type     :json
+                   :as               :json
+                   :follow-redirects false})))
 
 (defn delete-job
   [analysis-id]
-  (client/delete (apps-url "analyses" analysis-id)
-                 {:query-params     (secured-params)
-                  :as               :stream
-                  :follow-redirects false}))
+  (:body
+    (client/delete (apps-url "analyses" analysis-id)
+                   {:query-params     (secured-params)
+                    :as               :json
+                    :follow-redirects false})))
 
 (defn delete-jobs
   [body]
-  (client/post (apps-url "analyses" "shredder")
-               {:query-params     (secured-params)
-                :content-type     :json
-                :body             body
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "analyses" "shredder")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn get-job-params
   [analysis-id]
-  (client/get (apps-url "analyses" analysis-id "parameters")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "analyses" analysis-id "parameters")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn get-job-relaunch-info
   [analysis-id]
-  (client/get (apps-url "analyses" analysis-id "relaunch-info")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "analyses" analysis-id "relaunch-info")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn list-job-steps
   [analysis-id]
-  (client/get (apps-url "analyses" analysis-id "steps")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "analyses" analysis-id "steps")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn stop-job
   [analysis-id params]
-  (client/post (apps-url "analyses" analysis-id "stop")
-               {:query-params     (secured-params params [:job_status])
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "analyses" analysis-id "stop")
+                 {:query-params     (secured-params params)
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn get-job-history
   [analysis-id]
-  (client/get (apps-url "analyses" analysis-id "history")
-              {:query-params      (secured-params)
-               :as                :stream
-               :follow-redirecrts false}))
+  (:body
+    (client/get (apps-url "analyses" analysis-id "history")
+                {:query-params      (secured-params)
+                 :as                :json
+                 :follow-redirecrts false})))
 
 (defn admin-get-apps
   [params]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -8,6 +8,7 @@
         [terrain.auth.user-attributes]
         [terrain.middleware :only [wrap-context-path-adder wrap-query-param-remover]]
         [terrain.routes.admin]
+        [terrain.routes.analyses]
         [terrain.routes.apps.categories]
         [terrain.routes.apps.communities]
         [terrain.routes.apps.elements]
@@ -34,7 +35,6 @@
         [terrain.routes.token]
         [terrain.routes.webhooks]
         [terrain.routes.comments]
-        [terrain.routes.analyses]
         [terrain.util :as util]
         [terrain.util.transformers :as transform])
   (:require [cemerick.url :as curl]
@@ -197,6 +197,7 @@
                                      {:name "admin-comments", :description "Comment Administration Endpoints"}
                                      {:name "admin-communities", :description "Community Administration Endpoints"}
                                      {:name "admin-filesystem", :description "File System Administration Endpoints"}
+                                     {:name "analyses", :description "Analysis Endpoints"}
                                      {:name "analyses-quicklaunches", :description "Quick Launch Endpoints"}
                                      {:name "apps", :description, "Apps Endpoints"}
                                      {:name "app-categories", :description "App Category Endpoints"}

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -323,50 +323,6 @@
    (PUT "/apps/:app-id/metadata" [app-id :as {:keys [body]}]
      (service/success-response (apps/admin-set-avus app-id body)))))
 
-(defn analysis-routes
-  []
-  (optional-routes
-   [config/app-routes-enabled]
-
-   (GET "/analyses" [:as {:keys [params]}]
-     (service/success-response (apps/list-jobs params)))
-
-   (POST "/analyses" [:as {:keys [body]}]
-     (service/success-response (apps/submit-job body)))
-
-   (POST "/analyses/permission-lister" [:as {:keys [body params]}]
-     (service/success-response (apps/list-job-permissions body params)))
-
-   (POST "/analyses/sharing" [:as {:keys [body]}]
-     (service/success-response (apps/share-jobs body)))
-
-   (POST "/analyses/unsharing" [:as {:keys [body]}]
-     (service/success-response (apps/unshare-jobs body)))
-
-   (PATCH "/analyses/:analysis-id" [analysis-id :as {body :body}]
-          (service/success-response (apps/update-job analysis-id body)))
-
-   (DELETE "/analyses/:analysis-id" [analysis-id]
-     (service/success-response (apps/delete-job analysis-id)))
-
-   (POST "/analyses/shredder" [:as {:keys [body]}]
-     (service/success-response (apps/delete-jobs body)))
-
-   (GET "/analyses/:analysis-id/history" [analysis-id]
-     (service/success-response (apps/get-job-history analysis-id)))
-
-   (GET "/analyses/:analysis-id/parameters" [analysis-id]
-     (service/success-response (apps/get-job-params analysis-id)))
-
-   (GET "/analyses/:analysis-id/relaunch-info" [analysis-id]
-     (service/success-response (apps/get-job-relaunch-info analysis-id)))
-
-   (GET "/analyses/:analysis-id/steps" [analysis-id]
-     (service/success-response (apps/list-job-steps analysis-id)))
-
-   (POST "/analyses/:analysis-id/stop" [analysis-id :as {:keys [params]}]
-     (service/success-response (apps/stop-job analysis-id params)))))
-
 (defn admin-reference-genomes-routes
   []
   (optional-routes


### PR DESCRIPTION
This PR will add the Swagger docs added by cyverse-de/common-swagger-api#24 to the `/analyses` endpoints.