### PR TITLE
CORE-11 Add Swagger docs to /tool-requests endpoints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.7"]
+                 [org.cyverse/common-swagger-api "2.11.8-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/clients/apps.clj
+++ b/src/terrain/clients/apps.clj
@@ -9,12 +9,6 @@
        (:body)
        (service/decode-json)))
 
-(defn list-tool-request-status-codes
-  [params]
-  (-> (raw/list-tool-request-status-codes params)
-      (:body)
-      (service/decode-json)))
-
 (defn admin-add-tools
   [body]
   (raw/admin-add-tools (cheshire/encode body)))

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -744,12 +744,33 @@
                   :as               :stream
                   :follow-redirects false}))
 
+(defn list-tool-requests
+  "Lists the tool requests that were submitted by the authenticated user."
+  [params]
+  (:body
+    (client/get (apps-url "tool-requests")
+                {:query-params     (secured-params params)
+                 :as               :json
+                 :follow-redirects false})))
+
+(defn submit-tool-request
+  "Submits a tool request on behalf of the user found in the request params."
+  [body]
+  (:body
+    (client/post (apps-url "tool-requests")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
+
 (defn list-tool-request-status-codes
   [params]
-  (client/get (apps-url "tool-requests" "status-codes")
-              {:query-params     (secured-params params [:filter])
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "tool-requests" "status-codes")
+                {:query-params     (secured-params params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn get-tools-in-app
   [system-id app-id]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -219,6 +219,7 @@
                                      {:name "subjects", :description "Subject Endpoints"}
                                      {:name "teams", :description "Team Endpoints"}
                                      {:name "tools", :description "Tool Endpoints"}
+                                     {:name "tool-requests", :description "Tool Request Endpoints"}
                                      {:name "token", :description "OAuth Tokens"}
                                      {:name "user-info", :description "User Information Endpoints"}
                                      {:name "webhooks", :description "Webhook Endpoints"}]

--- a/src/terrain/routes/apps/tools.clj
+++ b/src/terrain/routes/apps/tools.clj
@@ -9,6 +9,7 @@
             [common-swagger-api.schema.tools :as schema]
             [compojure.api.middleware :as middleware]
             [terrain.clients.apps.raw :as apps]
+            [terrain.services.metadata.apps :as apps-services]
             [terrain.util.config :as config]))
 
 (defn tool-routes
@@ -92,3 +93,32 @@
              :summary schema/ToolIntegrationDataListingSummary
              :description schema/ToolIntegrationDataListingDocs
              (ok (apps/get-tool-integration-data tool-id)))))))
+
+(defn tool-request-routes
+  []
+  (optional-routes
+    [config/app-routes-enabled]
+
+    (context "/tool-requests" []
+      :tags ["tool-requests"]
+
+      (GET "/" []
+           :query [params schema/ToolRequestListingParams]
+           :return schema/ToolRequestListing
+           :summary schema/ToolInstallRequestListingSummary
+           :description schema/ToolInstallRequestListingDocs
+           (ok (apps/list-tool-requests params)))
+
+      (POST "/" []
+            :body [body schema/ToolRequest]
+            :return schema/ToolRequestDetails
+            :summary schema/ToolInstallRequestSummary
+            :description schema/ToolInstallRequestDocs
+            (ok (apps-services/submit-tool-request body)))
+
+      (GET "/status-codes" []
+           :query [params schema/ToolRequestStatusCodeListingParams]
+           :return schema/ToolRequestStatusCodeListing
+           :summary schema/ToolInstallRequestStatusCodeListingSummary
+           :description schema/ToolInstallRequestStatusCodeListingDocs
+           (ok (apps/list-tool-request-status-codes params))))))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -393,20 +393,6 @@
    (POST "/tool-requests/:request-id/status" [request-id :as req]
      (update-tool-request req request-id))))
 
-(defn tool-request-routes
-  []
-  (optional-routes
-   [config/app-routes-enabled]
-
-   (GET "/tool-requests" []
-     (list-tool-requests))
-
-   (POST "/tool-requests" [:as req]
-     (submit-tool-request req))
-
-   (GET "/tool-requests/status-codes" [:as {params :params}]
-     (list-tool-request-status-codes params))))
-
 (defn misc-metadata-routes
   []
   (optional-routes


### PR DESCRIPTION
This PR will add the schemas and docs added by cyverse-de/common-swagger-api#31 to to `/tool-requests` endpoints.

This requires refactoring the `username` extraction and `send-tool-request-email` call out of `terrain.services.metadata.apps/postprocess-tool-request` and into `submit-tool-request`.