### PR TITLE
CORE-675 - requests and concurrent job limit routes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -27,6 +27,7 @@
                  [me.raynes/fs "1.4.6"]
                  [medley "1.3.0"]
                  [metosin/ring-http-response "0.9.1"]
+                 [potemkin "0.4.5"]
                  [proto-repl "0.3.1"]
                  [org.apache.tika/tika-core "1.23"]
                  [ring/ring-jetty-adapter "1.8.0"]

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -118,3 +118,10 @@
                     {:content-type :json
                      :as           :json
                      :form-params  ql})))
+
+(defn set-concurrent-job-limit
+  [username concurrent-jobs]
+  (:body (http/put (analyses-url ["settings" "concurrent-job-limits" username])
+                   {:content-type :json
+                    :as           :json
+                    :form-params  {:concurrent_jobs concurrent-jobs}})))

--- a/src/terrain/clients/analyses.clj
+++ b/src/terrain/clients/analyses.clj
@@ -119,9 +119,24 @@
                      :as           :json
                      :form-params  ql})))
 
+(defn list-concurrent-job-limits
+  []
+  (:body (http/get (analyses-url ["settings" "concurrent-job-limits"])
+                   {:as :json})))
+
+(defn get-concurrent-job-limit
+  [username]
+  (:body (http/get (analyses-url ["settings" "concurrent-job-limits" username])
+                   {:as :json})))
+
 (defn set-concurrent-job-limit
   [username concurrent-jobs]
   (:body (http/put (analyses-url ["settings" "concurrent-job-limits" username])
                    {:content-type :json
                     :as           :json
                     :form-params  {:concurrent_jobs concurrent-jobs}})))
+
+(defn remove-concurrent-job-limit
+  [username]
+  (:body (http/delete (analyses-url ["settings" "concurrent-job-limits" username])
+                      {:as :json})))

--- a/src/terrain/clients/requests.clj
+++ b/src/terrain/clients/requests.clj
@@ -38,3 +38,13 @@
   [request-id]
   (:body (http/get (requests-url "requests" request-id)
                    {:as :json})))
+
+(defn update-request
+  "Updates a request."
+  [username request-id message request-status-code]
+  (:body (http/post (requests-url "requests" request-id "status")
+                    {:query-params {:user username}
+                     :form-params  {:message message
+                                    :status  request-status-code}
+                     :content-type :json
+                     :as           :json})))

--- a/src/terrain/clients/requests.clj
+++ b/src/terrain/clients/requests.clj
@@ -32,3 +32,9 @@
                                     :details      details}
                      :content-type :json
                      :as           :json})))
+
+(defn get-request
+  "Obtains information about the request with the given ID."
+  [request-id]
+  (:body (http/get (requests-url "requests" request-id)
+                   {:as :json})))

--- a/src/terrain/clients/requests.clj
+++ b/src/terrain/clients/requests.clj
@@ -1,0 +1,34 @@
+(ns terrain.clients.requests
+  (:require [cemerick.url :as curl]
+            [clj-http.client :as http]
+            [terrain.util.config :as config]))
+
+(defn- requests-url
+  [& components]
+  (str (apply curl/url (config/requests-base) components)))
+
+(def ^:private register-request-type
+  "Registers a request type if it hasn't already been registered and returns the response body of the request
+   type registration. This function is memoized so that we don't unnecessarily hammer the requests service."
+  (memoize (fn [request-type]
+             (:body (http/post (requests-url "request-types" request-type)) {:as :json}))))
+
+(defn list-requests
+  "Lists requests, optionally filtered by requesting user, request type, and whether or not completed requests
+   should be included in the listing. The available options are keywords with the same names as the query
+   parameters in the request listing service."
+  [opts]
+  (:body (http/get (requests-url "requests")
+                   {:query-params opts
+                    :as           :json})))
+
+(defn submit-request
+  "Submits a request to the requests service."
+  [request-type username details]
+  (register-request-type request-type)
+  (:body (http/post (requests-url "requests")
+                    {:query-params {:user username}
+                     :form-params  {:request_type request-type
+                                    :details      details}
+                     :content-type :json
+                     :as           :json})))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -157,6 +157,7 @@
    (admin-integration-data-routes)
    (admin-workspace-routes)
    (admin-user-info-routes)
