### PR TITLE
CORE-9 Add Swagger docs to the filesystem stat endpoint.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "2.11.23"]
+                 [org.cyverse/common-swagger-api "2.11.24"]
                  [org.cyverse/kameleon "3.0.4"]
                  [org.cyverse/metadata-client "3.0.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -104,8 +104,7 @@
   (let [paths-request {:paths [path]}]
     (create-dirs params paths-request)
     (-> (st/do-stat params paths-request)
-        json/decode
-        (get-in ["paths" path]))))
+        (get-in [:paths (keyword path)]))))
 
 (defn list-tickets
   [{:keys [user]} {:keys [paths]}]

--- a/src/terrain/clients/data_info/raw.clj
+++ b/src/terrain/clients/data_info/raw.clj
@@ -321,7 +321,7 @@
 
 (defn collect-stats
   "Uses the data-info stat-gatherer endpoint to gather stat information for a set of files/folders."
-  [user & {:keys [paths ids]}]
+  [user {:keys [paths ids]}]
   (request :post ["stat-gatherer"]
            (mk-req-map user
                        (json/encode (remove-vals nil? {:paths paths :ids ids})))))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -25,6 +25,7 @@
         [terrain.routes.filesystem]
         [terrain.routes.filesystem.exists]
         [terrain.routes.filesystem.navigation]
+        [terrain.routes.filesystem.stats]
         [terrain.routes.filesystem.tickets]
         [terrain.routes.groups]
         [terrain.routes.metadata]
@@ -45,8 +46,7 @@
         [terrain.routes.comments]
         [terrain.util :as util]
         [terrain.util.transformers :as transform])
-  (:require [cemerick.url :as curl]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [clojure-commons.exception :as cx]
             [compojure.route :as route]
             [service-logging.thread-context :as tc]
@@ -95,57 +95,58 @@
 (defn secured-routes
   []
   (util/flagged-routes
-    (secured-notification-routes)
-    (secured-bootstrap-routes)
-    (secured-pref-routes)
-    (secured-user-info-routes)
-    (secured-data-routes)
-    (secured-session-routes)
-    (secured-fileio-routes)
-    (filesystem-navigation-routes)
-    (filesystem-existence-routes)
-    (filesystem-ticket-routes)
-    (secured-filesystem-routes)
-    (secured-filesystem-metadata-routes)
-    (secured-search-routes)
-    (secured-oauth-routes)
-    (secured-favorites-routes)
-    (secured-tag-routes)
-    (data-comment-routes)
-    (route/not-found (service/unrecognized-path-response))))
+   (secured-notification-routes)
+   (secured-bootstrap-routes)
+   (secured-pref-routes)
+   (secured-user-info-routes)
+   (secured-data-routes)
+   (secured-session-routes)
+   (secured-fileio-routes)
+   (filesystem-navigation-routes)
+   (filesystem-existence-routes)
+   (filesystem-stat-routes)
+   (filesystem-ticket-routes)
+   (secured-filesystem-routes)
+   (secured-filesystem-metadata-routes)
+   (secured-search-routes)
+   (secured-oauth-routes)
+   (secured-favorites-routes)
+   (secured-tag-routes)
+   (data-comment-routes)
+   (route/not-found (service/unrecognized-path-response))))
 
 (defn admin-routes
   []
   (util/flagged-routes
-    (secured-admin-routes)
-    (admin-data-comment-routes)
-    (admin-category-routes)
-    (admin-apps-routes)
-    (admin-app-avu-routes)
-    (admin-app-comment-routes)
-    (admin-app-community-routes)
-    (admin-comment-routes)
-    (admin-community-routes)
-    (admin-filesystem-metadata-routes)
-    (admin-groups-routes)
-    (admin-notification-routes)
-    (admin-ontology-routes)
-    (admin-reference-genomes-routes)
-    (admin-tool-routes)
-    (admin-tool-request-routes)
-    (admin-permanent-id-request-routes)
-    (oauth-admin-routes)
-    (admin-integration-data-routes)
-    (admin-workspace-routes)
-    (admin-user-info-routes)
-    (route/not-found (service/unrecognized-path-response))))
+   (secured-admin-routes)
+   (admin-data-comment-routes)
+   (admin-category-routes)
+   (admin-apps-routes)
+   (admin-app-avu-routes)
+   (admin-app-comment-routes)
+   (admin-app-community-routes)
+   (admin-comment-routes)
+   (admin-community-routes)
+   (admin-filesystem-metadata-routes)
+   (admin-groups-routes)
+   (admin-notification-routes)
+   (admin-ontology-routes)
+   (admin-reference-genomes-routes)
+   (admin-tool-routes)
+   (admin-tool-request-routes)
+   (admin-permanent-id-request-routes)
+   (oauth-admin-routes)
+   (admin-integration-data-routes)
+   (admin-workspace-routes)
+   (admin-user-info-routes)
+   (route/not-found (service/unrecognized-path-response))))
 
 (defn unsecured-routes
   []
   (util/flagged-routes
-    (token-routes)
-    (unsecured-misc-routes)
-    (unsecured-notification-routes)))
+   (token-routes)
+   (unsecured-misc-routes)
+   (unsecured-notification-routes)))
 
 (def admin-handler
   (middleware
@@ -177,10 +178,10 @@
 (defn- terrain-routes
   []
   (util/flagged-routes
-    unsecured-routes-handler
-    (context "/admin" [] admin-handler)
-    (context "/secured" [] secured-routes-handler)
-    secured-routes-no-context-handler))
+   unsecured-routes-handler
+   (context "/admin" [] admin-handler)
+   (context "/secured" [] secured-routes-handler)
+   secured-routes-no-context-handler))
 
 (defn- site-handler
   [routes-fn]

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -16,9 +16,6 @@
   (optional-routes
     [config/filesystem-routes-enabled]
 
-    (POST "/filesystem/stat" [:as req]
-      (controller req stat/do-stat :params :body))
-
     (GET "/filesystem/display-download" [:as req]
       (controller req ud/do-special-download :params))
 

--- a/src/terrain/routes/filesystem/stats.clj
+++ b/src/terrain/routes/filesystem/stats.clj
@@ -1,0 +1,26 @@
+(ns terrain.routes.filesystem.stats
+  (:use [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]]
+        [terrain.util :only [optional-routes]]
+        [terrain.util.transformers :only [add-current-user-to-map]])
+  (:require [common-swagger-api.schema.data :as data-schema]
+            [common-swagger-api.schema.stats :as schema]
+            [terrain.services.filesystem.stat :as stat]
+            [terrain.util.config :as config]))
+
+(defn filesystem-stat-routes
+  "The routes for filesystem stat endpoints."
+  []
+
+  (optional-routes
+   [config/filesystem-routes-enabled]
+
+   (context "/filesystem" []
+     :tags ["filesystem"]
+
+     (POST "/stat" []
+       :body [body data-schema/OptionalPathsOrDataIds]
+       :responses schema/StatResponses
+       :summary schema/StatSummary
+       :description schema/StatDocs
+       (ok (stat/do-stat (add-current-user-to-map {}) body))))))


### PR DESCRIPTION
This PR will add the schemas and docs added by cyverse-de/common-swagger-api#52 to the  `filesystem/stat` endpoint.

The `terrain.routes` namespace was also reformatted with `lein-cljfmt`