### PR TITLE
added the InCommon CA certificate to the trusted CA certificates in t…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ COPY . /usr/src/app
 RUN lein uberjar && \
     cp target/terrain-standalone.jar .
 
+# Add the Internet2 InCommon intermediate CA certificate.
+ADD "https://incommon.org/wp-content/uploads/2019/06/sha384-Intermediate-cert.txt" "/uyr/local/share/ca-certificates/"
+RUN "update-ca-certificates"
+
 ENTRYPOINT ["terrain", "-Dlogback.confonFile=/etc/iplant/de/logging/terrain-logging.xml", "-cp", ".:terrain-standalone.jar", "terrain.core"]
 
 ARG git_commit=unknown


### PR DESCRIPTION
…he image in order to support external sites that use this certificate authority

NCSU uses this certificate authority, so I'm adding it to our trusted CA certificates in the images that need to access CAS for convenience.