+   (admin-request-routes)
    (route/not-found (service/unrecognized-path-response))))
 
 (defn unsecured-routes
@@ -240,6 +241,7 @@
                                      {:name "admin-communities", :description "Community Administration Endpoints"}
                                      {:name "admin-filesystem", :description "File System Administration Endpoints"}
                                      {:name "admin-reference-genomes", :description "Admin Reference Genome Endpoints"}
+                                     {:name "admin-requests", :description "Admin Requst Endpoints"}
                                      {:name "admin-tools", :description "Admin Tool Endpoints"}
                                      {:name "admin-tool-requests", :description "Admin Tool Request Endpoints"}
                                      {:name "admin-user-info", :description "User Info Administration Endpoints"}

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -46,6 +46,7 @@
         [terrain.routes.webhooks]
         [terrain.routes.comments]
         [terrain.routes.requests]
+        [terrain.routes.settings]
         [terrain.util :as util]
         [terrain.util.transformers :as transform])
   (:require [clojure.tools.logging :as log]
@@ -158,6 +159,7 @@
    (admin-workspace-routes)
    (admin-user-info-routes)
    (admin-request-routes)
+   (admin-setting-routes)
    (route/not-found (service/unrecognized-path-response))))
 
 (defn unsecured-routes
@@ -241,7 +243,8 @@
                                      {:name "admin-communities", :description "Community Administration Endpoints"}
                                      {:name "admin-filesystem", :description "File System Administration Endpoints"}
                                      {:name "admin-reference-genomes", :description "Admin Reference Genome Endpoints"}
-                                     {:name "admin-requests", :description "Admin Requst Endpoints"}
+                                     {:name "admin-requests", :description "Admin Request Endpoints"}
+                                     {:name "admin-settings", :description "Admin Setting Endpoints"}
                                      {:name "admin-tools", :description "Admin Tool Endpoints"}
                                      {:name "admin-tool-requests", :description "Admin Tool Request Endpoints"}
                                      {:name "admin-user-info", :description "User Info Administration Endpoints"}

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -45,6 +45,7 @@
         [terrain.routes.token]
         [terrain.routes.webhooks]
         [terrain.routes.comments]
+        [terrain.routes.requests]
         [terrain.util :as util]
         [terrain.util.transformers :as transform])
   (:require [clojure.tools.logging :as log]
@@ -103,6 +104,7 @@
    (misc-metadata-routes)
    (oauth-routes)
    (quicklaunch-routes)
+   (request-routes)
    (route/not-found (service/unrecognized-path-response))))
 
 ; The old way of adding secured routes. Prepends /secured to the URL
@@ -261,6 +263,7 @@
                                      {:name "fileio", :description "File Input/Output Endpoints"}
                                      {:name "filesystem", :description "Filesystem Endpoints"}
                                      {:name "reference-genomes", :description "Reference Genome Endpoints"}
+                                     {:name "requests", :description "Request Endpoints"}
                                      {:name "subjects", :description "Subject Endpoints"}
                                      {:name "teams", :description "Team Endpoints"}
                                      {:name "tools", :description "Tool Endpoints"}

--- a/src/terrain/routes/requests.clj
+++ b/src/terrain/routes/requests.clj
@@ -65,4 +65,27 @@
        :query [params schema/RequestListingQueryParams]
        :return schema/RequestListing
        :description "Lists administrative requests, optionally filtered by request type or requesting user."
-       (ok (requests/list-requests params))))))
+       (ok (requests/list-requests params)))
+
+     (context "/:request-id" []
+       :path-params [request-id :- schema/RequestId]
+
+       (GET "/" []
+         :summary "Get Request Information"
+         :return schema/Request
+         :description "Returns information about an existing request."
+         (ok (requests/get-request request-id)))
+
+       (POST "/in-progress" []
+         :summary "Mark Request as in Progress"
+         :body [body schema/RequestUpdateMessage]
+         :return schema/RequestUpdate
+         :description "Marks a request as being in progress."
+         (ok (requests/request-in-progress current-user request-id body)))
+
+       (POST "/rejected" []
+         :summary "Mark Request as Rejected"
+         :body [body schema/RequestUpdateMessage]
+         :return schema/RequestUpdate
+         :description "Marks a request as having been rejected."
+         (ok (requests/request-rejected current-user request-id body)))))))

