### PR TITLE
CORE-671: prevent terrain from following redirects returned by the ap…

### DIFF
--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -1,5 +1,6 @@
 (ns terrain.clients.apps.raw
-  (:use [terrain.util.transformers :only [secured-params]])
+  (:use [terrain.util :only [disable-redirects]]
+        [terrain.util.transformers :only [secured-params]])
   (:require [cemerick.url :as curl]
             [clj-http.client :as client]
             [terrain.util.config :as config]))
@@ -20,1158 +21,1158 @@
 (defn get-all-workflow-elements
   [params]
   (:body
-    (client/get (apps-url "apps" "elements")
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" "elements")
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn get-workflow-elements
   [element-type params]
   (:body
-    (client/get (apps-url "apps" "elements" element-type)
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" "elements" element-type)
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn list-ontologies
   []
   (client/get (apps-url "admin" "ontologies")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params)
+                :as           :stream})))
 
 (defn delete-ontology
   [ontology-version]
   (client/delete (apps-url-encoded "admin" "ontologies" ontology-version)
-                 {:query-params     (secured-params)
-                  :as               :stream
-                  :follow-redirects false}))
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :as           :stream})))
 
 (defn set-ontology-version
   [ontology-version]
   (client/post (apps-url-encoded "admin" "ontologies" ontology-version)
-               {:query-params     (secured-params)
-                :as               :stream
-                :follow-redirects false}))
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :stream})))
 
 (defn get-app-category-hierarchy
   ([ontology-version root-iri params]
    (client/get (apps-url-encoded "admin" "ontologies" ontology-version root-iri)
-               {:query-params     (secured-params params [:attr])
-                :as               :stream
-                :follow-redirects false}))
+               (disable-redirects
+                {:query-params (secured-params params [:attr])
+                 :as           :stream})))
   ([root-iri params]
    (:body
-     (client/get (apps-url-encoded "apps" "hierarchies" root-iri)
-                 {:query-params     (secured-params params [:attr])
-                  :as               :json
-                  :follow-redirects false}))))
+    (client/get (apps-url-encoded "apps" "hierarchies" root-iri)
+                (disable-redirects
+                 {:query-params (secured-params params [:attr])
+                  :as           :json})))))
 
 (defn get-app-category-hierarchies
   []
   (:body
-    (client/get (apps-url "apps" "hierarchies")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" "hierarchies")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn get-hierarchy-app-listing
   ([ontology-version root-iri params]
    (client/get (apps-url-encoded "admin" "ontologies" ontology-version root-iri "apps")
-               {:query-params     (secured-params params apps-hierarchy-sort-params)
-                :as               :stream
-                :follow-redirects false}))
+               (disable-redirects
+                {:query-params (secured-params params apps-hierarchy-sort-params)
+                 :as           :stream})))
   ([root-iri params]
    (:body
-     (client/get (apps-url-encoded "apps" "hierarchies" root-iri "apps")
-                 {:query-params     (secured-params params apps-hierarchy-sort-params)
-                  :as               :json
-                  :follow-redirects false}))))
+    (client/get (apps-url-encoded "apps" "hierarchies" root-iri "apps")
+                (disable-redirects
+                 {:query-params (secured-params params apps-hierarchy-sort-params)
+                  :as           :json})))))
 
 (defn get-unclassified-app-listing
   ([ontology-version root-iri params]
    (client/get (apps-url-encoded "admin" "ontologies" ontology-version root-iri "unclassified")
-               {:query-params     (secured-params params apps-hierarchy-sort-params)
-                :as               :stream
-                :follow-redirects false}))
+               (disable-redirects
+                {:query-params (secured-params params apps-hierarchy-sort-params)
+                 :as           :stream})))
   ([root-iri params]
    (:body
-     (client/get (apps-url-encoded "apps" "hierarchies" root-iri "unclassified")
-                 {:query-params     (secured-params params apps-hierarchy-sort-params)
-                  :as               :json
-                  :follow-redirects false}))))
+    (client/get (apps-url-encoded "apps" "hierarchies" root-iri "unclassified")
+                (disable-redirects
+                 {:query-params (secured-params params apps-hierarchy-sort-params)
+                  :as           :json})))))
 
 (defn get-app-categories
   [params]
   (:body
-    (client/get (apps-url "apps" "categories")
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" "categories")
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn apps-in-category
   [system-id category-id params]
   (:body
-    (client/get (apps-url "apps" "categories" system-id category-id)
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" "categories" system-id category-id)
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as            :json}))))
 
 (defn apps-in-community
   [community-id]
   (:body
-    (client/get (apps-url "apps" "communities" community-id "apps")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" "communities" community-id "apps")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn admin-get-apps-in-community
   [community-id  & {:keys [as] :or {as :stream}}]
   (client/get (apps-url "admin" "apps" "communities" community-id "apps")
-              {:query-params     (secured-params)
-               :as               as
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params)
+                :as           as})))
 
 (defn search-apps
   [params]
   (:body
-    (client/get (apps-url "apps")
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps")
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn create-app
   [system-id app]
   (:body
-    (client/post (apps-url "apps" system-id)
-                 {:query-params     (secured-params)
-                  :form-params      app
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" system-id)
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  app
+                  :content-type :json
+                  :as           :json}))))
 
 (defn preview-args
   [system-id app]
   (:body
-    (client/post (apps-url "apps" system-id "arg-preview")
-                 {:query-params     (secured-params)
-                  :form-params      app
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" system-id "arg-preview")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  app
+                  :content-type :json
+                  :as           :json}))))
 
 (defn delete-apps
   [deletion-request]
   (:body
-    (client/post (apps-url "apps" "shredder")
-                 {:query-params     (secured-params)
-                  :form-params      deletion-request
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" "shredder")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  deletion-request
+                  :content-type :json
+                  :as           :json}))))
 
 (defn list-permissions
   [body params]
   (:body
-    (client/post (apps-url "apps" "permission-lister")
-                 {:query-params     (secured-params params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" "permission-lister")
+                (disable-redirects
+                 {:query-params (secured-params params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn share
   [body]
   (:body
-    (client/post (apps-url "apps" "sharing")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" "sharing")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn unshare
   [body]
   (:body
-    (client/post (apps-url "apps" "unsharing")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" "unsharing")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn get-app
   [system-id app-id]
   (:body
-    (client/get (apps-url "apps" system-id app-id)
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" system-id app-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn delete-app
   [system-id app-id]
   (:body
-    (client/delete (apps-url "apps" system-id app-id)
-                   {:query-params     (secured-params)
-                    :as               :json
-                    :follow-redirects false})))
+   (client/delete (apps-url "apps" system-id app-id)
+                  (disable-redirects
+                   {:query-params (secured-params)
+                    :as           :json}))))
 
 (defn relabel-app
   [system-id app-id relabel-request]
   (:body
-    (client/patch (apps-url "apps" system-id app-id)
-                  {:query-params     (secured-params)
-                   :form-params      relabel-request
-                   :content-type     :json
-                   :as               :json
-                   :follow-redirects false})))
+   (client/patch (apps-url "apps" system-id app-id)
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :form-params  relabel-request
+                   :content-type :json
+                   :as           :json}))))
 
 (defn update-app
   [system-id app-id update-request]
   (:body
-    (client/put (apps-url "apps" system-id app-id)
-                {:query-params     (secured-params)
-                 :form-params      update-request
-                 :content-type     :json
-                 :as               :json
-                 :follow-redirects false})))
+   (client/put (apps-url "apps" system-id app-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :form-params  update-request
+                 :content-type :json
+                 :as           :json}))))
 
 (defn copy-app
   [system-id app-id]
   (:body
-    (client/post (apps-url "apps" system-id app-id "copy")
-                 {:query-params     (secured-params)
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" system-id app-id "copy")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :as           :json}))))
 
 (defn get-admin-app-details
   [system-id app-id]
   (:body
-    (client/get (apps-url "admin" "apps" system-id app-id "details")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "admin" "apps" system-id app-id "details")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn get-app-details
   [system-id app-id]
   (:body
-    (client/get (apps-url "apps" system-id app-id "details")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" system-id app-id "details")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn remove-favorite-app
   [system-id app-id]
   (:body
-    (client/delete (apps-url "apps" system-id app-id "favorite")
-                   {:query-params     (secured-params)
-                    :as               :json
-                    :follow-redirects false})))
+   (client/delete (apps-url "apps" system-id app-id "favorite")
+                  (disable-redirects
+                   {:query-params (secured-params)
+                    :as           :json}))))
 
 (defn add-favorite-app
   [system-id app-id]
   (:body
-    (client/put (apps-url "apps" system-id app-id "favorite")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/put (apps-url "apps" system-id app-id "favorite")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn app-publishable?
   [system-id app-id]
   (:body
-    (client/get (apps-url "apps" system-id app-id "is-publishable")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" system-id app-id "is-publishable")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn remove-app-from-communities
   [app-id body]
   (:body
-    (client/delete (apps-url "apps" app-id "communities")
-                   {:query-params     (secured-params)
-                    :form-params      body
-                    :content-type     :json
-                    :as               :json
-                    :follow-redirects false})))
+   (client/delete (apps-url "apps" app-id "communities")
+                  (disable-redirects
+                   {:query-params (secured-params)
+                    :form-params  body
+                    :content-type :json
+                    :as           :json}))))
 
 (defn update-app-communities
   [app-id body]
   (:body
-    (client/post (apps-url "apps" app-id "communities")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" app-id "communities")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn admin-list-avus
   [app-id]
   (client/get (apps-url "admin" "apps" app-id "metadata")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params)
+                :as           :stream})))
 
 (defn admin-set-avus
   [app-id body]
   (client/put (apps-url "admin" "apps" app-id "metadata")
-              {:query-params     (secured-params)
-               :body             body
-               :content-type     :json
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params)
+                :body         body
+                :content-type :json
+                :as           :stream})))
 
 (defn admin-update-avus
   [app-id body]
   (client/post (apps-url "admin" "apps" app-id "metadata")
-               {:query-params     (secured-params)
-                :body             body
-                :content-type     :json
-                :as               :stream
-                :follow-redirects false}))
+               (disable-redirects
+                {:query-params (secured-params)
+                 :body         body
+                 :content-type :json
+                 :as           :stream})))
 
 (defn list-avus
   [app-id]
   (:body
-    (client/get (apps-url "apps" app-id "metadata")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" app-id "metadata")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn set-avus
   [app-id body]
   (:body
-    (client/put (apps-url "apps" app-id "metadata")
-                {:query-params     (secured-params)
-                 :form-params      body
-                 :content-type     :json
-                 :as               :json
-                 :follow-redirects false})))
+   (client/put (apps-url "apps" app-id "metadata")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :form-params  body
+                 :content-type :json
+                 :as           :json}))))
 
 (defn update-avus
   [app-id body]
   (:body
-    (client/post (apps-url "apps" app-id "metadata")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" app-id "metadata")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn make-app-public
   [system-id app-id app]
   (:body
-    (client/post (apps-url "apps" system-id app-id "publish")
-                 {:query-params     (secured-params)
-                  :form-params      app
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" system-id app-id "publish")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  app
+                  :content-type :json
+                  :as           :json}))))
 
 (defn admin-publish-app
   [system-id app-id body]
   (:body
    (client/post (apps-url "admin" "apps" system-id app-id "publish")
-                {:query-params     (secured-params)
-                 :form-params      body
-                 :content-type     :json
-                 :as               :json
-                 :follow-redirects false})))
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn delete-rating
   [system-id app-id]
   (:body
-    (client/delete (apps-url "apps" system-id app-id "rating")
-                   {:query-params     (secured-params)
-                    :as               :json
-                    :follow-redirects false})))
+   (client/delete (apps-url "apps" system-id app-id "rating")
+                  (disable-redirects
+                   {:query-params (secured-params)
+                    :as           :json}))))
 
 (defn rate-app
   [system-id app-id rating]
   (:body
-    (client/post (apps-url "apps" system-id app-id "rating")
-                 {:query-params     (secured-params)
-                  :form-params      rating
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" system-id app-id "rating")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  rating
+                  :content-type :json
+                  :as           :json}))))
 
 (defn list-app-tasks
   [system-id app-id]
   (:body
-    (client/get (apps-url "apps" system-id app-id "tasks")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" system-id app-id "tasks")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn get-app-ui
   [system-id app-id]
   (:body
-    (client/get (apps-url "apps" system-id app-id "ui")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" system-id app-id "ui")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn add-pipeline
   [pipeline]
   (:body
-    (client/post (apps-url "apps" "pipelines")
-                 {:query-params     (secured-params)
-                  :form-params      pipeline
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" "pipelines")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  pipeline
+                  :content-type :json
+                  :as           :json}))))
 
 (defn update-pipeline
   [app-id pipeline]
   (:body
-    (client/put (apps-url "apps" "pipelines" app-id)
-                {:query-params     (secured-params)
-                 :form-params      pipeline
-                 :content-type     :json
-                 :as               :json
-                 :follow-redirects false})))
+   (client/put (apps-url "apps" "pipelines" app-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :form-params  pipeline
+                 :content-type :json
+                 :as           :json}))))
 
 (defn copy-pipeline
   [app-id]
   (:body
-    (client/post (apps-url "apps" "pipelines" app-id "copy")
-                 {:query-params     (secured-params)
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" "pipelines" app-id "copy")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :as           :json}))))
 
 (defn edit-pipeline
   [app-id]
   (:body
-    (client/get (apps-url "apps" "pipelines" app-id "ui")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" "pipelines" app-id "ui")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn list-jobs
   [params]
   (:body
-    (client/get (apps-url "analyses")
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "analyses")
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn list-job-permissions
   [body params]
   (:body
-    (client/post (apps-url "analyses" "permission-lister")
-                 {:query-params     (secured-params params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "analyses" "permission-lister")
+                (disable-redirects
+                 {:query-params (secured-params params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn share-jobs
   [body]
   (:body
-    (client/post (apps-url "analyses" "sharing")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "analyses" "sharing")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn unshare-jobs
   [body]
   (:body
-    (client/post (apps-url "analyses" "unsharing")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "analyses" "unsharing")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn submit-job
   [body]
   (:body
-    (client/post (apps-url "analyses")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "analyses")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn update-job
   [analysis-id body]
   (:body
-    (client/patch (apps-url "analyses" analysis-id)
-                  {:query-params     (secured-params)
-                   :form-params      body
-                   :content-type     :json
-                   :as               :json
-                   :follow-redirects false})))
+   (client/patch (apps-url "analyses" analysis-id)
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :form-params  body
+                   :content-type :json
+                   :as           :json}))))
 
 (defn delete-job
   [analysis-id]
   (:body
-    (client/delete (apps-url "analyses" analysis-id)
-                   {:query-params     (secured-params)
-                    :as               :json
-                    :follow-redirects false})))
+   (client/delete (apps-url "analyses" analysis-id)
+                  (disable-redirects
+                   {:query-params (secured-params)
+                    :as           :json}))))
 
 (defn delete-jobs
   [body]
   (:body
-    (client/post (apps-url "analyses" "shredder")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "analyses" "shredder")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn get-job-params
   [analysis-id]
   (:body
-    (client/get (apps-url "analyses" analysis-id "parameters")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "analyses" analysis-id "parameters")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn get-job-relaunch-info
   [analysis-id]
   (:body
-    (client/get (apps-url "analyses" analysis-id "relaunch-info")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "analyses" analysis-id "relaunch-info")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn list-job-steps
   [analysis-id]
   (:body
-    (client/get (apps-url "analyses" analysis-id "steps")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "analyses" analysis-id "steps")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn stop-job
   [analysis-id params]
   (:body
-    (client/post (apps-url "analyses" analysis-id "stop")
-                 {:query-params     (secured-params params)
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "analyses" analysis-id "stop")
+                (disable-redirects
+                 {:query-params (secured-params params)
+                  :as           :json}))))
 
 (defn get-job-history
   [analysis-id]
   (:body
-    (client/get (apps-url "analyses" analysis-id "history")
-                {:query-params      (secured-params)
-                 :as                :json
-                 :follow-redirecrts false})))
+   (client/get (apps-url "analyses" analysis-id "history")
+               {:query-params      (secured-params)
+                :as                :json
+                :follow-redirecrts false})))
 
 (defn admin-get-apps
   [params]
   (:body
-    (client/get (apps-url "admin" "apps")
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "admin" "apps")
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn categorize-apps
   [body]
   (:body
-    (client/post (apps-url "admin" "apps")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "admin" "apps")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn list-app-publication-requests
   [params]
   (:body
    (client/get (apps-url "admin" "apps" "publication-requests")
-               {:query-params     (secured-params params)
-                :as               :json
-                :follow-redirects false})))
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn permanently-delete-apps
   [body]
   (:body
-    (client/post (apps-url "admin" "apps" "shredder")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "admin" "apps" "shredder")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn admin-delete-app
   [system-id app-id]
   (:body
-    (client/delete (apps-url "admin" "apps" system-id app-id)
-                   {:query-params     (secured-params)
-                    :as               :json
-                    :follow-redirects false})))
+   (client/delete (apps-url "admin" "apps" system-id app-id)
+                  (disable-redirects
+                   {:query-params (secured-params)
+                    :as           :json}))))
 
 (defn admin-update-app
   [system-id app-id body]
   (:body
-    (client/patch (apps-url "admin" "apps" system-id app-id)
-                  {:query-params     (secured-params)
-                   :form-params      body
-                   :content-type     :json
-                   :as               :json
-                   :follow-redirects false})))
+   (client/patch (apps-url "admin" "apps" system-id app-id)
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :form-params  body
+                   :content-type :json
+                   :as           :json}))))
 
 (defn get-admin-app-categories
   [params]
   (client/get (apps-url "admin" "apps" "categories")
-              {:query-params     (secured-params params apps-sort-params)
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params params apps-sort-params)
+                :as           :stream})))
 
 (defn search-admin-app-categories
   [params]
   (client/get (apps-url "admin" "apps" "categories" "search")
-              {:query-params     (secured-params params [:name])
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params params [:name])
+                :as           :stream})))
 
 (defn add-category
   [system-id body]
   (client/post (apps-url "admin" "apps" "categories" system-id)
-               {:query-params     (secured-params)
-                :content-type     :json
-                :body             body
-                :as               :stream
-                :follow-redirects false}))
+               (disable-redirects
+                {:query-params (secured-params)
+                 :content-type :json
+                 :body         body
+                 :as           :stream})))
 
 (defn delete-category
   [system-id category-id]
   (client/delete (apps-url "admin" "apps" "categories" system-id category-id)
-                 {:query-params     (secured-params)
-                  :as               :stream
-                  :follow-redirects false}))
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :as           :stream})))
 
 (defn update-category
   [system-id category-id body]
   (client/patch (apps-url "admin" "apps" "categories" system-id category-id)
-                {:query-params     (secured-params)
-                 :content-type     :json
-                 :body             body
-                 :as               :stream
-                 :follow-redirects false}))
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :content-type :json
+                  :body         body
+                  :as           :stream})))
 
 (defn get-app-docs
   [system-id app-id]
   (:body
-    (client/get (apps-url "apps" system-id app-id "documentation")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" system-id app-id "documentation")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn edit-app-docs
   [system-id app-id docs]
   (:body
-    (client/patch (apps-url "apps" system-id app-id "documentation")
-                  {:query-params     (secured-params)
-                   :form-params      docs
-                   :content-type     :json
-                   :as               :json
-                   :follow-redirects false})))
+   (client/patch (apps-url "apps" system-id app-id "documentation")
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :form-params  docs
+                   :content-type :json
+                   :as           :json}))))
 
 (defn add-app-docs
   [system-id app-id docs]
   (:body
-    (client/post (apps-url "apps" system-id app-id "documentation")
-                 {:query-params     (secured-params)
-                  :form-params      docs
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "apps" system-id app-id "documentation")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  docs
+                  :content-type :json
+                  :as           :json}))))
 
 (defn admin-edit-app-docs
   [system-id app-id docs]
   (:body
-    (client/patch (apps-url "admin" "apps" system-id app-id "documentation")
-                  {:query-params     (secured-params)
-                   :form-params      docs
-                   :content-type     :json
-                   :as               :json
-                   :follow-redirects false})))
+   (client/patch (apps-url "admin" "apps" system-id app-id "documentation")
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :form-params  docs
+                   :content-type :json
+                   :as           :json}))))
 
 (defn admin-add-app-docs
   [system-id app-id docs]
   (:body
-    (client/post (apps-url "admin" "apps" system-id app-id "documentation")
-                 {:query-params     (secured-params)
-                  :form-params      docs
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "admin" "apps" system-id app-id "documentation")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  docs
+                  :content-type :json
+                  :as           :json}))))
 
 
 (defn get-oauth-access-token
   [api-name params]
   (client/get (apps-url "oauth" "access-code" api-name)
-              {:query-params     (secured-params params [:code :state])
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params params [:code :state])
+                :as           :stream})))
 
 (defn get-oauth-token-info
   [api-name]
   (client/get (apps-url "oauth" "token-info" api-name)
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params)
+                :as           :stream})))
 
 (defn delete-oauth-token-info
   [api-name]
   (client/delete (apps-url "oauth" "token-info" api-name)
-                 {:query-params     (secured-params)
-                  :as               :stream
-                  :follow-redirects false}))
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :as           :stream})))
 
 (defn get-oauth-redirect-uris
   []
   (client/get (apps-url "oauth" "redirect-uris")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params)
+                :as           :stream})))
 
 (defn get-admin-oauth-token-info
   [api-name params]
   (client/get (apps-url "admin" "oauth" "token-info" api-name)
-              {:query-params     (secured-params params [:proxy-user])
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params params [:proxy-user])
+                :as           :stream})))
 
 (defn delete-admin-oauth-token-info
   [api-name params]
   (client/delete (apps-url "admin" "oauth" "token-info" api-name)
-                 {:query-params     (secured-params params [:proxy-user])
-                  :as               :stream
-                  :follow-redirects false}))
+                 (disable-redirects
+                  {:query-params (secured-params params [:proxy-user])
+                   :as           :stream})))
 
 (defn admin-delete-tool-request-status-code
   [status-code-id]
   (:body
-    (client/delete (apps-url "admin" "tool-requests" "status-codes" status-code-id)
-                   {:query-params     (secured-params)
-                    :as               :json
-                    :follow-redirects false})))
+   (client/delete (apps-url "admin" "tool-requests" "status-codes" status-code-id)
+                  (disable-redirects
+                   {:query-params (secured-params)
+                    :as           :json}))))
 
 (defn admin-list-tool-requests
   [params]
   (:body
-    (client/get (apps-url "admin" "tool-requests")
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "admin" "tool-requests")
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn admin-delete-tool-request
   [request-id]
   (:body
-    (client/delete (apps-url "admin" "tool-requests" request-id)
-                   {:query-params     (secured-params)
-                    :as               :json
-                    :follow-redirects false})))
+   (client/delete (apps-url "admin" "tool-requests" request-id)
+                  (disable-redirects
+                   {:query-params (secured-params)
+                    :as           :json}))))
 
 (defn admin-get-tool-request
   [request-id]
   (:body
-    (client/get (apps-url "admin" "tool-requests" request-id)
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "admin" "tool-requests" request-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn admin-update-tool-request
   [body request-id]
   (:body
-    (client/post (apps-url "admin" "tool-requests" request-id "status")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "admin" "tool-requests" request-id "status")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn list-tool-requests
   "Lists the tool requests that were submitted by the authenticated user."
   [params]
   (:body
-    (client/get (apps-url "tool-requests")
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "tool-requests")
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn submit-tool-request
   "Submits a tool request on behalf of the user found in the request params."
   [body]
   (:body
-    (client/post (apps-url "tool-requests")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "tool-requests")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn list-tool-request-status-codes
   [params]
   (:body
-    (client/get (apps-url "tool-requests" "status-codes")
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "tool-requests" "status-codes")
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn get-tools-in-app
   [system-id app-id]
   (:body
-    (client/get (apps-url "apps" system-id app-id "tools")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" system-id app-id "tools")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn admin-list-tools
   [params]
   (:body
-    (client/get (apps-url "admin" "tools")
-                {:query-params     (secured-params params tools-search-params)
-                 :as               :json
-                 :follow-redirects :false})))
+   (client/get (apps-url "admin" "tools")
+               (disable-redirects
+                {:query-params (secured-params params tools-search-params)
+                 :as           :json}))))
 
 (defn admin-add-tools
   [body]
   (:body
-    (client/post (apps-url "admin" "tools")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :as               :json
-                  :content-type     :json
-                  :follow-redirects false})))
+   (client/post (apps-url "admin" "tools")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :as           :json
+                  :content-type :json}))))
 
 (defn admin-delete-tool
   [tool-id]
   (:body
-    (client/delete (apps-url "admin" "tools" tool-id)
-                   {:query-params     (secured-params)
-                    :as               :json
-                    :follow-redirects false})))
+   (client/delete (apps-url "admin" "tools" tool-id)
+                  (disable-redirects
+                   {:query-params (secured-params)
+                    :as           :json}))))
 
 (defn admin-get-tool
   [tool-id]
   (:body
-    (client/get (apps-url "admin" "tools" tool-id)
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "admin" "tools" tool-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn admin-update-tool
   [tool-id params tool]
   (:body
-    (client/patch (apps-url "admin" "tools" tool-id)
-                  {:query-params     (secured-params params [:overwrite-public])
-                   :form-params      tool
-                   :as               :json
-                   :content-type     :json
-                   :follow-redirects false})))
+   (client/patch (apps-url "admin" "tools" tool-id)
+                 (disable-redirects
+                  {:query-params (secured-params params [:overwrite-public])
+                   :form-params  tool
+                   :as           :json
+                   :content-type :json}))))
 
 (defn admin-get-apps-by-tool
   [tool-id]
   (:body
-    (client/get (apps-url "admin" "tools" tool-id "apps")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "admin" "tools" tool-id "apps")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn admin-publish-tool
   [tool-id body]
   (:body
-    (client/post (apps-url "admin" "tools" tool-id "publish")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "admin" "tools" tool-id "publish")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn list-tools
   [params]
   (:body
-    (client/get (apps-url "tools")
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects :false})))
+   (client/get (apps-url "tools")
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn create-private-tool
   [body]
   (:body
-    (client/post (apps-url "tools")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "tools")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn list-tool-permissions
   [body params]
   (:body
-    (client/post (apps-url "tools" "permission-lister")
-                 {:query-params     (secured-params params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "tools" "permission-lister")
+                (disable-redirects
+                 {:query-params (secured-params params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn share-tool
   [body]
   (:body
-    (client/post (apps-url "tools" "sharing")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "tools" "sharing")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn unshare-tool
   [body]
   (:body
-    (client/post (apps-url "tools" "unsharing")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :content-type     :json
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "tools" "unsharing")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :content-type :json
+                  :as           :json}))))
 
 (defn delete-private-tool
   [tool-id params]
   (:body
-    (client/delete (apps-url "tools" tool-id)
-                   {:query-params     (secured-params params)
-                    :as               :json
-                    :follow-redirects false})))
+   (client/delete (apps-url "tools" tool-id)
+                  (disable-redirects
+                   {:query-params (secured-params params)
+                    :as           :json}))))
 
 (defn get-tool
   [tool-id]
   (:body
-    (client/get (apps-url "tools" tool-id)
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "tools" tool-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn update-private-tool
   [tool-id body]
   (:body
-    (client/patch (apps-url "tools" tool-id)
-                  {:query-params     (secured-params)
-                   :form-params      body
-                   :as               :json
-                   :content-type     :json
-                   :follow-redirects false})))
+   (client/patch (apps-url "tools" tool-id)
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :form-params  body
+                   :as           :json
+                   :content-type :json}))))
 
 (defn get-apps-by-tool
   [tool-id]
   (:body
-    (client/get (apps-url "tools" tool-id "apps")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "tools" tool-id "apps")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn list-reference-genomes
   [params]
   (:body
-    (client/get (apps-url "reference-genomes")
-                {:query-params     (secured-params params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "reference-genomes")
+               (disable-redirects
+                {:query-params (secured-params params)
+                 :as           :json}))))
 
 (defn get-reference-genome
   [reference-genome-id]
   (:body
-    (client/get (apps-url "reference-genomes" reference-genome-id)
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "reference-genomes" reference-genome-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn admin-add-reference-genome
   [body]
   (:body
-    (client/post (apps-url "admin" "reference-genomes")
-                 {:query-params     (secured-params)
-                  :form-params      body
-                  :as               :json
-                  :content-type     :json
-                  :follow-redirects false})))
+   (client/post (apps-url "admin" "reference-genomes")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  body
+                  :as           :json
+                  :content-type :json}))))
 
 (defn admin-delete-reference-genome
   [reference-genome-id params]
   (:body
-    (client/delete (apps-url "admin" "reference-genomes" reference-genome-id)
-                   {:query-params     (secured-params params)
-                    :as               :json
-                    :follow-redirects false})))
+   (client/delete (apps-url "admin" "reference-genomes" reference-genome-id)
+                  (disable-redirects
+                   {:query-params (secured-params params)
+                    :as           :json}))))
 
 (defn admin-update-reference-genome
   [body reference-genome-id]
   (:body
-    (client/patch (apps-url "admin" "reference-genomes" reference-genome-id)
-                  {:query-params     (secured-params)
-                   :form-params      body
-                   :as               :json
-                   :content-type     :json
-                   :follow-redirects false})))
+   (client/patch (apps-url "admin" "reference-genomes" reference-genome-id)
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :form-params  body
+                   :as           :json
+                   :content-type :json}))))
 
 (defn record-login
   [ip-address user-agent]
   (let [params {:ip-address ip-address :user-agent user-agent}]
     (:body
-      (client/post (apps-url "users" "login")
-                   {:query-params     (secured-params params)
-                    :as               :json
-                    :follow-redirects false}))))
+     (client/post (apps-url "users" "login")
+                  (disable-redirects
+                   {:query-params (secured-params params)
+                    :as           :json})))))
 
 (defn record-logout
   [params]
   (:body
-    (client/post (apps-url "users" "logout")
-                 {:query-params     (secured-params params)
-                  :as               :json
-                  :follow-redirects false})))
+   (client/post (apps-url "users" "logout")
+                (disable-redirects
+                 {:query-params (secured-params params)
+                  :as           :json}))))
 
 (defn list-integration-data
   [params]
   (client/get (apps-url "admin" "integration-data")
-              {:query-params     (secured-params params base-search-params)
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params params base-search-params)
+                :as           :stream})))
 
 (defn add-integration-data
   [body]
   (client/post (apps-url "admin" "integration-data")
-               {:query-params     (secured-params)
-                :as               :stream
-                :body             body
-                :content-type     :json
-                :follow-redirects false}))
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :stream
+                 :body         body
+                 :content-type :json})))
 
 (defn get-integration-data
   [integration-data-id]
   (client/get (apps-url "admin" "integration-data" integration-data-id)
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params)
+                :as           :stream})))
 
 (defn update-integration-data
   [integration-data-id body]
   (client/put (apps-url "admin" "integration-data" integration-data-id)
-              {:query-params     (secured-params)
-               :as               :stream
-               :body             body
-               :content-type     :json
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params)
+                :as           :stream
+                :body         body
+                :content-type :json})))
 
 (defn delete-integration-data
   [integration-data-id]
   (client/delete (apps-url "admin" "integration-data" integration-data-id)
-                 {:query-params     (secured-params)
-                  :as               :stream
-                  :follow-redirects false}))
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :as           :stream})))
 
 (defn get-app-integration-data
   [system-id app-id]
   (:body
-    (client/get (apps-url "apps" system-id app-id "integration-data")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "apps" system-id app-id "integration-data")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn get-tool-integration-data
   [tool-id]
   (:body
-    (client/get (apps-url "tools" tool-id "integration-data")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "tools" tool-id "integration-data")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn update-app-integration-data
   [system-id app-id integration-data-id]
   (:body
-    (client/put (apps-url "admin" "apps" system-id app-id "integration-data" integration-data-id)
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/put (apps-url "admin" "apps" system-id app-id "integration-data" integration-data-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn update-tool-integration-data
   [tool-id integration-data-id]
   (:body
-    (client/put (apps-url "admin" "tools" tool-id "integration-data" integration-data-id)
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/put (apps-url "admin" "tools" tool-id "integration-data" integration-data-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn get-workshop-group
   []
   (client/get (apps-url "admin" "groups" "workshop")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params)
+                :as           :stream})))
 
 (defn get-workshop-group-members
   []
   (client/get (apps-url "admin" "groups" "workshop" "members")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params)
+                :as           :stream})))
 
 (defn update-workshop-group-members
   [body]
   (client/put (apps-url "admin" "groups" "workshop" "members")
-              {:query-params     (secured-params)
-               :as               :stream
-               :body             body
-               :content-type     :json
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params)
+                :as           :stream
+                :body         body
+                :content-type :json})))
 
 (defn bootstrap
   []
   (:body
-    (client/get (apps-url "bootstrap")
-                {:query-params     (secured-params)
-                 :as               :json
-                 :follow-redirects false})))
+   (client/get (apps-url "bootstrap")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
 
 (defn save-webhooks
   [webhooks]
   (:body (client/put (apps-url "webhooks")
-            {:query-params     (secured-params)
-             :as               :json
-             :form-params      webhooks
-             :content-type     :json
-             :follow-redirects false})))
+                     (disable-redirects
+                      {:query-params (secured-params)
+                       :as           :json
+                       :form-params  webhooks
+                       :content-type :json}))))
 
 (defn admin-list-workspaces
   [params]
   (client/get (apps-url "admin" "workspaces")
-              {:query-params     (secured-params params [:username])
-               :as               :stream
-               :follow-redirects false}))
+              (disable-redirects
+               {:query-params (secured-params params [:username])
+                :as           :stream})))
 
 (defn admin-delete-workspaces
   [params]
   (client/delete (apps-url "admin" "workspaces")
-                 {:query-params     (secured-params params [:username])
-                  :as               :stream
-                  :follow-redirects false}))
+                 (disable-redirects
+                  {:query-params (secured-params params [:username])
+                   :as           :stream})))
 
 (defn get-webhook-types
   []
   (:body (client/get (apps-url "webhooks" "types")
-              {:query-params     (secured-params)
-               :as               :json
-               :follow-redirects false})))
+                     (disable-redirects
+                      {:query-params (secured-params)
+                       :as           :json}))))
 
 (defn get-webhook-topics
   []
   (:body (client/get (apps-url "webhooks" "topics")
-              {:query-params     (secured-params)
-               :as               :json
-               :follow-redirects false})))
+                     (disable-redirects
+                      {:query-params (secured-params)
+                       :as           :json}))))
 
 (defn get-webhooks
   []
   (:body (client/get (apps-url "webhooks")
-              {:query-params     (secured-params)
-               :as               :json
-               :follow-redirects false})))
+                     (disable-redirects
+                      {:query-params (secured-params)
+                       :as           :json}))))

