### PR TITLE
CORE-11 Add Swagger docs to /admin/reference-genomes endpoints

### DIFF
--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -939,12 +939,33 @@
                  :as               :json
                  :follow-redirects false})))
 
+(defn admin-add-reference-genome
+  [body]
+  (:body
+    (client/post (apps-url "admin" "reference-genomes")
+                 {:query-params     (secured-params)
+                  :form-params      body
+                  :as               :json
+                  :content-type     :json
+                  :follow-redirects false})))
+
 (defn admin-delete-reference-genome
   [reference-genome-id params]
-  (client/delete (apps-url "admin" "reference-genomes" reference-genome-id)
-                 {:query-params     (secured-params params [:permanent])
-                  :as               :stream
-                  :follow-redirects false}))
+  (:body
+    (client/delete (apps-url "admin" "reference-genomes" reference-genome-id)
+                   {:query-params     (secured-params params)
+                    :as               :json
+                    :follow-redirects false})))
+
+(defn admin-update-reference-genome
+  [body reference-genome-id]
+  (:body
+    (client/patch (apps-url "admin" "reference-genomes" reference-genome-id)
+                  {:query-params     (secured-params)
+                   :form-params      body
+                   :as               :json
+                   :content-type     :json
+                   :follow-redirects false})))
 
 (defn get-authenticated-user
   []

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -10,6 +10,7 @@
         [terrain.routes.admin]
         [terrain.routes.analyses]
         [terrain.routes.apps.admin.apps]
+        [terrain.routes.apps.admin.reference-genomes]
         [terrain.routes.apps.categories]
         [terrain.routes.apps.communities]
         [terrain.routes.apps.elements]
@@ -200,6 +201,7 @@
                                      {:name "admin-comments", :description "Comment Administration Endpoints"}
                                      {:name "admin-communities", :description "Community Administration Endpoints"}
                                      {:name "admin-filesystem", :description "File System Administration Endpoints"}
+                                     {:name "admin-reference-genomes", :description "Admin Reference Genome Endpoints"}
                                      {:name "admin-user-info", :description "User Info Administration Endpoints"}
                                      {:name "analyses", :description "Analysis Endpoints"}
                                      {:name "analyses-quicklaunches", :description "Quick Launch Endpoints"}

--- a/src/terrain/routes/apps/admin/reference_genomes.clj
+++ b/src/terrain/routes/apps/admin/reference_genomes.clj
@@ -1,0 +1,41 @@
+(ns terrain.routes.apps.admin.reference-genomes
+  (:use [common-swagger-api.schema]
+        [common-swagger-api.schema.apps.reference-genomes
+         :only [ReferenceGenome
+                ReferenceGenomeIdParam]]
+        [ring.util.http-response :only [ok]]
+        [terrain.util :only [optional-routes]]
+        [terrain.util.config :as config])
+  (:require [common-swagger-api.schema.apps.admin.reference-genomes :as schema]
+            [terrain.clients.apps.raw :as apps]))
+
+(defn admin-reference-genomes-routes
+  []
+  (optional-routes
+    [#(and (config/admin-routes-enabled)
+           (config/app-routes-enabled))]
+
+    (context "/reference-genomes" []
+      :tags ["admin-reference-genomes"]
+
+      (POST "/" []
+            :body [body schema/ReferenceGenomeAddRequest]
+            :return ReferenceGenome
+            :summary schema/ReferenceGenomeAddSummary
+            :description schema/ReferenceGenomeAddDocs
+            (ok (apps/admin-add-reference-genome body)))
+
+      (DELETE "/:reference-genome-id" []
+              :path-params [reference-genome-id :- ReferenceGenomeIdParam]
+              :query [params schema/ReferenceGenomeDeletionParams]
+              :summary schema/ReferenceGenomeDeleteSummary
+              :description schema/ReferenceGenomeDeleteDocs
+              (ok (apps/admin-delete-reference-genome reference-genome-id params)))
+
+      (PATCH "/:reference-genome-id" []
+             :path-params [reference-genome-id :- ReferenceGenomeIdParam]
+             :body [body schema/ReferenceGenomeUpdateRequest]
+             :return ReferenceGenome
+             :summary schema/ReferenceGenomeUpdateSummary
+             :description schema/ReferenceGenomeUpdateDocs
+             (ok (apps/admin-update-reference-genome body reference-genome-id))))))

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -289,21 +289,6 @@
    (PUT "/apps/:app-id/metadata" [app-id :as {:keys [body]}]
      (service/success-response (apps/admin-set-avus app-id body)))))
 
-(defn admin-reference-genomes-routes
-  []
-  (optional-routes
-   [#(and (config/admin-routes-enabled)
-          (config/app-routes-enabled))]
-
-   (POST "/reference-genomes" [:as req]
-     (add-reference-genome req))
-
-   (DELETE "/reference-genomes/:reference-genome-id" [reference-genome-id :as {:keys [params]}]
-     (apps/admin-delete-reference-genome reference-genome-id params))
-
-   (PATCH "/reference-genomes/:reference-genome-id" [reference-genome-id :as req]
-          (update-reference-genome req reference-genome-id))))
-
 (defn admin-tool-routes
   []
   (optional-routes

--- a/src/terrain/services/metadata/apps.clj
+++ b/src/terrain/services/metadata/apps.clj
@@ -37,20 +37,6 @@
     (dorun (map dn/send-tool-notification (:tools json))))
   (success-response))
 
-(defn add-reference-genome
-  "Adds a reference genome via apps."
-  [req]
-  (let [url (apps-url {} "admin" "reference-genomes")
-        req (apps-request req)]
-    (forward-post url req)))
-
-(defn update-reference-genome
-  "Updates a reference genome via apps."
-  [req reference-genome-id]
-  (let [url (apps-url {} "admin" "reference-genomes" reference-genome-id)
-        req (apps-request req)]
-    (forward-patch url req)))
-
 (defn- postprocess-tool-request
   "Postprocesses a tool request update."
   [res]


### PR DESCRIPTION
This PR will add the Swagger docs, added by cyverse-de/common-swagger-api#34, to `/admin/reference-genomes` endpoints.