--- a/src/terrain/routes/requests.clj
+++ b/src/terrain/routes/requests.clj
@@ -1,0 +1,33 @@
+(ns terrain.routes.requests
+  (:use [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]]
+        [schema.core :only [Any]]
+        [terrain.auth.user-attributes :only [current-user]]
+        [terrain.util :only [optional-routes]])
+  (:require [terrain.util.config :as config]
+            [terrain.routes.schemas.requests :as schemas]
+            [terrain.services.requests :as requests]))
+
+(defn request-routes
+  "Routes for submitting administrative requests."
+  []
+  (optional-routes
+   [config/request-routes-enabled]
+
+   (context "/requests" []
+     :tags ["requests"]
+
+     (context "/vice" []
+
+       (GET "/" []
+         :summary "List VICE Access Requests"
+         :return schemas/ViceRequestListing
+         :description "Returns VICE access requests that were submitted by the authentiated user."
+         (ok (requests/list-vice-requests current-user)))
+
+       (POST "/" []
+         :summary "Request VICE Access"
+         :body [body schemas/ViceRequestDetails]
+         :return schemas/ViceRequest
+         :description "Submits a request for VICE access for the authenticated user."
+         (ok (requests/submit-vice-request current-user body)))))))

--- a/src/terrain/routes/requests.clj
+++ b/src/terrain/routes/requests.clj
@@ -4,8 +4,9 @@
         [schema.core :only [Any]]
         [terrain.auth.user-attributes :only [current-user]]
         [terrain.util :only [optional-routes]])
-  (:require [terrain.util.config :as config]
-            [terrain.routes.schemas.requests :as schemas]
+  (:require [schema-tools.core :as st]
+            [terrain.util.config :as config]
+            [terrain.routes.schemas.requests :as schema]
             [terrain.services.requests :as requests]))
 
 (defn request-routes
@@ -21,13 +22,24 @@
 
        (GET "/" []
          :summary "List VICE Access Requests"
-         :return schemas/ViceRequestListing
+         :return schema/ViceRequestListing
          :description "Returns VICE access requests that were submitted by the authentiated user."
          (ok (requests/list-vice-requests current-user)))
 
        (POST "/" []
          :summary "Request VICE Access"
-         :body [body schemas/ViceRequestDetails]
-         :return schemas/ViceRequest
+         :body [body schema/ViceRequestDetails]
+         :return (st/dissoc schema/ViceRequest :updates)
          :description "Submits a request for VICE access for the authenticated user."
-         (ok (requests/submit-vice-request current-user body)))))))
+         (ok (requests/submit-vice-request current-user body)))
+
+       (context "/:request-id" []
+         :path-params [request-id :- schema/RequestId]
+
+         (GET "/" []
+           :summary "Get VICE Request Information"
+           :return schema/ViceRequest
+           :description "Returns information about an existing request."
+           (->> (requests/get-vice-request request-id)
+                (requests/validate-request-user current-user)
+                ok)))))))

--- a/src/terrain/routes/requests.clj
+++ b/src/terrain/routes/requests.clj
@@ -88,4 +88,11 @@
          :body [body schema/RequestUpdateMessage]
          :return schema/RequestUpdate
          :description "Marks a request as having been rejected."
-         (ok (requests/request-rejected current-user request-id body)))))))
+         (ok (requests/request-rejected current-user request-id body)))
+
+       (POST "/approved" []
+         :summary "Approve a Request"
+         :body [body schema/RequestUpdateMessage]
+         :return schema/RequestUpdate
+         :description "Marks a request as approved and performs any actions required to fulfill the request."
+         (ok (requests/request-approved current-user request-id body)))))))

--- a/src/terrain/routes/schemas/requests.clj
+++ b/src/terrain/routes/schemas/requests.clj
@@ -1,7 +1,17 @@
 (ns terrain.routes.schemas.requests
   (:use [common-swagger-api.schema :only [describe NonBlankString]]
         [schema.core :only [defschema enum optional-key]])
+  (:require [schema-tools.core :as st])
   (:import [java.util UUID]))
