### PR TITLE
CORE-3: made the `overwrite` and `notify` query parameters optional i…

### DIFF
--- a/src/terrain/routes/schemas/coge.clj
+++ b/src/terrain/routes/schemas/coge.clj
@@ -1,6 +1,6 @@
 (ns terrain.routes.schemas.coge
   (:use [common-swagger-api.schema :only [describe]]
-        [schema.core :only [defschema maybe]]))
+        [schema.core :only [defschema maybe optional-key]]))
 
 (def GenomeIdPathParam (describe Long "The genome ID"))
 
@@ -8,8 +8,12 @@
   {:search (describe String "The genome search string, which must be at least three characters long")})
 
 (defschema GenomeExportParams
-  {:notify    (describe Boolean "Set to `true` to be notified when the export is complete")
-   :overwrite (describe Boolean "Set to `true` to indicate that the file should be overwritten if it exists")})
+  {(optional-key :notify)
+   (describe Boolean "Set to `true` to be notified when the export is complete (defaults to `false`)")
+
+   (optional-key :overwrite)
+   (describe Boolean (str "Set to `true` to indicate that the file should be overwritten if it exists "
+                          "(defaults to `false`)"))})
 
 (defschema GenomeLoadRequest
   {:paths (describe [String] "The paths to the files in the data store to view in CoGe.")})

--- a/src/terrain/services/coge.clj
+++ b/src/terrain/services/coge.clj
@@ -27,7 +27,7 @@
 
 (defn export-fasta
   "Exports the FastA file corresponding to a Genome into the user's CoGe data folder."
-  [genome-id {:keys [notify overwrite]}]
+  [genome-id {:keys [notify overwrite] :or {notify false overwrite false}}]
   (let [data-folder-path (coge-data-folder-path (:shortUsername current-user))]
     (create-coge-data-folder (:shortUsername current-user) data-folder-path)
     (coge/export-fasta genome-id


### PR DESCRIPTION
…n the `/coge/genomes/{genome-id}/export-fasta` endpoint