### PR TITLE
Add support for scroll and scroll_id to this facade

### DIFF
--- a/src/terrain/routes/schemas/search.clj
+++ b/src/terrain/routes/schemas/search.clj
@@ -33,10 +33,14 @@
    (s/optional-key :none) (describe [Clause] NoneDocs)})
 
 (s/defschema SearchRequest
-  {:query (describe Query "A querydsl-compatible JSON query inside a JSON object")
+  {(s/optional-key :query) (describe Query "A querydsl-compatible JSON query inside a JSON object. Mutually exclusive with 'scroll_id'.")
    (s/optional-key :size) (describe (s/both Long (s/pred pos? 'positive-integer?))
                                     "Limits the response to X number of results. Default is 10")
    (s/optional-key :from) (describe (s/both Long (s/pred (partial <= 0) 'non-negative-integer?))
                                     "Skips the first X number of results. Default is 0")
    (s/optional-key :sort) (describe [SearchSortParams]
-                                    "Sorts the results based on a list of criteria")})
+                                    "Sorts the results based on a list of criteria")
+   (s/optional-key :scroll) (describe String
+                                    "Sets a scroll timeout for this search. Required if scroll_id is present.")
+   (s/optional-key :scroll_id) (describe String
+                                    "Gets the next set of results for a given scroll ID. Mutually exclusive with 'query'.")})


### PR DESCRIPTION
I missed this when reviewing the original PR, but these are also things that can be passed! Scroll sets a timeout, but as a string (e.g. "1m" for one minute), and if a scroll timeout is provided the response will include a scroll_id. Then, subsequent requests can get more results from the same search by passing back the scroll ID. This is pretty much the same as the underlying ES stuff, and it was added for the use case of pulling down the ES representations of a bunch of things at once.

Since in the case of a scroll_id being passed the query isn't, now every key is marked optional, but, alas.