+
+(def RequestId (describe UUID "The request ID"))
+
+(defschema RequestUpdate
+  {:created_date  (describe NonBlankString "The date and time the update occurred")
+   :id            (describe UUID "The update ID")
+   :message       (describe String "The message entered by the person who updated the requst")
+   :status        (describe String "The request status code")
+   :updating_user (describe String "The username of the person who updated the request")})
 
 (defschema ViceRequestDetails
   {(optional-key :name)
@@ -29,10 +39,11 @@
    (describe Integer "The requested number of concurrently running VICE jobs")})
 
 (defschema ViceRequest
-  {:id              (describe UUID "The request ID")
+  {:id              RequestId
    :request_type    (describe NonBlankString "The name of the request type")
    :requesting_user (describe NonBlankString "The username of the requesting user")
-   :details         (describe ViceRequestDetails "The request details")})
+   :details         (describe ViceRequestDetails "The request details")
+   :updates         (describe [RequestUpdate] "Updates that were made to the request")})
 
 (defschema ViceRequestListing
-  {:requests (describe [ViceRequest] "A listing of VICE access requests")})
+  {:requests (describe [(st/dissoc ViceRequest :updates)] "A listing of VICE access requests")})

--- a/src/terrain/routes/schemas/requests.clj
+++ b/src/terrain/routes/schemas/requests.clj
@@ -13,19 +13,19 @@
    (optional-key :email)
    (describe NonBlankString "The user's email address")
 
-   :intended-use
+   :intended_use
    (describe NonBlankString "The reason for requesting VICE access")
 
-   :funding-award-number
+   :funding_award_number
    (describe NonBlankString "The award number from any relevant funding agency")
 
-   (optional-key :references)
+   :references
    (describe [NonBlankString] "The names of other CyVerse users who can vouch for the user")
 
-   (optional-key :orcid)
+   :orcid
    (describe NonBlankString "The user's ORCID identifier")
 
