### PR TITLE
CORE-11 Add Swagger docs for /admin/apps endpoints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.8"]
+                 [org.cyverse/common-swagger-api "2.11.9-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -6,8 +6,6 @@
 
 (def apps-sort-params [:limit :offset :sort-field :sort-dir :app-type])
 (def base-search-params (conj apps-sort-params :search))
-(def apps-search-params (conj base-search-params :start_date :end_date))
-(def admin-apps-search-params (conj apps-search-params :app-subset))
 (def apps-hierarchy-sort-params (conj apps-sort-params :attr))
 (def tools-search-params (conj base-search-params :include-hidden :public))
 
@@ -248,10 +246,11 @@
 
 (defn get-admin-app-details
   [system-id app-id]
-  (client/get (apps-url "admin" "apps" system-id app-id "details")
-              {:query-params      (secured-params)
-               :as                :stream
-               :follow-redirects  false}))
+  (:body
+    (client/get (apps-url "admin" "apps" system-id app-id "details")
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn get-app-details
   [system-id app-id]
@@ -556,44 +555,49 @@
 
 (defn admin-get-apps
   [params]
-  (client/get (apps-url "admin" "apps")
-              {:query-params     (secured-params params admin-apps-search-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/get (apps-url "admin" "apps")
+                {:query-params     (secured-params params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn categorize-apps
   [body]
-  (client/post (apps-url "admin" "apps")
-               {:query-params     (secured-params)
-                :content-type     :json
-                :body             body
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "admin" "apps")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn permanently-delete-apps
   [body]
-  (client/post (apps-url "admin" "apps" "shredder")
-               {:query-params     (secured-params)
-                :content-type     :json
-                :body             body
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "admin" "apps" "shredder")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 (defn admin-delete-app
   [system-id app-id]
-  (client/delete (apps-url "admin" "apps" system-id app-id)
-                 {:query-params     (secured-params)
-                  :as               :stream
-                  :follow-redirects false}))
+  (:body
+    (client/delete (apps-url "admin" "apps" system-id app-id)
+                   {:query-params     (secured-params)
+                    :as               :json
+                    :follow-redirects false})))
 
 (defn admin-update-app
   [system-id app-id body]
-  (client/patch (apps-url "admin" "apps" system-id app-id)
-                {:query-params     (secured-params)
-                 :content-type     :json
-                 :body             body
-                 :as               :stream
-                 :follow-redirects false}))
+  (:body
+    (client/patch (apps-url "admin" "apps" system-id app-id)
+                  {:query-params     (secured-params)
+                   :form-params      body
+                   :content-type     :json
+                   :as               :json
+                   :follow-redirects false})))
 
 (defn get-admin-app-categories
   [params]
@@ -664,21 +668,23 @@
 
 (defn admin-edit-app-docs
   [system-id app-id docs]
-  (client/patch (apps-url "admin" "apps" system-id app-id "documentation")
-                {:query-params     (secured-params)
-                 :content-type     :json
-                 :body             docs
-                 :as               :stream
-                 :follow-redirects false}))
+  (:body
+    (client/patch (apps-url "admin" "apps" system-id app-id "documentation")
+                  {:query-params     (secured-params)
+                   :form-params      docs
+                   :content-type     :json
+                   :as               :json
+                   :follow-redirects false})))
 
 (defn admin-add-app-docs
   [system-id app-id docs]
-  (client/post (apps-url "admin" "apps" system-id app-id "documentation")
-               {:query-params     (secured-params)
-                :content-type     :json
-                :body             docs
-                :as               :stream
-                :follow-redirects false}))
+  (:body
+    (client/post (apps-url "admin" "apps" system-id app-id "documentation")
+                 {:query-params     (secured-params)
+                  :form-params      docs
+                  :content-type     :json
+                  :as               :json
+                  :follow-redirects false})))
 
 
 (defn get-oauth-access-token
@@ -1021,10 +1027,11 @@
 
 (defn update-app-integration-data
   [system-id app-id integration-data-id]
-  (client/put (apps-url "admin" "apps" system-id app-id "integration-data" integration-data-id)
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+  (:body
+    (client/put (apps-url "admin" "apps" system-id app-id "integration-data" integration-data-id)
+                {:query-params     (secured-params)
+                 :as               :json
+                 :follow-redirects false})))
 
 (defn update-tool-integration-data
   [tool-id integration-data-id]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -9,6 +9,7 @@
         [terrain.middleware :only [wrap-context-path-adder wrap-query-param-remover]]
         [terrain.routes.admin]
         [terrain.routes.analyses]
+        [terrain.routes.apps.admin.apps]
         [terrain.routes.apps.categories]
         [terrain.routes.apps.communities]
         [terrain.routes.apps.elements]

--- a/src/terrain/routes/apps/admin/apps.clj
+++ b/src/terrain/routes/apps/admin/apps.clj
@@ -1,0 +1,88 @@
+(ns terrain.routes.apps.admin.apps
+  (:use [common-swagger-api.schema]
+        [common-swagger-api.schema.apps.admin.categories
+         :only [AppCategorizationDocs
+                AppCategorizationRequest
+                AppCategorizationSummary]]
+        [common-swagger-api.schema.integration-data
+         :only [IntegrationData
+                IntegrationDataIdPathParam]]
+        [ring.util.http-response :only [ok]]
+        [terrain.routes.schemas.admin :only [AdminAppSearchParams]]
+        [terrain.util :only [optional-routes]])
+  (:require [common-swagger-api.routes]                     ;; for :description-file
+            [common-swagger-api.schema.apps :as apps-schema]
+            [common-swagger-api.schema.apps.admin.apps :as schema]
+            [terrain.clients.apps.raw :as apps]
+            [terrain.util.config :as config]))
+
+(defn admin-apps-routes
+  []
+  (optional-routes
+    [#(and (config/admin-routes-enabled)
+           (config/app-routes-enabled))]
+
+    (context "/apps" []
+      :tags ["admin-apps"]
+
+      (GET "/" []
+           :query [params AdminAppSearchParams]
+           :summary apps-schema/AppListingSummary
+           :return schema/AdminAppListing
+           :description schema/AppListingDocs
+           (ok (apps/admin-get-apps params)))
+
+      (POST "/" []
+            :body [body AppCategorizationRequest]
+            :summary AppCategorizationSummary
+            :description AppCategorizationDocs
+            (ok (apps/categorize-apps body)))
+
+      (POST "/shredder" []
+            :body [body apps-schema/AppDeletionRequest]
+            :summary schema/AppShredderSummary
+            :description schema/AppShredderDocs
+            (ok (apps/permanently-delete-apps body)))
+
+      (context "/:system-id/:app-id" []
+        :path-params [system-id :- apps-schema/SystemId
+                      app-id :- apps-schema/StringAppIdParam]
+
+        (DELETE "/" []
+                :summary apps-schema/AppDeleteSummary
+                :description schema/AppDeleteDocs
+                (ok (apps/admin-delete-app system-id app-id)))
+
+        (PATCH "/" []
+               :body [body schema/AdminAppPatchRequest]
+               :return schema/AdminAppDetails
+               :summary schema/AdminAppPatchSummary
+               :description-file "docs/apps/admin/app-label-update.md"
+               (ok (apps/admin-update-app system-id app-id body)))
+
+        (GET "/details" []
+             :return schema/AdminAppDetails
+             :summary apps-schema/AppDetailsSummary
+             :description schema/AppDetailsDocs
+             (ok (apps/get-admin-app-details system-id app-id)))
+
+        (PATCH "/documentation" []
+               :body [body apps-schema/AppDocumentationRequest]
+               :return apps-schema/AppDocumentation
+               :summary apps-schema/AppDocumentationUpdateSummary
+               :description schema/AppDocumentationUpdateDocs
+               (ok (apps/admin-edit-app-docs system-id app-id body)))
+
+        (POST "/documentation" []
+              :body [body apps-schema/AppDocumentationRequest]
+              :return apps-schema/AppDocumentation
+              :summary apps-schema/AppDocumentationAddSummary
+              :description schema/AppDocumentationAddDocs
+              (ok (apps/admin-add-app-docs system-id app-id body)))
+
+        (PUT "/integration-data/:integration-data-id" []
+             :path-params [integration-data-id :- IntegrationDataIdPathParam]
+             :return IntegrationData
+             :summary schema/AppIntegrationDataUpdateSummary
+             :description schema/AppIntegrationDataUpdateDocs
+             (ok (apps/update-app-integration-data system-id app-id integration-data-id)))))))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -95,39 +95,6 @@
     (GET "/apps/communities/:community-id/apps" [community-id]
       (service/success-response (apps/admin-get-apps-in-community community-id)))))
 
-(defn admin-apps-routes
-  []
-  (optional-routes
-   [#(and (config/admin-routes-enabled)
-          (config/app-routes-enabled))]
-
-   (GET "/apps" [:as {:keys [params]}]
-     (service/success-response (apps/admin-get-apps params)))
-
-   (POST "/apps" [:as {:keys [body]}]
-     (service/success-response (apps/categorize-apps body)))
-
-   (POST "/apps/shredder" [:as {:keys [body]}]
-     (service/success-response (apps/permanently-delete-apps body)))
-
-   (DELETE "/apps/:system-id/:app-id" [system-id app-id]
-     (service/success-response (apps/admin-delete-app system-id app-id)))
-
-   (PATCH "/apps/:system-id/:app-id" [system-id app-id :as {:keys [body]}]
-     (service/success-response (apps/admin-update-app system-id app-id body)))
-
-   (GET "/apps/:system-id/:app-id/details" [system-id app-id]
-     (service/success-response (apps/get-admin-app-details system-id app-id)))
-
-   (POST "/apps/:system-id/:app-id/documentation" [system-id app-id :as {:keys [body]}]
-     (service/success-response (apps/admin-add-app-docs system-id app-id body)))
-
-   (PATCH "/apps/:system-id/:app-id/documentation" [system-id app-id :as {:keys [body]}]
-     (service/success-response (apps/admin-edit-app-docs system-id app-id body)))
-
-   (PUT "/apps/:system-id/:app-id/integration-data/:integration-data-id" [system-id app-id integration-data-id]
-     (service/success-response (apps/update-app-integration-data system-id app-id integration-data-id)))))
-
 (defn apps-routes
   []
   (optional-routes

--- a/src/terrain/routes/schemas/admin.clj
+++ b/src/terrain/routes/schemas/admin.clj
@@ -1,6 +1,22 @@
 (ns terrain.routes.schemas.admin
-  (:use [common-swagger-api.schema :only [describe]]
-        [schema.core :only [defschema]]))
+  (:use [common-swagger-api.schema
+         :only [describe
+                SortFieldDocs
+                SortFieldOptionalKey]]
+        [schema.core :only [defschema enum]])
+  (:require [common-swagger-api.schema.apps.admin.apps :as apps-schema]))
+
+;; Convert the keywords in AdminAppSearchValidSortFields to strings,
+;; so that the correct param format is passed through to the apps service.
+(defschema AdminAppSearchParams
+  (merge apps-schema/AdminAppSearchParams
+         {SortFieldOptionalKey
+          (describe (apply enum (map name apps-schema/AdminAppSearchValidSortFields))
+                    SortFieldDocs)
+
+          apps-schema/AppSubsetOptionalKey
+          (describe (apply enum (map name apps-schema/AppSubsets))
+                    apps-schema/AppSubsetDocs :default :public)}))
 
 (defschema StatusResponse
   {:iRODS             (describe Boolean "True if the data store appears to be functional")


### PR DESCRIPTION
This PR will add the Swagger docs added by cyverse-de/common-swagger-api#33 to `/admin/apps` endpoints.

It will also refactor `terrain.routes.metadata/admin-apps-routes` into a new `terrain.routes.apps.admin.apps` namespace.