### PR TITLE
CORE-11 Add Swagger docs to bootstrap and logout endpoints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.6"]
+                 [org.cyverse/common-swagger-api "2.11.7"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/clients/apps.clj
+++ b/src/terrain/clients/apps.clj
@@ -24,20 +24,3 @@
   (-> (raw/get-authenticated-user)
       (:body)
       (service/decode-json)))
-
-(defn record-login
-  [ip-address user-agent]
-  (-> (raw/record-login ip-address user-agent)
-      (:body)
-      (service/decode-json)))
-
-(defn record-logout
-  [ip-address login-time]
-  (raw/record-logout ip-address login-time)
-  nil)
-
-(defn bootstrap
-  []
-  (-> (raw/bootstrap)
-      :body
-      service/decode-json))

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -927,17 +927,18 @@
 (defn record-login
   [ip-address user-agent]
   (let [params {:ip-address ip-address :user-agent user-agent}]
-    (client/post (apps-url "users" "login")
-                 {:query-params     (secured-params params)
-                  :as               :stream
-                  :follow-redirects false})))
+    (:body
+      (client/post (apps-url "users" "login")
+                   {:query-params     (secured-params params)
+                    :as               :json
+                    :follow-redirects false}))))
 
 (defn record-logout
-  [ip-address login-time]
-  (let [params {:ip-address ip-address :login-time login-time}]
+  [params]
+  (:body
     (client/post (apps-url "users" "logout")
                  {:query-params     (secured-params params)
-                  :as               :stream
+                  :as               :json
                   :follow-redirects false})))
 
 (defn list-integration-data
@@ -1034,10 +1035,11 @@
 
 (defn bootstrap
   []
-  (client/get (apps-url "bootstrap")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "bootstrap")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn save-webhooks
   [webhooks]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -15,6 +15,7 @@
         [terrain.routes.apps.metadata]
         [terrain.routes.apps.pipelines]
         [terrain.routes.apps.tools]
+        [terrain.routes.bootstrap]
         [terrain.routes.data]
         [terrain.routes.permanent-id-requests]
         [terrain.routes.fileio]
@@ -88,7 +89,7 @@
   []
   (util/flagged-routes
     (secured-notification-routes)
-    (secured-metadata-routes)
+    (secured-bootstrap-routes)
     (secured-pref-routes)
     (secured-user-info-routes)
     (secured-data-routes)
@@ -208,6 +209,7 @@
                                      {:name "app-element-types", :description, "App Element Endpoints"}
                                      {:name "app-metadata", :description "App Metadata Endpoints"}
                                      {:name "app-pipelines", :description "App Pipeline Endpoints"}
+                                     {:name "bootstrap", :description "Bootstrap Endpoints"}
                                      {:name "coge", :description "CoGe Endpoints"}
                                      {:name "collaborator-lists", :description "Collaborator List Endpoints"}
                                      {:name "communities", :description "Community Endpoints"}
@@ -222,7 +224,8 @@
                                      {:name "webhooks", :description "Webhook Endpoints"}]
                :securityDefinitions security-definitions}})
   (middleware
-   [[wrap-query-param-remover "ip-address" #{#"^/terrain/secured/bootstrap"}]
+   [[wrap-query-param-remover "ip-address" #{#"^/terrain/secured/bootstrap"
+                                             #"^/terrain/secured/logout"}]
     wrap-query-params
     wrap-lcase-params
     wrap-keyword-params

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -19,7 +19,6 @@
         [ring.util.http-response :only [ok]]
         [terrain.routes.schemas.apps]
         [terrain.services.metadata.apps]
-        [terrain.services.bootstrap]
         [terrain.util])
   (:require [common-swagger-api.routes]                     ;; Required for :description-file
             [common-swagger-api.schema.apps :as schema]
@@ -415,17 +414,6 @@
 
    (POST "/support-email" [:as {body :body}]
      (send-support-email body))))
-
-(defn secured-metadata-routes
-  []
-  (optional-routes
-   [config/app-routes-enabled]
-
-   (GET "/bootstrap" [:as req]
-     (bootstrap req))
-
-   (GET "/logout" [:as {params :params}]
-     (logout params))))
 
 (defn admin-integration-data-routes
   []

--- a/src/terrain/routes/schemas/bootstrap.clj
+++ b/src/terrain/routes/schemas/bootstrap.clj
@@ -1,0 +1,23 @@
+(ns terrain.routes.schemas.bootstrap
+  (:use [common-swagger-api.schema :only [describe doc-only]]
+        [schema.core :only [defschema]])
+  (:require [common-swagger-api.schema.apps.bootstrap :as apps-schema]
+            [common-swagger-api.schema.data.navigation :as navigation-schema]
+            [common-swagger-api.schema.sessions :as sessions-schema]
+            [terrain.routes.schemas.user-prefs :as user-prefs-schema]))
+
+(defschema UserInfo
+  (-> {:username      (describe String "The authenticated user's short username")
+       :full_username (describe String "The authenticated user's fully qualified username")
+       :email         (describe String "The authenticated user's email")
+       :first_name    (describe String "The authenticated user's first name")
+       :last_name     (describe String "The authenticated user's last name")}
+      (describe "User attributes obtained during the authentication process.")))
+
+(defschema TerrainBootstrapResponse
+  {:user_info   UserInfo
+   :session     sessions-schema/LoginResponse
+   :apps_info   apps-schema/AppsBootstrapResponse
+   :data_info   navigation-schema/UserBasePaths
+   :preferences (doc-only user-prefs-schema/UserPreferencesResponse
+                          user-prefs-schema/UserPreferencesResponseDocs)})

--- a/src/terrain/routes/schemas/user_prefs.clj
+++ b/src/terrain/routes/schemas/user_prefs.clj
@@ -1,0 +1,23 @@
+(ns terrain.routes.schemas.user-prefs
+  (:use [common-swagger-api.schema :only [describe]]
+        [common-swagger-api.schema.stats :only [DataItemPathParam]]
+        [schema.core :only [defschema Any Keyword optional-key]]))
+
+(def default-output-dir-key :default_output_folder)
+
+(def AnyPreferenceValue (describe Any "Any preference value"))
+
+(defschema DefaultOutputDirPreference
+  (-> {:id   DataItemPathParam
+       :path DataItemPathParam}
+      (describe "The user's default analyses output directory, required by this terrain service.")))
+
+(defschema UserPreferencesResponse
+  {default-output-dir-key                  DefaultOutputDirPreference
+   (describe Keyword "Any preference key") AnyPreferenceValue})
+
+(defschema UserPreferencesResponseDocs
+  (-> UserPreferencesResponse
+      (merge {(optional-key :any_preference_key) AnyPreferenceValue})
+      (describe (str "The User Preferences map may contain any number of key/value pairs"
+                     " that the client wishes to store and retrieve between sessions."))))

--- a/src/terrain/services/bootstrap.clj
+++ b/src/terrain/services/bootstrap.clj
@@ -4,7 +4,7 @@
     [terrain.auth.user-attributes :only [current-user]])
   (:require
     [clojure.tools.logging :as log]
-    [terrain.clients.apps :as apps-client]
+    [terrain.clients.apps.raw :as apps-client]
     [terrain.clients.data-info :as data-info-client]
     [terrain.services.user-prefs :as prefs]
     [terrain.util.service :as service]))
@@ -54,21 +54,19 @@
 (defn bootstrap
   "This service obtains information about and initializes the workspace for the authenticated user.
    It also records the fact that the user logged in."
-  [{{:keys [ip-address]} :params {user-agent "user-agent"} :headers}]
-  (service/assert-valid ip-address "Missing or empty query string parameter: ip-address")
+  [ip-address user-agent]
   (service/assert-valid user-agent "Missing or empty request parameter: user-agent")
   (let [{user :shortUsername :keys [email firstName lastName username]} current-user
         login-session (future (get-login-session ip-address user-agent))
         apps-info     (future (get-apps-info))
         data-info     (future (get-user-data-info user))
         preferences   (future (get-user-prefs username))]
-    (service/success-response
-      {:user_info   {:username      user
-                     :full_username username
-                     :email         email
-                     :first_name    firstName
-                     :last_name     lastName}
-       :session     @login-session
-       :apps_info   @apps-info
-       :data_info   @data-info
-       :preferences @preferences})))
+    {:user_info   {:username      user
+                   :full_username username
+                   :email         email
+                   :first_name    firstName
+                   :last_name     lastName}
+     :session     @login-session
+     :apps_info   @apps-info
+     :data_info   @data-info
+     :preferences @preferences}))