-   (optional-key :concurrent-jobs)
+   :concurrent_jobs
    (describe Integer "The requested number of concurrently running VICE jobs")})
 
 (defschema ViceRequest

--- a/src/terrain/routes/schemas/requests.clj
+++ b/src/terrain/routes/schemas/requests.clj
@@ -33,6 +33,10 @@
 (defschema RequestListing
   {:requests (describe [(st/dissoc Request :updates)] "A listing of administrative requests")})
 
+(defschema RequestUpdateMessage
+  {(optional-key :message)
+   (describe NonBlankString "The message to store with the request.")})
+
 (defschema ViceRequestDetails
   {(optional-key :name)
    (describe NonBlankString "The user's name")

--- a/src/terrain/routes/schemas/requests.clj
+++ b/src/terrain/routes/schemas/requests.clj
@@ -1,0 +1,38 @@
+(ns terrain.routes.schemas.requests
+  (:use [common-swagger-api.schema :only [describe NonBlankString]]
+        [schema.core :only [defschema enum optional-key]])
+  (:import [java.util UUID]))
+
+(defschema ViceRequestDetails
+  {(optional-key :name)
+   (describe NonBlankString "The user's name")
+
+   :institution
+   (describe NonBlankString "The name of the institution that user works for")
+
+   (optional-key :email)
+   (describe NonBlankString "The user's email address")
+
+   :intended-use
+   (describe NonBlankString "The reason for requesting VICE access")
+
+   :funding-award-number
+   (describe NonBlankString "The award number from any relevant funding agency")
+
+   (optional-key :references)
+   (describe [NonBlankString] "The names of other CyVerse users who can vouch for the user")
+
+   (optional-key :orcid)
+   (describe NonBlankString "The user's ORCID identifier")
+
+   (optional-key :concurrent-jobs)
+   (describe Integer "The requested number of concurrently running VICE jobs")})
+
+(defschema ViceRequest
+  {:id              (describe UUID "The request ID")
+   :request_type    (describe NonBlankString "The name of the request type")
+   :requesting_user (describe NonBlankString "The username of the requesting user")
+   :details         (describe ViceRequestDetails "The request details")})
+
+(defschema ViceRequestListing
+  {:requests (describe [ViceRequest] "A listing of VICE access requests")})

--- a/src/terrain/routes/schemas/requests.clj
+++ b/src/terrain/routes/schemas/requests.clj
@@ -1,10 +1,20 @@
 (ns terrain.routes.schemas.requests
   (:use [common-swagger-api.schema :only [describe NonBlankString]]
-        [schema.core :only [defschema enum optional-key]])
+        [schema.core :only [Any defschema enum optional-key]])
   (:require [schema-tools.core :as st])
   (:import [java.util UUID]))
 
 (def RequestId (describe UUID "The request ID"))
+
+(defschema RequestListingQueryParams
+  {(optional-key :include-completed)
+   (describe Boolean "If set to true, completed requests will be included in the listing")
+
+   (optional-key :request-type)
+   (describe String "If specified, only requests of the selected type will be included in the listing")
+
+   (optional-key :requesting-user)
+   (describe String "If specified, only requests submitted by the selected user will be included in the listing")})
 
 (defschema RequestUpdate
   {:created_date  (describe NonBlankString "The date and time the update occurred")
@@ -12,6 +22,16 @@
    :message       (describe String "The message entered by the person who updated the requst")
    :status        (describe String "The request status code")
    :updating_user (describe String "The username of the person who updated the request")})
+
+(defschema Request
+  {:id              RequestId
+   :request_type    (describe NonBlankString "The name of the request type")
+   :requesting_user (describe NonBlankString "The username of the requesting user")
+   :details         (describe Any "The request details")
+   :updates         (describe [RequestUpdate] "Updates that were made to the request")})
+
+(defschema RequestListing
+  {:requests (describe [(st/dissoc Request :updates)] "A listing of administrative requests")})
 
 (defschema ViceRequestDetails
   {(optional-key :name)
@@ -39,11 +59,8 @@
    (describe Integer "The requested number of concurrently running VICE jobs")})
 
 (defschema ViceRequest
-  {:id              RequestId
-   :request_type    (describe NonBlankString "The name of the request type")
-   :requesting_user (describe NonBlankString "The username of the requesting user")
-   :details         (describe ViceRequestDetails "The request details")
-   :updates         (describe [RequestUpdate] "Updates that were made to the request")})
+  (st/assoc Request
+            :details (describe ViceRequestDetails "The request details")))
 
 (defschema ViceRequestListing
   {:requests (describe [(st/dissoc ViceRequest :updates)] "A listing of VICE access requests")})

--- a/src/terrain/routes/settings.clj
+++ b/src/terrain/routes/settings.clj
@@ -1,0 +1,47 @@
+(ns terrain.routes.settings
+  (:use [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]]
+        [terrain.auth.user-attributes :only [current-user]]
+        [terrain.util :only [optional-routes]])
+  (:require [common-swagger-api.schema.analyses :as analyses-schema]
+            [terrain.clients.analyses :as ac]
+            [terrain.util.config :as config]))
+
+(defn admin-setting-routes
+  "Routes for administering settings."
+  []
+  (optional-routes
+   [#(and (config/admin-routes-enabled) (config/setting-routes-enabled))]
+
+   (context "/settings" []
+     :tags ["admin-settings"]
+
+     (context "/concurrent-job-limits" []
+
+       (GET "/" []
+         :summary analyses-schema/ConcurrentJobLimitListingSummary
+         :return analyses-schema/ConcurrentJobLimits
+         :description analyses-schema/ConcurrentJobLimitListingDescription
+         (ok (ac/list-concurrent-job-limits)))
+
+       (context "/:username" []
+         :path-params [username :- analyses-schema/ConcurrentJobLimitUsername]
+
+         (GET "/" []
+           :summary analyses-schema/ConcurrentJobLimitRetrievalSummary
+           :return analyses-schema/ConcurrentJobLimit
+           :description analyses-schema/ConcurrentJobLimitRetrievalDescription
+           (ok (ac/get-concurrent-job-limit username)))
+
+         (PUT "/" []
+           :summary analyses-schema/ConcurrentJobLimitUpdateSummary
+           :body [body analyses-schema/ConcurrentJobLimitUpdate]
+           :return analyses-schema/ConcurrentJobLimit
+           :description analyses-schema/ConcurrentJobLimitUpdateDescription
+           (ok (ac/set-concurrent-job-limit username (:concurrent_jobs body))))
+
+         (DELETE "/" []
+           :summary analyses-schema/ConcurrentJobLimitRemovalSummary
+           :return analyses-schema/ConcurrentJobLimit
+           :description analyses-schema/ConcurrentJobLimitRemovalDescription
+           (ok (ac/remove-concurrent-job-limit username))))))))

--- a/src/terrain/services/requests.clj
+++ b/src/terrain/services/requests.clj
@@ -1,10 +1,12 @@
 (ns terrain.services.requests
-  (:require [terrain.clients.requests :as rc]))
+  (:require [clojure-commons.exception-util :as cxu]
+            [terrain.clients.requests :as rc]))
 
 ;; Request type constants
 (def vice-request-type "vice")
 
 (defn list-vice-requests
+  "Lists VICE requests. for the currently authenticated user."
   [{username :shortUsername}]
   (rc/list-requests {:request-type    vice-request-type
                      :requesting-user username}))
