### PR TITLE
CORE-9 Add Swagger docs to path existence endpoint.

### DIFF
--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -119,6 +119,13 @@
   [{:keys [user]} {:keys [tickets]}]
   (raw/delete-tickets user tickets))
 
+(defn check-existence
+  "Uses the data-info existence-marker endpoint to query existence for a set of files/folders."
+  [user paths]
+  (-> (raw/check-existence user paths)
+      :body
+      (json/decode true)))
+
 (defn- url-encoded?
   [string-to-check]
   (re-seq #"\%[A-Fa-f0-9]{2}" string-to-check))
@@ -132,10 +139,8 @@
 (defn path-exists?
   [user path]
   (let [path (url-decode (ft/rm-last-slash path))]
-    (-> (raw/check-existence user [path])
-        :body
-        json/decode
-        (get-in ["paths" path]))))
+    (-> (check-existence user [path])
+        (get-in [:paths (keyword path)]))))
 
 (defn get-or-create-dir
   "Returns the path argument if the path exists and refers to a directory.  If
@@ -222,11 +227,6 @@
      (raw/restore-files (:user params)))
     ([params body]
      (raw/restore-files (:user params) (:paths body))))
-
-(defn check-existence
-    "Uses the data-info existence-marker endpoint to query existence for a set of files/folders."
-    [params body]
-    (raw/check-existence (:user params) (:paths body)))
 
 (defn collect-permissions
     "Uses the data-info permissions-gatherer endpoint to query user permissions for a set of files/folders."

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -23,6 +23,7 @@
         [terrain.routes.data]
         [terrain.routes.fileio]
         [terrain.routes.filesystem]
+        [terrain.routes.filesystem.exists]
         [terrain.routes.filesystem.navigation]
         [terrain.routes.groups]
         [terrain.routes.metadata]
@@ -101,6 +102,7 @@
     (secured-session-routes)
     (secured-fileio-routes)
     (filesystem-navigation-routes)
+    (filesystem-existence-routes)
     (secured-filesystem-routes)
     (secured-filesystem-metadata-routes)
     (secured-search-routes)

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -16,9 +16,6 @@
   (optional-routes
     [config/filesystem-routes-enabled]
 
-    (POST "/filesystem/exists" [:as req]
-      (controller req data/check-existence :params :body))
-
     (POST "/filesystem/stat" [:as req]
       (controller req stat/do-stat :params :body))
 

--- a/src/terrain/routes/filesystem/exists.clj
+++ b/src/terrain/routes/filesystem/exists.clj
@@ -1,0 +1,25 @@
+(ns terrain.routes.filesystem.exists
+  (:use [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]]
+        [terrain.auth.user-attributes :only [current-user]]
+        [terrain.util :only [optional-routes]])
+  (:require [common-swagger-api.schema.data.exists :as schema]
+            [terrain.clients.data-info :as data]
+            [terrain.util.config :as config]))
+
+(defn filesystem-existence-routes
+  "The routes for path existence endpoints."
+  []
+
+  (optional-routes
+    [config/filesystem-routes-enabled]
+
+    (context "/filesystem" []
+      :tags ["filesystem"]
+
+      (POST "/exists" []
+            :body [{:keys [paths]} schema/ExistenceRequest]
+            :responses schema/ExistenceResponses
+            :summary schema/ExistenceSummary
+            :description schema/ExistenceDocs
+            (ok (data/check-existence (:shortUsername current-user) paths))))))


### PR DESCRIPTION
This PR will add the schemas and docs from cyverse-de/common-swagger-api#43 to the `POST /secured/filesystem/exists` endpoint.