### PR TITLE
CORE-11 Add coerce-tool-import-requests middleware to /tool endpoints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.4"]
+                 [org.cyverse/common-swagger-api "2.11.5"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/routes/apps/tools.clj
+++ b/src/terrain/routes/apps/tools.clj
@@ -27,6 +27,7 @@
            (ok (apps/list-tools params)))
 
       (POST "/" []
+            :middleware [schema/coerce-tool-import-requests]
             :body [body schema/PrivateToolImportRequest]
             :responses schema/PrivateToolImportResponses
             :summary schema/ToolAddSummary
@@ -73,6 +74,7 @@
              (ok (apps/get-tool tool-id)))
 
         (PATCH "/" []
+               :middleware [schema/coerce-tool-import-requests]
                :body [body schema/PrivateToolUpdateRequest]
                :responses schema/ToolUpdateResponses
                :summary schema/ToolUpdateSummary


### PR DESCRIPTION
This PR will add the `coerce-tool-import-requests` middleware, added by cyverse-de/common-swagger-api#28, to the add and update `/tools` endpoints.

Missed in #107.