@@ -16,5 +18,30 @@
          :email email))
 
 (defn submit-vice-request
+  "Submits a VICE request. Details about the currently authenticated user are automatically added to the request."
   [{username :shortUsername :as user} details]
   (rc/submit-request vice-request-type username (add-user-to-request-details user details)))
+
+(defn- get-request
+  "Gets information about a request and verifies that the request type is correct. If the request exists but is of
+   a different type then an exception will be thrown to cause the service endpoint to return a 404."
+  [request-type request-id]
+  (let [request (rc/get-request request-id)]
+    (when-not (= request-type (:request_type request))
+      (cxu/not-found (str request-type " request " request-id " not found")))
+    request))
+
+(def get-vice-request
+  "Gets information about a VICE request. If the request exists but is not a VICE request then an exception will be
+   thrown to cause the service endpoint to return a 404."
+  (partial get-request vice-request-type))
+
+(defn validate-request-user
+  "Verifies that the current user is the person who submitted the request. If the user did not submit the request
+   then an exception will be thrown to cause the service endpoint to return a 404. This is useful in cases where
+   the user is getting information about a request, and we don't want them to be able to obtain information about
+   requests submitted by other users."
+  [{username :shortUsername} {requesting-user :requesting_user request-id :id :as request}]
+  (when-not (= username requesting-user)
+    (cxu/not-found (str "request " request-id " not found")))
+  request)

--- a/src/terrain/services/requests.clj
+++ b/src/terrain/services/requests.clj
@@ -5,6 +5,11 @@
 ;; Request type constants
 (def vice-request-type "vice")
 
+(defn list-requests
+  "Lists requests for administrative endpoints."
+  [params]
+  (rc/list-requests params))
+
 (defn list-vice-requests
   "Lists VICE requests. for the currently authenticated user."
   [{username :shortUsername}]

--- a/src/terrain/services/requests.clj
+++ b/src/terrain/services/requests.clj
@@ -1,0 +1,13 @@
+(ns terrain.services.requests
+  (:use [kameleon.uuids :only [uuid]]))
+
+(defn list-vice-requests
+  [current-user]
+  {:requests []})
+
+(defn submit-vice-request
+  [current-user details]
+  {:id              (uuid)
+   :request_type    "vice"
+   :requesting_user (:shortUsername current-user)
+   :details         details})

--- a/src/terrain/services/requests.clj
+++ b/src/terrain/services/requests.clj
@@ -1,13 +1,20 @@
 (ns terrain.services.requests
-  (:use [kameleon.uuids :only [uuid]]))
+  (:require [terrain.clients.requests :as rc]))
+
+;; Request type constants
+(def vice-request-type "vice")
 
 (defn list-vice-requests
-  [current-user]
-  {:requests []})
+  [{username :shortUsername}]
+  (rc/list-requests {:request-type    vice-request-type
+                     :requesting-user username}))
+
+(defn- add-user-to-request-details
+  [{name :commonName :keys [email]} details]
+  (assoc details
+         :name name
+         :email email))
 
 (defn submit-vice-request
-  [current-user details]
-  {:id              (uuid)
-   :request_type    "vice"
-   :requesting_user (:shortUsername current-user)
-   :details         details})
+  [{username :shortUsername :as user} details]
+  (rc/submit-request vice-request-type username (add-user-to-request-details user details)))

