### PR TITLE
Ensure limit param gets passed through to backing service

### DIFF
--- a/src/terrain/clients/dashboard_aggregator.clj
+++ b/src/terrain/clients/dashboard_aggregator.clj
@@ -8,11 +8,17 @@
               [terrain.util.config :as config]))
 
 (defn- dashboard-aggregator-url
-  [& parts]
-  (str (apply url (config/dashboard-aggregator-url) parts)))
+  ([limit]
+    (dashboard-aggregator-url [] limit))
+
+  ([components limit]
+    (-> (apply url (config/dashboard-aggregator-url) components)
+        (assoc :query {:limit limit})
+        (str))))
 
 (defn get-dashboard-data
-  ([username]
-    (:body (http/get (dashboard-aggregator-url "users" username) {:as :json})))
-  ([]
-    (:body (http/get (dashboard-aggregator-url) {:as :json}))))
+  ([username {:keys [limit] :or {limit 8}}]
+    (:body (http/get (dashboard-aggregator-url  ["users" username] limit) {:as :json})))
+
+  ([{:keys [limit] :or {limit 8}}]
+    (:body (http/get (dashboard-aggregator-url limit) {:as :json}))))

--- a/src/terrain/routes/dashboard_aggregator.clj
+++ b/src/terrain/routes/dashboard_aggregator.clj
@@ -18,5 +18,5 @@
       :summary "Get data for the dashboard"
       :description "Returns data for populating the dashboard view."
       (ok (if current-user
-        (dcl/get-dashboard-data (:username current-user))
-        (dcl/get-dashboard-data))))))
+        (dcl/get-dashboard-data (:username current-user) params)
+        (dcl/get-dashboard-data params))))))


### PR DESCRIPTION
Refactors the dashboard-aggregator client and route so the limit query parameter gets passed down to the dashboard-aggregator service.

Tested locally, both logged in and logged out. Appears to be working as intended.