### PR TITLE
CORE-20 Add swagger docs for user-info endpoints

### DIFF
--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -197,6 +197,7 @@
                                      {:name "admin-comments", :description "Comment Administration Endpoints"}
                                      {:name "admin-communities", :description "Community Administration Endpoints"}
                                      {:name "admin-filesystem", :description "File System Administration Endpoints"}
+                                     {:name "admin-user-info", :description "User Info Administration Endpoints"}
                                      {:name "analyses", :description "Analysis Endpoints"}
                                      {:name "analyses-quicklaunches", :description "Quick Launch Endpoints"}
                                      {:name "apps", :description, "Apps Endpoints"}

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -216,7 +216,8 @@
                                      {:name "subjects", :description "Subject Endpoints"}
                                      {:name "teams", :description "Team Endpoints"}
                                      {:name "tools", :description "Tool Endpoints"}
-                                     {:name "token", :description "OAuth Tokens"}]
+                                     {:name "token", :description "OAuth Tokens"}
+                                     {:name "user-info", :description "User Information Endpoints"}]
                :securityDefinitions security-definitions}})
   (middleware
    [[wrap-query-param-remover "ip-address" #{#"^/terrain/secured/bootstrap"}]

--- a/src/terrain/routes/schemas/user_info.clj
+++ b/src/terrain/routes/schemas/user_info.clj
@@ -1,7 +1,11 @@
 (ns terrain.routes.schemas.user-info
-  (:use [common-swagger-api.schema :only [describe]])
-  (:require [common-swagger-api.schema.subjects :as subjects]
+  (:use [common-swagger-api.schema :only [describe
+                                          NonBlankString]])
+  (:require [common-swagger-api.schema.groups :as groups]
+            [common-swagger-api.schema.subjects :as subjects]
             [schema.core :as s]))
+
+(def UsernameParam (describe NonBlankString "The user's ID"))
 
 (s/defschema UserInfoRequest
   {:username (describe [s/Str] "A list containing user IDs")})
@@ -11,3 +15,5 @@
 
 (s/defschema UserInfoResponseDocs
   {:username subjects/Subject})
+
+(s/defschema GroupListing (groups/group-list "group" "groups"))

--- a/src/terrain/routes/schemas/user_info.clj
+++ b/src/terrain/routes/schemas/user_info.clj
@@ -1,0 +1,13 @@
+(ns terrain.routes.schemas.user-info
+  (:use [common-swagger-api.schema :only [describe]])
+  (:require [common-swagger-api.schema.subjects :as subjects]
+            [schema.core :as s]))
+
+(s/defschema UserInfoRequest
+  {:username (describe [s/Str] "A list containing user IDs")})
+
+(s/defschema UserInfoResponse
+  {s/Str subjects/Subject})
+
+(s/defschema UserInfoResponseDocs
+  {:username subjects/Subject})

--- a/src/terrain/routes/user_info.clj
+++ b/src/terrain/routes/user_info.clj
@@ -1,5 +1,7 @@
 (ns terrain.routes.user-info
   (:use [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]]
+        [terrain.routes.schemas.user-info]
         [terrain.services.user-info]
         [terrain.util]
         [terrain.util.service :only [success-response]])
@@ -14,8 +16,15 @@
    (context "/user-info" []
      :tags ["user-info"]
 
-     (GET "/" [:as {:keys [params]}]
-          (user-info (as-vector (:username params)))))))
+     (GET "/" []
+          :query [params UserInfoRequest]
+          :return (doc-only UserInfoResponse UserInfoResponseDocs)
+          :summary "Get user information"
+          :description "Returns account information associated with each username or ID.  If the ID
+          belongs to an individual user, information like first and last name, as well as institution and
+          email will be returned.  If the ID belongs to a group, such as a team or collaborator list,
+          then the name and description of the group will be returned."
+          (ok (user-info (:username params)))))))
 
 (defn admin-user-info-routes
   []

--- a/src/terrain/routes/user_info.clj
+++ b/src/terrain/routes/user_info.clj
@@ -31,5 +31,11 @@
   (optional-routes
    [config/user-info-routes-enabled]
 
-   (GET "/users/:username/groups" [username]
-     (success-response (ipg/list-groups-for-user username)))))
+   (context "/users" []
+     :tags ["admin-user-info"]
+     (GET "/:username/groups" []
+          :path-params [username :- UsernameParam]
+          :summary "Get a user's groups"
+          :description "Lists all groups to which a user belongs"
+          :return GroupListing
+          (ok (ipg/list-groups-for-user username))))))

--- a/src/terrain/routes/user_info.clj
+++ b/src/terrain/routes/user_info.clj
@@ -11,9 +11,11 @@
   (optional-routes
    [config/user-info-routes-enabled]
 
-   (GET "/user-info" [:as {:keys [params]}]
-     (user-info (as-vector (:username params))))))
+   (context "/user-info" []
+     :tags ["user-info"]
 
+     (GET "/" [:as {:keys [params]}]
+          (user-info (as-vector (:username params)))))))
 
 (defn admin-user-info-routes
   []

--- a/src/terrain/routes/user_info.clj
+++ b/src/terrain/routes/user_info.clj
@@ -11,9 +11,6 @@
   (optional-routes
    [config/user-info-routes-enabled]
 
-   (GET "/user-search" [:as {:keys [params]}]
-     (user-search (:search params)))
-
    (GET "/user-info" [:as {:keys [params]}]
      (user-info (as-vector (:username params))))))
 

--- a/src/terrain/services/user_info.clj
+++ b/src/terrain/services/user_info.clj
@@ -1,9 +1,7 @@
 (ns terrain.services.user-info
   (:use [terrain.util.service :only [success-response]])
-  (:require [cheshire.core :as cheshire]
-            [terrain.clients.iplant-groups :as ipg]
-            [terrain.auth.user-attributes :as user]
-            [clojure.tools.logging :as log]))
+  (:require [terrain.clients.iplant-groups :as ipg]
+            [terrain.auth.user-attributes :as user]))
 
 (defn- add-user-info
   "Adds the information for a single user to a user-info lookup result."
@@ -24,7 +22,4 @@
   "Performs a user search for one or more usernames, returning a response whose
    body consists of a JSON object indexed by username."
   [usernames]
-  (let [body (reduce add-user-info {} (map get-user-info usernames))]
-    {:status       200
-     :body         (cheshire/encode body)
-     :content-type :json}))
+  (reduce add-user-info {} (map get-user-info usernames)))

--- a/src/terrain/services/user_info.clj
+++ b/src/terrain/services/user_info.clj
@@ -5,14 +5,6 @@
             [terrain.auth.user-attributes :as user]
             [clojure.tools.logging :as log]))
 
-(defn user-search
-  "Performs user searches by username, name and e-mail address and returns the
-   merged results."
-  [search-string]
-     (let [results (ipg/find-subjects (:shortUsername user/current-user) search-string)
-           users   (:subjects results)]
-       (success-response {:users users :truncated false})))
-
 (defn- add-user-info
   "Adds the information for a single user to a user-info lookup result."
   [result [username user-info]]


### PR DESCRIPTION
Also removed the `/user-search` endpoint since the UI uses the `/subjects` for searching instead.