### PR TITLE
CORE-11 Refactor terrain.routes.schemas.admin/AdminAppSearchParams

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.9-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "2.11.9"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/routes/schemas/admin.clj
+++ b/src/terrain/routes/schemas/admin.clj
@@ -1,22 +1,30 @@
 (ns terrain.routes.schemas.admin
   (:use [common-swagger-api.schema
          :only [describe
+                NonBlankString
                 SortFieldDocs
                 SortFieldOptionalKey]]
         [schema.core :only [defschema enum]])
-  (:require [common-swagger-api.schema.apps.admin.apps :as apps-schema]))
+  (:require [common-swagger-api.schema.apps :as apps-schema]
+            [common-swagger-api.schema.apps.admin.apps :as admin-apps-schema]))
 
-;; Convert the keywords in AdminAppSearchValidSortFields to strings,
-;; so that the correct param format is passed through to the apps service.
+;; Convert Date params and keywords in enum values to strings,
+;; so that the correct param formats are passed through to the apps service.
 (defschema AdminAppSearchParams
-  (merge apps-schema/AdminAppSearchParams
-         {SortFieldOptionalKey
-          (describe (apply enum (map name apps-schema/AdminAppSearchValidSortFields))
+  (merge admin-apps-schema/AdminAppSearchParams
+         {apps-schema/AppJobStatsStartDateOptionalParam
+          (describe NonBlankString apps-schema/AppJobStatsStartDateParamDocs)
+
+          apps-schema/AppJobStatsEndDateOptionalParam
+          (describe NonBlankString apps-schema/AppJobStatsEndDateParamDocs)
+
+          SortFieldOptionalKey
+          (describe (apply enum (map name admin-apps-schema/AdminAppSearchValidSortFields))
                     SortFieldDocs)
 
-          apps-schema/AppSubsetOptionalKey
-          (describe (apply enum (map name apps-schema/AppSubsets))
-                    apps-schema/AppSubsetDocs :default :public)}))
+          admin-apps-schema/AppSubsetOptionalKey
+          (describe (apply enum (map name admin-apps-schema/AppSubsets))
+                    admin-apps-schema/AppSubsetDocs :default :public)}))
 
 (defschema StatusResponse
   {:iRODS             (describe Boolean "True if the data store appears to be functional")


### PR DESCRIPTION
This PR will refactor App job stats start/end date params as Strings, using params added by cyverse-de/common-swagger-api#35, since `Date` query params are parsed into invalid string formats (`Tue Dec 30 17:00:00 MST 1969` for example) when forwarded to the apps service.