### PR TITLE
Dashboard-related endpoint

### DIFF
--- a/src/terrain/clients/dashboard_aggregator.clj
+++ b/src/terrain/clients/dashboard_aggregator.clj
@@ -13,10 +13,4 @@
 
 (defn get-dashboard-data
   [username]
-  (let [resp (http/get (dashboard-aggregator-url username) {:throw-exceptions false})]
-    (cond
-      (not (<= 200 (:status resp) 299))
-      (throw+ {:error_code ERR_UNCHECKED_EXCEPTION :msg (:body resp)})
-      
-      :else
-      (json/parse-string (:body resp) true))))
+  (:body (http/get (dashboard-aggregator-url username) {:as :json})))

--- a/src/terrain/clients/dashboard_aggregator.clj
+++ b/src/terrain/clients/dashboard_aggregator.clj
@@ -1,0 +1,22 @@
+(ns terrain.clients.dashboard-aggregator
+    (:use [clojure-commons.error-codes]
+          [slingshot.slingshot :only [try+ throw+]])
+    (:require [clj-http.client :as http]
+              [cemerick.url :refer [url]]
+              [cheshire.core :as json]
+              [clojure.tools.logging :as log]
+              [terrain.util.config :as config]))
+
+(defn- dashboard-aggregator-url
+  [user]
+  (str (url (config/dashboard-aggregator-url) "users" user)))
+
+(defn get-dashboard-data
+  [username]
+  (let [resp (http/get (dashboard-aggregator-url username) {:throw-exceptions false})]
+    (cond
+      (not (<= 200 (:status resp) 299))
+      (throw+ {:error_code ERR_UNCHECKED_EXCEPTION :msg (:body resp)})
+      
+      :else
+      (json/parse-string (:body resp) true))))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -65,6 +65,9 @@
         (tc/with-logging-context {:user-info (cheshire/encode user-info)}
           (handler request))))))
 
+; Add new secured routes to this function, not to (secured-routes).
+; This function allows for secured routes without the /secured content/prefix,
+; which is what the -no-context refers to.
 (defn secured-routes-no-context
   []
   (util/flagged-routes
@@ -91,8 +94,12 @@
    (misc-metadata-routes)
    (oauth-routes)
    (quicklaunch-routes)
+   (secured-dashboard-aggregator-routes)
    (route/not-found (service/unrecognized-path-response))))
 
+; The old way of adding secured routes. Prepends /secured to the URL
+; path. Add new secured endpoints to (secured-routes-no-context), not
+; here.
 (defn secured-routes
   []
   (util/flagged-routes
@@ -114,7 +121,6 @@
    (secured-favorites-routes)
    (secured-tag-routes)
    (data-comment-routes)
-   (secured-dashboard-aggregator-routes)
    (route/not-found (service/unrecognized-path-response))))
 
 (defn admin-routes

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -20,6 +20,7 @@
         [terrain.routes.apps.reference-genomes]
         [terrain.routes.apps.tools]
         [terrain.routes.bootstrap]
+        [terrain.routes.dashboard-aggregator]
         [terrain.routes.data]
         [terrain.routes.fileio]
         [terrain.routes.filesystem]
@@ -113,6 +114,7 @@
    (secured-favorites-routes)
    (secured-tag-routes)
    (data-comment-routes)
+   (secured-dashboard-aggregator-routes)
    (route/not-found (service/unrecognized-path-response))))
 
 (defn admin-routes
@@ -228,6 +230,7 @@
                                      {:name "coge", :description "CoGe Endpoints"}
                                      {:name "collaborator-lists", :description "Collaborator List Endpoints"}
                                      {:name "communities", :description "Community Endpoints"}
+                                     {:name "dashboard", :description "Dashboard Aggregator Endpoints"}
                                      {:name "data", :description "Data Endpoints"}
                                      {:name "favorites", :description "Favorites Endpoints"}
                                      {:name "fileio", :description "File Input/Output Endpoints"}

--- a/src/terrain/routes/dashboard_aggregator.clj
+++ b/src/terrain/routes/dashboard_aggregator.clj
@@ -1,0 +1,18 @@
+(ns terrain.routes.dashboard-aggregator
+  (:use [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]]
+        [terrain.routes.schemas.dashboard-aggregator]
+        [terrain.services.dashboard-aggregator]
+        [terrain.util])
+
+(defn secured-dashboard-aggregator-routes
+  []
+  (context "/dashboard" []
+    :tags ["dashboard"]
+    
+    (GET "/" []
+      :query [params DashboardRequestParams]
+      :return DashboardAggregatorResponse
+      :summary "Get data for the dashboard"
+      :description "Returns data for populating the dashboard view."
+      (ok (dashboard-data)))))

--- a/src/terrain/routes/dashboard_aggregator.clj
+++ b/src/terrain/routes/dashboard_aggregator.clj
@@ -3,7 +3,7 @@
         [ring.util.http-response :only [ok]]
         [terrain.routes.schemas.dashboard-aggregator]
         [terrain.services.dashboard-aggregator]
-        [terrain.util])
+        [terrain.util]))
 
 (defn secured-dashboard-aggregator-routes
   []

--- a/src/terrain/routes/dashboard_aggregator.clj
+++ b/src/terrain/routes/dashboard_aggregator.clj
@@ -1,9 +1,11 @@
 (ns terrain.routes.dashboard-aggregator
   (:use [common-swagger-api.schema]
         [ring.util.http-response :only [ok]]
+        [terrain.auth.user-attributes :only [current-user]]
         [terrain.routes.schemas.dashboard-aggregator]
-        [terrain.services.dashboard-aggregator]
-        [terrain.util]))
+        [terrain.util])
+  (:require [clojure.tools.logging :as log]
+            [terrain.clients.dashboard-aggregator :as dcl]))
 
 (defn secured-dashboard-aggregator-routes
   []
@@ -15,4 +17,4 @@
       :return DashboardAggregatorResponse
       :summary "Get data for the dashboard"
       :description "Returns data for populating the dashboard view."
-      (ok (dashboard-data)))))
+      (ok (dcl/get-dashboard-data (:username current-user))))))