--- a/src/terrain/services/metadata/apps.clj
+++ b/src/terrain/services/metadata/apps.clj
@@ -36,14 +36,6 @@
     (dorun (map dn/send-tool-notification (:tools json))))
   (success-response))
 
-(defn logout
-  "This service records the fact that the user logged out."
-  [{:keys [ip-address login-time]}]
-  (assert-valid ip-address "Missing or empty query string parameter: ip-address")
-  (assert-valid login-time "Missing or empty query string parameter: login-time")
-  (dm/record-logout ip-address login-time)
-  (success-response))
-
 (defn add-reference-genome
   "Adds a reference genome via apps."
   [req]

--- a/src/terrain/services/user_prefs.clj
+++ b/src/terrain/services/user_prefs.clj
@@ -1,7 +1,8 @@
 (ns terrain.services.user-prefs
   (:use [slingshot.slingshot :only [throw+]]
-        [terrain.util.service :only [success-response]]
-        [terrain.auth.user-attributes :only [current-user]])
+        [terrain.auth.user-attributes :only [current-user]]
+        [terrain.routes.schemas.user-prefs :only [default-output-dir-key]]
+        [terrain.util.service :only [success-response]])
   (:require [cheshire.core :as cheshire]
             [clojure.tools.logging :as log]
             [clojure-commons.error-codes :as ce]
@@ -32,9 +33,9 @@
 
 (defn validate-user-prefs
   [prefs]
-  (if-not (contains? prefs output-dir/default-output-dir-key)
+  (if-not (contains? prefs default-output-dir-key)
     (throw+ {:error_code ce/ERR_BAD_REQUEST
-             :msg        (str "Missing " (name output-dir/default-output-dir-key))})))
+             :msg        (str "Missing " (name default-output-dir-key))})))
 
 (defn user-prefs
   "Retrieves or saves the user's preferences."

--- a/src/terrain/services/user_prefs/output_dir.clj
+++ b/src/terrain/services/user_prefs/output_dir.clj
@@ -1,12 +1,11 @@
 (ns terrain.services.user-prefs.output-dir
-  (:use [terrain.auth.user-attributes :only [current-user]])
+  (:use [terrain.auth.user-attributes :only [current-user]]
+        [terrain.routes.schemas.user-prefs :only [default-output-dir-key]])
   (:require [clojure.string :as string]
             [clojure.tools.logging :as log]
             [clojure-commons.file-utils :as ft]
             [terrain.clients.data-info :as di]
             [terrain.util.config :as cfg]))
-
-(def default-output-dir-key :default_output_folder)
 
 (defn- convert-default-output-dir-keys
   [prefs]


### PR DESCRIPTION
This PR will use the Swagger docs added by cyverse-de/common-swagger-api#30 for the `/bootstrap` and `/logout` endpoints.

Also includes a fix for the `logout` endpoint to prevent terrain's middleware from stripping the required `ip-address` param.