### PR TITLE
Remove some obsolete terrain.util.service functions.

### DIFF
--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -20,8 +20,7 @@
             [terrain.services.filesystem.users :as users]
             [terrain.services.filesystem.uuids :as uuids]
             [terrain.services.filesystem.validators :as validators]
-            [terrain.util.config :as cfg]
-            [terrain.util.service :as svc])
+            [terrain.util.config :as cfg])
   (:import [clojure.lang IPersistentMap ISeq Keyword]
            [java.util UUID]))
 
@@ -423,14 +422,14 @@
   [method url msg]
   (let [full-msg (str method " " url " had a service error: " msg)]
     (log/error full-msg)
-    (svc/request-failure full-msg)))
+    (assertions/request-failure full-msg)))
 
 
 (defn- handle-client-error
   [method url err msg]
   (let [full-msg (str "interal error related to usage of " method " " url ": " msg)]
     (log/error err full-msg)
-    (svc/request-failure full-msg)))
+    (assertions/request-failure full-msg)))
 
 
 (defn ^String mk-data-path-url-path

--- a/src/terrain/services/bootstrap.clj
+++ b/src/terrain/services/bootstrap.clj
@@ -4,6 +4,7 @@
     [terrain.auth.user-attributes :only [current-user]])
   (:require
     [clojure.tools.logging :as log]
+    [clojure-commons.assertions :as assertions]
     [terrain.clients.apps.raw :as apps-client]
     [terrain.clients.data-info :as data-info-client]
     [terrain.services.user-prefs :as prefs]
@@ -55,7 +56,7 @@
   "This service obtains information about and initializes the workspace for the authenticated user.
    It also records the fact that the user logged in."
   [ip-address user-agent]
-  (service/assert-valid user-agent "Missing or empty request parameter: user-agent")
+  (assertions/assert-valid user-agent "Missing or empty request parameter: user-agent")
   (let [{user :shortUsername :keys [email firstName lastName username]} current-user
         login-session (future (get-login-session ip-address user-agent))
         apps-info     (future (get-apps-info))

--- a/src/terrain/services/teams.clj
+++ b/src/terrain/services/teams.clj
@@ -1,8 +1,8 @@
 (ns terrain.services.teams
-  (:require [terrain.clients.iplant-groups :as ipg]
+  (:require [clojure-commons.assertions :as assertions]
+            [terrain.clients.iplant-groups :as ipg]
             [terrain.clients.permissions :as perms-client]
-            [terrain.clients.notifications :as cn]
-            [terrain.util.service :as service]))
+            [terrain.clients.notifications :as cn]))
 
 (defn get-teams [{user :shortUsername} params]
   (ipg/get-teams user (select-keys params [:search :creator :member])))
@@ -54,7 +54,7 @@
   (ipg/verify-team-exists user name)
   (if-let [email (:email (ipg/lookup-subject user requester))]
     (cn/send-team-join-denial requester email name message)
-    (service/not-found "user" requester)))
+    (assertions/not-found "user" requester)))
 
 (defn leave [{user :shortUsername} name]
   (ipg/leave-team user name))


### PR DESCRIPTION
This PR will update a few hold-out namespaces in terrain to use `clojure-commons.assertions` so that the duplicate assertions in `terrain.util.service` can be removed.

It will also remove other obsolete functions in `terrain.util.service` that are no longer in use.