--- a/src/terrain/clients/metadata/raw.clj
+++ b/src/terrain/clients/metadata/raw.clj
@@ -30,9 +30,8 @@
   ([]
    (get-options {}))
   ([params]
-   {:query-params     (user-params params)
-    :as               :stream
-    :follow-redirects false})
+   {:query-params (user-params params)
+    :as           :stream})
   ([params param-keys]
    (get-options (user-params params param-keys))))
 
@@ -40,9 +39,8 @@
   ([]
    (json-get-options {}))
   ([params]
-   {:query-params     (user-params params)
-    :as               :json
-    :follow-redirects false}))
+   {:query-params (user-params params)
+    :as           :json}))
 
 (def delete-options get-options)
 
@@ -50,21 +48,19 @@
   ([body]
    (post-options body {}))
   ([body params]
-   {:query-params     (user-params params)
-    :body             body
-    :content-type     :json
-    :as               :stream
-    :follow-redirects false}))
+   {:query-params (user-params params)
+    :body         body
+    :content-type :json
+    :as           :stream}))
 
 (defn json-post-options
   ([body]
    (json-post-options body {}))
   ([body params]
-   {:query-params     (user-params params)
-    :form-params      body
-    :content-type     :json
-    :as               :json
-    :follow-redirects false}))
+   {:query-params (user-params params)
+    :form-params  body
+    :content-type :json
+    :as           :json}))
 
 (def put-options post-options)
 