--- a/src/terrain/routes/schemas/dashboard_aggregator.clj
+++ b/src/terrain/routes/schemas/dashboard_aggregator.clj
@@ -1,0 +1,39 @@
+(ns terrain.routes.schemas.dashboard-aggregator
+  (:use [common-swagger-api.schema :only [describe]]
+        [schema.core :only [defschema Any maybe optional-key]])
+  (:import [java.util UUID]))
+
+(defschema DashboardApp
+  {:id                              (describe UUID "The app ID")
+   :name                            (describe String "The name of the app")
+   :description                     (describe (maybe String) "The description of the app")
+   (optional-key :wiki_url)         (describe (maybe String) "The URL to the wiki entry for the app")
+   (optional-key :integration_date) (describe (maybe Long) "The date the app was integrated. Milliseconds since epoch")
+   (optional-key :edited_date)      (describe (maybe Long) "The date the app was last edited")})
+
+(defschema DashboardAnalysis
+  {:id                                (describe UUID "The analysis/job ID")
+   :name                              (describe String "The name of the analysis")
+   :description                       (describe (maybe String) "The description of the analysis")
+   :app_id                            (describe UUID "The ID of the app used for the analysis")
+   :app_name                          (describe String "The name of the app used for the analysis")
+   :app_description                   (describe (maybe String) "The description of the app used for the analysis")
+   (optional-key :result_folder_path) (describe (maybe String) "The path to the analysis outputs")
+   :start_date                        (describe (maybe Long) "The date the analysis was started. Milliseconds since the epoch")
+   (optional-key :end_date)           (describe (maybe Long) "The date the analysis ended. Milliseconds since the epoch")
+   (optional-key :planned_end_date)   (describe (maybe Long) "The date the analysis was scheduled to end. VICE only. Milliseconds since the epoch")
+   (optional-key :status)             (describe (maybe String) "The current status of the analysis")
+   (optional-key :subdomain)          (describe (maybe String) "The subdomain assigned to the analysis. VICE only")
+   (optional-key :parent_id)          (describe (maybe UUID) "The UUID of the parent analysis. Only for batch analyses")})
+
+(defschema DashboardAggregatedApps
+  {(optional-key :recentlyAdded) (describe (maybe [DashboardApp]) "Apps recently added by the user")
+   :public                       (describe [DashboardApp] "Apps recently made public")})
+
+(defschema DashboardAggregatedAnalyses
+  {(optional-key :recent)  (describe (maybe [DashboardAnalysis]) "Analyses recent launched by the user")
+   (optional-key :running) (describe (maybe [DashboardAnalysis]) "Analyses currently running for the user")})
+
+(defschema DashboardAggregatorResponse
+ {:apps                    (describe DashboardAggregatedApps "The app listings returned for the dashboard")
+  (optional-key :analyses) (describe DashboardAggregatedAnalyses "The analysis listings returned for the dashboard")})

