### PR TITLE
CORE-9 Add Swagger docs to filesystem ticket endpoints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.7"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.18"]
+                 [org.cyverse/common-swagger-api "2.11.20"]
                  [org.cyverse/kameleon "3.0.3"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -109,15 +109,21 @@
 
 (defn list-tickets
   [{:keys [user]} {:keys [paths]}]
-  (raw/list-tickets user paths))
+  (-> (raw/list-tickets user paths)
+      :body
+      (json/decode true)))
 
 (defn add-tickets
-  [{:keys [user public]} {:keys [paths]}]
-  (raw/add-tickets user paths (and public (= public "1"))))
+  [{:keys [user]} paths params]
+  (-> (raw/add-tickets user paths params)
+      :body
+      (json/decode true)))
 
 (defn delete-tickets
   [{:keys [user]} {:keys [tickets]}]
-  (raw/delete-tickets user tickets))
+  (-> (raw/delete-tickets user tickets)
+      :body
+      (json/decode true)))
 
 (defn check-existence
   "Uses the data-info existence-marker endpoint to query existence for a set of files/folders."

--- a/src/terrain/clients/data_info/raw.clj
+++ b/src/terrain/clients/data_info/raw.clj
@@ -295,9 +295,9 @@
 
 (defn add-tickets
   "Create potentially-public tickets for a list of paths."
-  [user paths public?]
+  [user paths params]
   (request :post ["tickets"]
-           (mk-req-map user (json/encode {:paths paths}) {:public public?})))
+           (mk-req-map user (json/encode {:paths paths}) params)))
 
 (defn delete-tickets
   "Delete tickets for a list of ticket IDs"

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -25,6 +25,7 @@
         [terrain.routes.filesystem]
         [terrain.routes.filesystem.exists]
         [terrain.routes.filesystem.navigation]
+        [terrain.routes.filesystem.tickets]
         [terrain.routes.groups]
         [terrain.routes.metadata]
         [terrain.routes.misc]
@@ -103,6 +104,7 @@
     (secured-fileio-routes)
     (filesystem-navigation-routes)
     (filesystem-existence-routes)
+    (filesystem-ticket-routes)
     (secured-filesystem-routes)
     (secured-filesystem-metadata-routes)
     (secured-search-routes)

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -61,15 +61,6 @@
     (POST "/filesystem/restore-all" [:as req]
       (controller req data/restore-files :params))
 
-    (POST "/filesystem/tickets" [:as req]
-      (controller req data/add-tickets :params :body))
-
-    (POST "/filesystem/delete-tickets" [:as req]
-      (controller req data/delete-tickets :params :body))
-
-    (POST "/filesystem/list-tickets" [:as req]
-      (controller req data/list-tickets :params :body))
-
     (DELETE "/filesystem/trash" [:as req]
       (controller req data/delete-trash :params))
 

--- a/src/terrain/routes/filesystem/tickets.clj
+++ b/src/terrain/routes/filesystem/tickets.clj
@@ -1,0 +1,58 @@
+(ns terrain.routes.filesystem.tickets
+  (:use [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]]
+        [terrain.routes.schemas.filesystem.tickets]
+        [terrain.util :only [optional-routes]]
+        [terrain.util.transformers :only [add-current-user-to-map]])
+  (:require [common-swagger-api.schema.data :as data-schema]
+            [common-swagger-api.schema.data.tickets :as schema]
+            [terrain.clients.data-info :as data]
+            [terrain.util.config :as config]))
+
+;; FIXME: The `coerce-public-param` middleware is only for backwards compatibility
+;; and should be removed in the next version of the API
+(defn- public-param->boolean
+  "Sets the `public` key in `params` to `true` if its string value is `1` or `true`,
+   otherwise sets it to `false`."
+  [{public "public" :as params}]
+  (assoc params "public" (or (= public "1") (= public "true"))))
+
+(defn- coerce-public-param
+  "Middleware to convert public param string values of `1` to a boolean `true`."
+  [handler]
+  (fn [request]
+    (handler (update request :query-params public-param->boolean))))
+
+(defn filesystem-ticket-routes
+  "The routes for filesystem ticket endpoints."
+  []
+
+  (optional-routes
+    [config/filesystem-routes-enabled]
+
+    (context
+      "/filesystem" []
+      :tags ["filesystem"]
+
+      (POST "/tickets" []
+            :middleware [coerce-public-param]
+            :query [params AddTicketQueryParams]
+            :body [{:keys [paths]} data-schema/Paths]
+            :responses schema/AddTicketResponses
+            :summary schema/AddTicketSummary
+            :description schema/AddTicketDocs
+            (ok (data/add-tickets (add-current-user-to-map {}) paths params)))
+
+      (POST "/delete-tickets" []
+            :body [body schema/Tickets]
+            :responses schema/DeleteTicketResponses
+            :summary schema/DeleteTicketSummary
+            :description schema/DeleteTicketDocs
+            (ok (data/delete-tickets (add-current-user-to-map {}) body)))
+
+      (POST "/list-tickets" []
+            :body [body data-schema/Paths]
+            :responses schema/ListTicketResponses
+            :summary schema/ListTicketSummary
+            :description schema/ListTicketDocs
+            (ok (data/list-tickets (add-current-user-to-map {}) body))))))

--- a/src/terrain/routes/schemas/filesystem/tickets.clj
+++ b/src/terrain/routes/schemas/filesystem/tickets.clj
@@ -1,0 +1,17 @@
+(ns terrain.routes.schemas.filesystem.tickets
+  (:use [common-swagger-api.schema :only [describe]])
+  (:require [common-swagger-api.schema.data.tickets :as schema]
+            [schema.core :as s]
+            [schema-tools.core :as st]))
+
+;; Convert the keywords in the `mode` param to strings,
+;; so that the correct param format is passed through to the apps service.
+;; Remove `for-job` param.
+;; FIXME: Make `public` param optional (for backwards compatibility).
+(s/defschema AddTicketQueryParams
+  (-> schema/AddTicketQueryParams
+      (st/dissoc :for-job)
+      (st/optional-keys [:public])
+      (merge {schema/ModeParamOptionalKey
+              (describe (apply s/enum (map name schema/ModeParamValues))
+                        schema/ModeParamDocs)})))


### PR DESCRIPTION
This PR will add the Swagger docs from cyverse-de/common-swagger-api#49 to the filesystem ticket endpoints.