### PR TITLE
CORE-9 Add Swagger docs to filesystem navigation endpoints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.12"]
+                 [org.cyverse/common-swagger-api "2.11.13-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -21,17 +21,18 @@
         [terrain.routes.apps.tools]
         [terrain.routes.bootstrap]
         [terrain.routes.data]
-        [terrain.routes.permanent-id-requests]
         [terrain.routes.fileio]
+        [terrain.routes.filesystem]
+        [terrain.routes.filesystem.navigation]
         [terrain.routes.groups]
         [terrain.routes.metadata]
         [terrain.routes.misc]
         [terrain.routes.notification]
+        [terrain.routes.permanent-id-requests]
         [terrain.routes.pref]
         [terrain.routes.session]
         [terrain.routes.user-info]
         [terrain.routes.collaborator]
-        [terrain.routes.filesystem]
         [terrain.routes.search]
         [terrain.routes.coge]
         [terrain.routes.oauth]
@@ -99,6 +100,7 @@
     (secured-data-routes)
     (secured-session-routes)
     (secured-fileio-routes)
+    (filesystem-navigation-routes)
     (secured-filesystem-routes)
     (secured-filesystem-metadata-routes)
     (secured-search-routes)

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -1,26 +1,20 @@
 (ns terrain.routes.filesystem
   (:use [common-swagger-api.schema]
-        [terrain.util])
-  (:require [terrain.util.config :as config]
-            [clojure.tools.logging :as log]
-            [terrain.clients.data-info :as data]
+        [terrain.util :only [controller optional-routes]])
+  (:require [terrain.clients.data-info :as data]
+            [terrain.clients.metadata.raw :as meta-raw]
             [terrain.services.filesystem.directory :as dir]
             [terrain.services.filesystem.metadata :as meta]
             [terrain.services.filesystem.metadata-templates :as mt]
-            [terrain.clients.metadata.raw :as meta-raw]
-            [terrain.services.filesystem.root :as root]
-            [terrain.services.filesystem.sharing :as sharing]
             [terrain.services.filesystem.stat :as stat]
-            [terrain.services.filesystem.updown :as ud]))
+            [terrain.services.filesystem.updown :as ud]
+            [terrain.util.config :as config]))
 
 (defn secured-filesystem-routes
   "The routes for file IO endpoints."
   []
   (optional-routes
     [config/filesystem-routes-enabled]
-
-    (GET "/filesystem/root" [:as req]
-      (controller req root/do-root-listing :params))
 
     (POST "/filesystem/exists" [:as req]
       (controller req data/check-existence :params :body))
@@ -30,9 +24,6 @@
 
     (GET "/filesystem/display-download" [:as req]
       (controller req ud/do-special-download :params))
-
-    (GET "/filesystem/directory" [:as req]
-      (controller req dir/do-directory :params))
 
     (GET "/filesystem/paged-directory" [:as req]
       (controller req dir/do-paged-listing :params))

--- a/src/terrain/routes/filesystem/navigation.clj
+++ b/src/terrain/routes/filesystem/navigation.clj
@@ -1,0 +1,33 @@
+(ns terrain.routes.filesystem.navigation
+  (:use [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]]
+        [terrain.util :only [optional-routes]]
+        [terrain.util.transformers :only [add-current-user-to-map]])
+  (:require [common-swagger-api.schema.data.navigation :as schema]
+            [terrain.routes.schemas.filesystem.navigation :as terrain-nav-schema]
+            [terrain.services.filesystem.directory :as dir]
+            [terrain.services.filesystem.root :as root]
+            [terrain.util.config :as config]))
+
+(defn filesystem-navigation-routes
+  "The routes for filesystem navigation endpoints."
+  []
+
+  (optional-routes
+    [config/filesystem-routes-enabled]
+
+    (context "/filesystem" []
+      :tags ["filesystem"]
+
+      (GET "/root" []
+           :responses terrain-nav-schema/RootResponses
+           :summary schema/NavigationRootSummary
+           :description schema/NavigationRootDocs
+           (ok (root/do-root-listing (add-current-user-to-map {}))))
+
+      (GET "/directory" [:as {:keys [params]}]
+           :query [params terrain-nav-schema/DirectoryQueryParams]
+           :responses terrain-nav-schema/DirectoryResponses
+           :summary schema/NavigationSummary
+           :description schema/NavigationDocs
+           (ok (dir/do-directory (add-current-user-to-map params)))))))

--- a/src/terrain/routes/schemas/filesystem/navigation.clj
+++ b/src/terrain/routes/schemas/filesystem/navigation.clj
@@ -1,0 +1,39 @@
+(ns terrain.routes.schemas.filesystem.navigation
+  (:use [common-swagger-api.schema :only [describe NonBlankString]])
+  (:require [common-swagger-api.schema.data.navigation :as nav-schema]
+            [schema.core :as s]
+            [schema-tools.core :as schema-tools]))
+
+(def HasSubDirsParam (describe Boolean "Flag indicating whether the folder has any subdirectories"))
+
+(s/defschema DirectoryQueryParams
+  {(s/optional-key :path) (describe NonBlankString "The IRODS path to a directory")})
+
+(s/defschema RootListing
+  (merge nav-schema/RootListing
+         {:hasSubDirs HasSubDirsParam}))
+
+(s/defschema FolderListing
+  (merge nav-schema/FolderListing
+         {:hasSubDirs HasSubDirsParam
+          :badName    (describe Boolean "Flag indicating whether the folder should be disabled/avoided in the client UI")
+          :isFavorite (describe Boolean "Flag indicating whether the folder is marked as a favorite by the user")
+          (s/optional-key :folders)
+                      (describe [(s/recursive #'FolderListing)] "Subdirectories of this directory")}))
+
+(s/defschema DirectoryResponse
+  ((comp schema-tools/optional-keys merge)
+   FolderListing
+   {:roots (describe [FolderListing]
+                     "This `roots` key will only be returned when the `path` param is omitted in the request,
+                      and then only this `roots` key will be included at the top-level of the response")}))
+
+(s/defschema RootResponses
+  (update-in nav-schema/NavigationRootResponses
+             [200 :schema]
+             merge {:roots [RootListing]}))
+
+(s/defschema DirectoryResponses
+  (update-in nav-schema/NavigationResponses
+             [200]
+             merge {:schema DirectoryResponse}))

--- a/src/terrain/services/filesystem/directory.clj
+++ b/src/terrain/services/filesystem/directory.clj
@@ -47,20 +47,22 @@
 
 
 (defn- fmt-folder
-  [user favorite-ids data-item]
-  (let [id   (:id data-item)
-        path (:path data-item)]
-    {:id            id
-     :path          path
-     :label         (:label data-item)
-     :isFavorite    (is-favorite? favorite-ids id)
-     :badName       (or (is-bad? user path)
-                        (is-bad? user (fs/base-name path)))
-     :permission    (:permission data-item)
-     :date-created  (:dateCreated data-item)
-     :date-modified (:dateModified data-item)
-     :file-size     0
-     :hasSubDirs    true}))
+  [user favorite-ids {:keys [id
+                             path
+                             label
+                             permission
+                             date-created
+                             date-modified]}]
+  {:id            id
+   :path          path
+   :label         label
+   :permission    permission
+   :date-created  date-created
+   :date-modified date-modified
+   :isFavorite    (is-favorite? favorite-ids id)
+   :badName       (or (is-bad? user path)
+                      (is-bad? user (fs/base-name path)))
+   :hasSubDirs    true})
 
 
 (defn- fmt-dir-resp

--- a/src/terrain/services/filesystem/root.clj
+++ b/src/terrain/services/filesystem/root.clj
@@ -6,7 +6,7 @@
             [terrain.services.filesystem.common-paths :as paths]))
 
 (defn- format-roots
-  [roots user]
+  [roots]
   (letfn [(format-subdir [root] (assoc root :hasSubDirs true))
           (update-subdirs [root-list] (map format-subdir root-list))]
     (update-in roots [:roots] update-subdirs)))
@@ -16,7 +16,7 @@
   (-> (data-raw/list-roots user)
       :body
       (json/string->json true)
-      (format-roots user)))
+      format-roots))
 
 (with-pre-hook! #'do-root-listing
   (fn [params]


### PR DESCRIPTION
This PR will use the docs and schemas added by cyverse-de/common-swagger-api#41 in the `/filesystem/root` and `/filesystem/directory` endpoints.

These endpoints still need to be moved into a `filesystem` tagged context, so they don't stay in the `default` group of the Swagger UI. So this PR is marked as a `WIP` for now.