### PR TITLE
CORE-331 Update DOI completion notification message.

### DIFF
--- a/src/terrain/util/email.clj
+++ b/src/terrain/util/email.clj
@@ -69,11 +69,12 @@
 
 (defn send-permanent-id-request-complete
   "Sends an email message informing data curators of a Permanent ID Request completion."
-  [request-type path identifiers]
+  [request-type path identifiers doi]
   (let [template-values {:environment  (config/environment-name)
                          :request_type request-type
                          :path         path
-                         :identifiers  identifiers}]
+                         :identifiers  identifiers
+                         :doi          doi}]
     (send-permanent-id-request
       "Permanent ID Request Complete"
       "permanent_id_request_complete"


### PR DESCRIPTION
This PR will update the DOI completion notification message (sent to the requesting user) to include additional user instructions and the DOI's landing page link.

It will also include the created DOI in curator completion email template values (support added in cyverse-de/iplant-email#8).