--- a/src/terrain/services/requests.clj
+++ b/src/terrain/services/requests.clj
@@ -1,6 +1,12 @@
 (ns terrain.services.requests
+  (:use [potemkin :only [import-vars]])
   (:require [clojure-commons.exception-util :as cxu]
+            [terrain.clients.analyses :as ac]
             [terrain.clients.requests :as rc]))
+
+(import-vars
+ [terrain.clients.requests
+  get-request])
 
 ;; Request type constants
 (def vice-request-type "vice")
@@ -26,11 +32,6 @@
   "Submits a VICE request. Details about the currently authenticated user are automatically added to the request."
   [{username :shortUsername :as user} details]
   (rc/submit-request vice-request-type username (add-user-to-request-details user details)))
-
-(def get-request
-  "Gets information about a request and verifies that the request type is correct. If the request exists but is of
-   a different type then an exception will be thrown to cause the service endpoint to return a 404."
-  rc/get-request)
 
 (defn- validate-request-type
   "Verifies that a request has the expected type. This is useful for endpoints where the request type is included
@@ -69,3 +70,32 @@
 (def request-rejected
   "Marks a request as having been rejected."
   (request-update-fn "No deinal reason given." "rejected"))
+
+(def mark-request-approved
+  "Marks a request as having been approved."
+  (request-update-fn "Your request has been approved." "complete"))
+
+(defn fulfill-vice-request
+  "Fulfills a request for VICE access by changing the user's limit for the number of cuncurrently running VICE
+   analyses to the requested number."
+  [{username :requesting_user {concurrent-jobs :concurrent_jobs} :details}]
+  (ac/set-concurrent-job-limit username concurrent-jobs))
+
+(def fulfillment-fns
+  "The functions required to fulfill different types of requests."
+  {vice-request-type fulfill-vice-request})
+
+(defn fulfill-request
+  "Performs actions required to fulfill a request. The specific action taken varies depending on the type of
+   request being fulfilled."
+  [{request-type :request_type :as request}]
+  (if-let [fulfillment-fn (fulfillment-fns request-type)]
+    (fulfillment-fn request)
+    (cxu/internal-system-error (str "request type " request-type " is not supported yet"))))
+
+(defn request-approved
+  "Performs actions required to fulfill a request and marks the request as approved."
+  [user request-id message-body]
+  (let [request (get-request request-id)]
+    (fulfill-request request)
+    (mark-request-approved user request-id message-body)))

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -105,6 +105,11 @@
   [props config-valid configs]
   "terrain.routes.search" false)
 
+(cc/defprop-optboolean request-routes-enabled
+  "Enables or disabled routes related to administrative requests."
+  [props config-valid configs]
+  "terrain.routes.requests" true)
+
 (cc/defprop-optboolean coge-enabled
   "Enables or disables COGE endpoints."
   [props config-valid configs]
@@ -113,7 +118,7 @@
 (cc/defprop-optstr iplant-email-base-url
   "The base URL to use when connnecting to the iPlant email service."
   [props config-valid configs app-routes-enabled]
-  "terrain.email.base-url" "http://iplant-email:60000")
+  "terrain.email.base-url" "http://iplant-email")
 
 (cc/defprop-str tool-request-dest-addr
   "The destination email address for tool request messages."
@@ -143,22 +148,22 @@
 (cc/defprop-optstr apps-base-url
   "The base URL to use when connecting to secured Apps services."
   [props config-valid configs app-routes-enabled]
-  "terrain.apps.base-url" "http://apps:60000")
+  "terrain.apps.base-url" "http://apps")
 
 (cc/defprop-optstr metadata-base-url
   "The base URL to use when connecting to the metadata services."
   [props config-valid configs metadata-routes-enabled]
-  "terrain.metadata.base-url" "http://metadata:60000")
+  "terrain.metadata.base-url" "http://metadata")
 
 (cc/defprop-optstr notificationagent-base-url
   "The base URL to use when connecting to the notification agent."
   [props config-valid configs notification-routes-enabled]
-  "terrain.notificationagent.base-url" "http://notification-agent:60000")
+  "terrain.notificationagent.base-url" "http://notification-agent")
 
 (cc/defprop-optstr ipg-base
   "The base URL for the iplant-groups service."
   [props config-valid configs]
-  "terrain.iplant-groups.base-url" "http://iplant-groups:60000")
+  "terrain.iplant-groups.base-url" "http://iplant-groups")
 
 (cc/defprop-optstr grouper-user
   "The administrative user to use for Grouper."
@@ -173,12 +178,17 @@
 (cc/defprop-optstr permissions-base
   "The base URL for the permissions service."
   [props config-valid configs]
-  "terrain.permissions.base-url" "http://permissions:60000")
+  "terrain.permissions.base-url" "http://permissions")
+
+(cc/defprop-optstr requests-base
+  "The base URL for the requests service."
+  [props config-valid configs]
+  "terrain.requests.base-url" "http://requests")
 
 (cc/defprop-optstr jex-base-url
   "The base URL for the JEX."
   [props config-valid configs app-routes-enabled]
-  "terrain.jex.base-url" "http://jex-adapter:60000")
+  "terrain.jex.base-url" "http://jex-adapter")
 
 
 ;;;iRODS connection information