--- a/src/terrain/routes/schemas/dashboard_aggregator.clj
+++ b/src/terrain/routes/schemas/dashboard_aggregator.clj
@@ -37,3 +37,6 @@
 (defschema DashboardAggregatorResponse
  {:apps                    (describe DashboardAggregatedApps "The app listings returned for the dashboard")
   (optional-key :analyses) (describe DashboardAggregatedAnalyses "The analysis listings returned for the dashboard")})
+
+(defschema DashboardRequestParams
+  {(optional-key :limit) (describe (maybe Integer) "The number of responses to include in each field.")})

--- a/src/terrain/routes/schemas/dashboard_aggregator.clj
+++ b/src/terrain/routes/schemas/dashboard_aggregator.clj
@@ -8,8 +8,8 @@
    :name                            (describe String "The name of the app")
    :description                     (describe (maybe String) "The description of the app")
    (optional-key :wiki_url)         (describe (maybe String) "The URL to the wiki entry for the app")
-   (optional-key :integration_date) (describe (maybe Long) "The date the app was integrated. Milliseconds since epoch")
-   (optional-key :edited_date)      (describe (maybe Long) "The date the app was last edited")})
+   (optional-key :integration_date) (describe (maybe String) "The date the app was integrated. Milliseconds since epoch")
+   (optional-key :edited_date)      (describe (maybe String) "The date the app was last edited")})
 
 (defschema DashboardAnalysis
   {:id                                (describe UUID "The analysis/job ID")
@@ -19,9 +19,9 @@
    :app_name                          (describe String "The name of the app used for the analysis")
    :app_description                   (describe (maybe String) "The description of the app used for the analysis")
    (optional-key :result_folder_path) (describe (maybe String) "The path to the analysis outputs")
-   :start_date                        (describe (maybe Long) "The date the analysis was started. Milliseconds since the epoch")
-   (optional-key :end_date)           (describe (maybe Long) "The date the analysis ended. Milliseconds since the epoch")
-   (optional-key :planned_end_date)   (describe (maybe Long) "The date the analysis was scheduled to end. VICE only. Milliseconds since the epoch")
+   :start_date                        (describe (maybe String) "The date the analysis was started. Milliseconds since the epoch")
+   (optional-key :end_date)           (describe (maybe String) "The date the analysis ended. Milliseconds since the epoch")
+   (optional-key :planned_end_date)   (describe (maybe String) "The date the analysis was scheduled to end. VICE only. Milliseconds since the epoch")
    (optional-key :status)             (describe (maybe String) "The current status of the analysis")
    (optional-key :subdomain)          (describe (maybe String) "The subdomain assigned to the analysis. VICE only")
    (optional-key :parent_id)          (describe (maybe UUID) "The UUID of the parent analysis. Only for batch analyses")})

--- a/src/terrain/services/dashboard_aggregator.clj
+++ b/src/terrain/services/dashboard_aggregator.clj
@@ -1,0 +1,8 @@
+(ns terrain.services.dashboard-aggregator
+  (:use [terrain.auth.user-attributes :only [current-user]]
+        [terrain.util.service :only [success-response]])
+  (:require [terrain.clients.dashboard-aggregator :as dcl]))
+
+(defn dashboard-data
+  []
+  (success-response (dcl/get-dashboard-data (:username current-user))))

--- a/src/terrain/services/dashboard_aggregator.clj
+++ b/src/terrain/services/dashboard_aggregator.clj
@@ -1,8 +1,0 @@
-(ns terrain.services.dashboard-aggregator
-  (:use [terrain.auth.user-attributes :only [current-user]]
-        [terrain.util.service :only [success-response]])
-  (:require [terrain.clients.dashboard-aggregator :as dcl]))
-
-(defn dashboard-data
-  []
-  (success-response (dcl/get-dashboard-data (:username current-user))))

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -513,6 +513,11 @@
   [props config-valid configs]
   "terrain.keycloak.realm" "CyVerse")
 
+(cc/defprop-optstr dashboard-aggregator-url
+  "The URL to the dashboard-aggregator service."
+  [props config-valid configs]
+  "terrain.dashboard-aggregator.base-uri" "http://dashboard-aggregator")
+
 (def metadata-client
   (memoize #(metadata-client/new-metadata-client (metadata-base-url))))
 


### PR DESCRIPTION
Adds an authenticated endpoint called `/secured/dashboard` that passes requests along to the `/users/:username` endpoint of the dashboard-aggregator service. The intention is to use it to get information for the dashboard in Sonora.

The data included now isn't complete, this is intended to get the plumbing in place for future work.