### PR TITLE
Use de-irods to move folders for permanent ID requests

### DIFF
--- a/src/terrain/services/permanent_id_requests.clj
+++ b/src/terrain/services/permanent_id_requests.clj
@@ -205,7 +205,7 @@ If this dataset accompanies a paper, please contact us with the DOI for that pap
 (defn- publish-data-item
   [user folder]
   (let [curators-group (config/permanent-id-curators-group)
-        publish-path   (move-folder curators-group
+        publish-path   (move-folder (config/irods-user)
                                     folder
                                     (config/permanent-id-publish-dir))]
     (data-info/share (config/irods-user) [curators-group] [publish-path] "own")


### PR DESCRIPTION
and, rely on the share function afterwards to ensure permissions for the DOI curators group

This sets it up so we can change data-info to pass a client user when doing moves and renames, as requested by @tedgin 