@@ -316,7 +326,7 @@
 (cc/defprop-optstr data-info-base-url
   "The base URL for the data info service."
   [props config-valid configs filesystem-routes-enabled]
-  "terrain.data-info.base-url" "http://data-info:60000")
+  "terrain.data-info.base-url" "http://data-info")
 
 (cc/defprop-optstr es-url
   "The URL for Elastic Search"
@@ -461,22 +471,22 @@
 (cc/defprop-optstr prefs-base-url
   "The hostname of the user-preferences service"
   [props config-valid configs]
-  "terrain.preferences.host" "http://user-preferences:60000")
+  "terrain.preferences.host" "http://user-preferences")
 
 (cc/defprop-optstr search-base-url
   "The hostname of the search service"
   [props config-valid configs]
-  "terrain.search.base-url" "http://search:60000")
+  "terrain.search.base-url" "http://search")
 
 (cc/defprop-optstr sessions-base-url
   "The hostname of the user-sessions service"
   [props config-valid configs]
-  "terrain.sessions.host" "http://user-sessions:60000")
+  "terrain.sessions.host" "http://user-sessions")
 
 (cc/defprop-optstr saved-searches-base-url
   "The base URL of the saved-searches service"
   [props config-valid configs]
-  "terrain.saved-searches.host" "http://saved-searches:60000")
+  "terrain.saved-searches.host" "http://saved-searches")
 
 (cc/defprop-optstr oauth-base-uri
   "The base URI for the OAuth API endpoints."

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -106,9 +106,14 @@
   "terrain.routes.search" false)
 
 (cc/defprop-optboolean request-routes-enabled
-  "Enables or disabled routes related to administrative requests."
+  "Enables or disables routes related to administrative requests."
   [props config-valid configs]
   "terrain.routes.requests" true)
+
+(cc/defprop-optboolean setting-routes-enabled
+  "Enables or disables routes related to user settings."
+  [props config-valid configs]
+  "terrain.routes.settings" true)
 
 (cc/defprop-optboolean coge-enabled
   "Enables or disables COGE endpoints."


### PR DESCRIPTION
This PR adds several routes that can be used to allow users to submit VICE access requests and view the requests that they've submitted. It also adds administrative routes for requests and concurrent job limits.

There's a bit of an inconsistency between the way that the administrative and non-administrative request routes are defined. The non-administrative routes are explicitly defined for each type of request (currently, there's only one type of request: `vice`). The administrative routes are written to handle multiple different types of requests instead. The reason for this is that it's convenient to be able to specify the `detail` fields that are required for each request in the non-administrative endpoints. In the administrative endpoints, the details are never changed, so we can treat the details as mostly opaque and simply display them to administrators who are responding to incoming requests.

Another benefit of allowing administrative endpoints to process multiple types of requests is that it allows us to create a consolidated page in the administrative UI that can be used to process multiple different types of requests. We don't have to have a consolidated page, but I wanted to make it a possibility in case we decide that we want to have one.