### PR TITLE
CORE-11 Fixes for URL import and tool search endpoints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.2"]
+                 [org.cyverse/common-swagger-api "2.11.4"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/clients/apps.clj
+++ b/src/terrain/clients/apps.clj
@@ -19,10 +19,6 @@
   [body]
   (raw/admin-add-tools (cheshire/encode body)))
 
-(defn submit-job
-  [submission]
-  (raw/submit-job (cheshire/encode submission)))
-
 (defn get-authenticated-user
   []
   (-> (raw/get-authenticated-user)

--- a/src/terrain/services/metadata/internal_jobs.clj
+++ b/src/terrain/services/metadata/internal_jobs.clj
@@ -2,8 +2,7 @@
   (:use [slingshot.slingshot :only [throw+]]
         [terrain.auth.user-attributes :only [current-user]])
   (:require [clojure-commons.error-codes :as ce]
-            [terrain.clients.apps :as apps]
-            [terrain.clients.apps.raw :as apps-client]
+            [terrain.clients.apps.raw :as apps]
             [terrain.clients.user-prefs :as prefs]
             [terrain.util.config :as config]))
 
@@ -15,7 +14,7 @@
 
 (defn- load-param-map
   [app-id]
-  (->> (apps-client/get-app config/de-system-id app-id)
+  (->> (apps/get-app config/de-system-id app-id)
        (:groups)
        (mapcat :parameters)
        (map (juxt :label :id))


### PR DESCRIPTION
This PR will:
* Update `terrain.services.metadata.internal-jobs/launch-url-import-job` to use `terrain.clients.apps.raw/submit-job`.
* Remove the obsolete `terrain.clients.apps/submit-job` function.
* Bump `common-swagger-api` dependency to version `2.11.4`, which includes a fix from cyverse-de/common-swagger-api#27 that added paging params to the `/tools` endpoint.