@@ -259,8 +255,7 @@
               :multipart        [{:part-name "ontology-xml"
                                   :name      filename
                                   :mime-type content-type
-                                  :content   istream}]
-              :follow-redirects false}))
+                                  :content   istream}]}))
 
 (defn delete-app-category-hierarchy
   [ontology-version root-iri]

--- a/src/terrain/clients/notifications/raw.clj
+++ b/src/terrain/clients/notifications/raw.clj
@@ -16,189 +16,165 @@
 (defn get-messages
   [params]
   (client/get (na-url "messages")
-              {:query-params     (secured-params params na-message-params)
-               :as               :stream
-               :follow-redirects false}))
+              {:query-params (secured-params params na-message-params)
+               :as           :stream}))
 
 (defn get-unseen-messages
   [params]
   (client/get (na-url "unseen-messages")
-              {:query-params     (secured-params params na-message-params)
-               :as               :stream
-               :follow-redirects false}))
+              {:query-params (secured-params params na-message-params)
+               :as           :stream}))
 
 (defn last-ten-messages
   []
   (client/get (na-url "last-ten-messages")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              {:query-params (secured-params)
+               :as           :stream}))
 
 (defn count-messages
   [params]
   (client/get (na-url "count-messages")
-              {:query-params     (secured-params params na-filter-params)
-               :as               :stream
-               :follow-redirects false}))
+              {:query-params (secured-params params na-filter-params)
+               :as           :stream}))
 
 (defn delete-notifications
   [body]
   (client/post (na-url "delete")
-               {:query-params     (secured-params)
-                :as               :stream
-                :content-type     :json
-                :body             body
-                :follow-redirects false}))
+               {:query-params (secured-params)
+                :as           :stream
+                :content-type :json
+                :body         body}))
 
 (defn delete-all-notifications
   [params]
   (client/delete (na-url "delete-all")
-                 {:query-params     (secured-params params na-message-params)
-                  :as               :stream
-                  :follow-redirects false}))
+                 {:query-params (secured-params params na-message-params)
+                  :as           :stream}))
 
 (defn mark-notifications-seen
   [body]
   (client/post (na-url "seen")
-               {:query-params     (secured-params)
-                :as               :stream
-                :content-type     :json
-                :body             body
-                :follow-redirects false}))
+               {:query-params (secured-params)
+                :as           :stream
+                :content-type :json
+                :body         body}))
 
 (defn mark-all-notifications-seen
   [body]
   (client/post (na-url "mark-all-seen")
-               {:query-params     (secured-params)
-                :as               :stream
-                :content-type     :json
-                :body             body
-                :follow-redirects false}))
+               {:query-params (secured-params)
+                :as           :stream
+                :content-type :json
+                :body         body}))
 
 (defn send-notification
   [body]
   (client/post (na-url "notification")
-               {:query-params     (secured-params)
-                :as               :stream
-                :content-type     :json
-                :body             body
-                :follow-redirects false}))
+               {:query-params (secured-params)
+                :as           :stream
+                :content-type :json
+                :body         body}))
 
 (defn get-system-messages
   []
   (client/get (na-url "system" "messages")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              {:query-params (secured-params)
+               :as           :stream}))
 
 (defn get-new-system-messages
   []
   (client/get (na-url "system" "new-messages")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              {:query-params (secured-params)
+               :as           :stream}))
 
 (defn get-unseen-system-messages
   []
   (client/get (na-url "system" "unseen-messages")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              {:query-params (secured-params)
+               :as           :stream}))
 
 (defn mark-system-messages-received
   [body]
   (client/post (na-url "system" "received")
-               {:query-params     (secured-params)
-                :as               :stream
-                :content-type     :json
-                :body             body
-                :follow-redirects false}))
+               {:query-params (secured-params)
+                :as           :stream
+                :content-type :json
+                :body         body}))
 
 (defn mark-all-system-messages-received
   [body]
   (client/post (na-url "system" "mark-all-received")
-               {:query-params     (secured-params)
-                :as               :stream
-                :content-type     :json
-                :body             body
-                :follow-redirects false}))
+               {:query-params (secured-params)
+                :as           :stream
+                :content-type :json
+                :body         body}))
 
 (defn mark-system-messages-seen
   [body]
   (client/post (na-url "system" "seen")
-               {:query-params     (secured-params)
-                :as               :stream
-                :content-type     :json
-                :body             body
-                :follow-redirects false}))
+               {:query-params (secured-params)
+                :as           :stream
+                :content-type :json
+                :body         body}))
 
 (defn mark-all-system-messages-seen
   [body]
   (client/post (na-url "system" "mark-all-seen")
-               {:query-params     (secured-params)
-                :as               :stream
-                :content-type     :json
-                :body             body
-                :follow-redirects false}))
+               {:query-params (secured-params)
+                :as           :stream
+                :content-type :json
+                :body         body}))
 
 (defn delete-system-messages
   [body]
   (client/post (na-url "system" "delete")
-               {:query-params     (secured-params)
-                :as               :stream
-                :content-type     :json
-                :body             body
-                :follow-redirects false}))
+               {:query-params (secured-params)
+                :as           :stream
+                :content-type :json
+                :body         body}))
 
 (defn delete-all-system-messages
   [params]
   (client/delete (na-url "system" "delete-all")
-                 {:query-params     (secured-params)
-                  :as               :stream
-                  :follow-redirects false}))
+                 {:query-params (secured-params)
+                  :as           :stream}))
 
 (defn admin-add-system-message
   [body]
   (client/put (na-url "admin" "system")
-              {:query-params     (secured-params)
-               :as               :stream
-               :content-type     :json
-               :body             body
-               :follow-redirects false}))
+              {:query-params (secured-params)
+               :as           :stream
+               :content-type :json
+               :body         body}))
 
 (defn admin-list-system-types
   []
   (client/get (na-url "admin" "system-types")
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              {:query-params (secured-params)
+               :as           :stream}))
 
 (defn admin-list-system-messages
   [params]
   (client/get (na-url "admin" "system")
-              {:query-params     (secured-params params na-system-message-params)
-               :as               :stream
-               :follow-redirects false}))
+              {:query-params (secured-params params na-system-message-params)
+               :as           :stream}))
 
 (defn admin-get-system-message
   [uuid]
   (client/get (na-url "admin" "system" uuid)
-              {:query-params     (secured-params)
-               :as               :stream
-               :follow-redirects false}))
+              {:query-params (secured-params)
+               :as           :stream}))
 
 (defn admin-update-system-message
   [uuid body]
   (client/post (na-url "admin" "system" uuid)
-               {:query-params     (secured-params)
-                :as               :stream
-                :content-type     :json
-                :body             body
-                :follow-redirects false}))
+               {:query-params (secured-params)
+                :as           :stream
+                :content-type :json
+                :body         body}))
 
 (defn admin-delete-system-message
   [uuid]
   (client/delete (na-url "admin" "system" uuid)
-                 {:query-params     (secured-params)
-                  :as               :stream
-                  :follow-redirects false}))
+                 {:query-params (secured-params)
+                  :as           :stream}))

--- a/src/terrain/util.clj
+++ b/src/terrain/util.clj
@@ -44,3 +44,11 @@
             (partial ctlr req true func)
             (partial ctlr req false func))]
     (apply p args)))
+
+(defn disable-redirects
+  ([]
+   (disable-redirects {}))
+  ([opts]
+   (assoc opts
+          :redirect-strategy    :none
+          :unexceptional-status (fn [status] (<= 200 status 299)))))


### PR DESCRIPTION
…ps service

Note that the code to disable redirects has been removed from the clients for the notification agent and metadata services. We really only need to worry about it for the apps service.