### PR TITLE
Add VICE admin UI endpoints to Terrain

### DIFF
--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -16,7 +16,11 @@
   ([components query]
    (-> (apply curl/url (config/app-exposer-base-uri) components)
        (assoc :query (assoc query :user (:shortUsername current-user)))
-       str)))
+       str))
+  ([components query no-user]
+    (-> (apply curl/url (config/app-exposer-base-uri) components)
+        (assoc :query query)
+        str)))
 
 (defn get-pod-logs
   "Returns the logs for a pod"
@@ -36,4 +40,4 @@
 (defn get-resources
   "Calls app-exposer's GET /vice/listing endpoint, with filter as the query filter map."
   [filter]
-  (:body (client/get (app-exposer-url ["vice" "listing"] filter))))
+  (:body (client/get (app-exposer-url ["vice" "listing"] filter true) {:as :json})))

--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -10,16 +10,17 @@
             [terrain.auth.user-attributes :refer [current-user]]))
 
 
+(defn- augment-query
+  [query {:keys [no-user]}]
+  (as-> query q
+    (if no-user q (assoc q :user (:shortUsername current-user)))))
+
 (defn- app-exposer-url
   ([components]
-   (app-exposer-url components {}))
-  ([components query]
-   (-> (apply curl/url (config/app-exposer-base-uri) components)
-       (assoc :query (assoc query :user (:shortUsername current-user)))
-       str))
-  ([components query no-user]
+    (app-exposer-url components {}))
+  ([components query & {:as opts}]
     (-> (apply curl/url (config/app-exposer-base-uri) components)
-        (assoc :query query)
+        (assoc :query (augment-query query opts))
         str)))
 
 (defn get-pod-logs
@@ -40,4 +41,4 @@
 (defn get-resources
   "Calls app-exposer's GET /vice/listing endpoint, with filter as the query filter map."
   [filter]
-  (:body (client/get (app-exposer-url ["vice" "listing"] filter true) {:as :json})))
+  (:body (client/get (app-exposer-url ["vice" "listing"] filter :no-user true) {:as :json})))

--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -32,3 +32,8 @@
   "Calls the endpoint that adds two days to the time limit for a VICE analysis"
   [analysis-id]
   (:body (client/post (app-exposer-url ["vice" analysis-id "time-limit"]) {:as :json})))
+
+(defn get-resources
+  "Calls app-exposer's GET /vice/listing endpoint, with filter as the query filter map."
+  [filter]
+  (:body (client/get (app-exposer-url ["vice" "listing"] filter))))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -47,6 +47,7 @@
         [terrain.routes.comments]
         [terrain.routes.requests]
         [terrain.routes.settings]
+        [terrain.routes.vice]
         [terrain.util :as util]
         [terrain.util.transformers :as transform])
   (:require [clojure.tools.logging :as log]
@@ -160,6 +161,7 @@
    (admin-user-info-routes)
    (admin-request-routes)
    (admin-setting-routes)
+   (admin-vice-routes)
    (route/not-found (service/unrecognized-path-response))))
 
 (defn unsecured-routes
@@ -248,6 +250,7 @@
                                      {:name "admin-tools", :description "Admin Tool Endpoints"}
                                      {:name "admin-tool-requests", :description "Admin Tool Request Endpoints"}
                                      {:name "admin-user-info", :description "User Info Administration Endpoints"}
+                                     {:name "admin-vice", :description "VICE Administration Endpoints"}
                                      {:name "analyses", :description "Analysis Endpoints"}
                                      {:name "analyses-quicklaunches", :description "Quick Launch Endpoints"}
                                      {:name "apps", :description, "Apps Endpoints"}

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -32,13 +32,13 @@
   {:startedAt (describe String "The time the container started running")})
 
 (defschema ContainerStateTerminated
-  {:exitCode    (describe Long "The exit code for the container")
-   (optional-key :signal)      (describe Long "The numerical signal sent to the container process")
-   :reason      (describe (maybe String) "The reason the container terminated")
-   (optional-key :message)     (describe (maybe String) "The message associated with the container termination")
-   :startedAt   (describe String "The time the container started")
-   :finishedAt  (describe String "The time the container finished")
-   :containerID (describe String "The ID of the container")})
+  {:exitCode               (describe Long "The exit code for the container")
+   (optional-key :signal)  (describe Long "The numerical signal sent to the container process")
+   :reason                 (describe (maybe String) "The reason the container terminated")
+   (optional-key :message) (describe (maybe String) "The message associated with the container termination")
+   :startedAt              (describe String "The time the container started")
+   :finishedAt             (describe String "The time the container finished")
+   :containerID            (describe String "The ID of the container")})
 
 (defschema ContainerState
   {(optional-key :waiting)    (describe (maybe ContainerStateWaiting) "The waiting container state")

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -1,0 +1,84 @@
+(ns terrain.routes.schemas.vice
+  (:use [common-swagger-api.schema :only [describe]]
+        [schema.core :only [defschema Any maybe optional-key]])
+  (:import [java.util UUID]))
+
+(defschema BaseListing
+  {:name                      (describe String "The name of the resource")
+   :namespace                 (describe String "The namespace for the resource")
+   :analysisName              (describe String "The name of the analysis the resource is associated with")
+   (optional-key :analysisID) (describe (maybe UUID) "The UUID assigned to the analysis")
+   :appName                   (describe String "The name of the app the resource is associated with")
+   :appID                     (describe UUID "The UUID of the app the resource is associated with")
+   :externalID                (describe UUID "The UUID assigned to the job step")
+   :userID                    (describe UUID "The UUID assigned to the user that launched the analysis")
+   :username                  (describe String "The username of the user that launched the analysis")
+   :creationTimestamp         (describe String "The time the resource was created")})
+
+(defschema Deployment
+  (merge
+    BaseListing
+    {:image   (describe String "The container image name used in the K8s Deployment")
+     :port    (describe Long "The port number the pods in the deployment are listening on")
+     :user    (describe Long "The user ID of the analysis process")
+     :group   (describe Long "The group ID of the analysis process")
+     :command (describe [String] "The command used to start the analysis")}))
+
+(defschema ContainerStateWaiting
+  {:reason  (describe (maybe String) "The reason the container is in the waiting state")
+   :message (describe (maybe String) "The message associated with the waiting state")})
+
+(defschema ContainerStateRunning
+  {:startedAt (describe String "The time the container started running")})
+
+(defschema ContainerStateTerminated
+  {:exitCode    (describe Long "The exit code for the container")
+   :signal      (describe Long "The numerical signal sent to the container process")
+   :reason      (describe (maybe String) "The reason the container terminated")
+   :message     (describe (maybe String) "The message associated with the container termination")
+   :startedAt   (describe String "The time the container started")
+   :finishedAt  (describe String "The time the container finished")
+   :containerID (describe String "The ID of the container")})
+
+(defschema ContainerState
+  {(optional-key :waiting)    (describe (maybe ContainerStateWaiting) "The waiting container state")
+   (optional-key :running)    (describe (maybe ContainerStateRunning) "The running container state")
+   (optional-key :terminated) (describe (maybe ContainerTerminated) "The terminated container state")})
+
+(defschem ContainerStatus
+  {:name         (describe String "The name of the container")
+   :ready        (describe Boolean "Whether or not the container is ready")
+   :restartCount (describe Long "The number of times the container has restarted")
+   :state        (describe ContainerState "The current state of the container")
+   :lastState    (describe ContainerState "The previous state of the container")
+   :image        (describe String "The image name used for the container")
+   :imageID      (describe String "The image ID assocaited with the container")
+   :containerID  (describe String "The ID associated with the container")
+   :started      (describe Boolean "Whether or not the container has started")})
+
+(defschema Pod
+  (merge
+    BaseListing
+    {:phase               (describe String "The pod phase")
+     :message             (describe (maybe String) "The message associated with the current state/phase of the pod")
+     :reason              (describe (maybe String) "The reason the pod is in the phase")
+     :containerStatuses   (describe [ContainerStatus] "The list of container statuses for the pod")
+     :initContainerStatus (describe [ContainerStatus] "The list of container status for the init containers in the pod")}))
+
+(defschema ConfigMap
+  (merge
+    BaseListing
+    {:data (describe Any "The data of the config map")}))
+
+(defschema ServicePort
+  {:name                         (describe String "The name of the port")
+   (optional-key :nodePort)      (describe (maybe Long) "The exposed port on the k8s nodes")
+   (optional-key :targetPort)    (describe (maybe Long) "The target port in the selected pods. Will not be present if targetPortName is set")
+   (optional-key :targetPortName (describe (maybe String) "The name of the target port on the selected pods. Will not be present if targetPort is set"))
+   :port                         (describe Long "The service port")
+   :protocol                     (describe String "The protocol the primary service port supports")})
+
+(defschema Service
+   (merge
+     BaseListing
+     {:ports (describe [ServicePort] "The list of ports open in the service")}))

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -43,9 +43,9 @@
 (defschema ContainerState
   {(optional-key :waiting)    (describe (maybe ContainerStateWaiting) "The waiting container state")
    (optional-key :running)    (describe (maybe ContainerStateRunning) "The running container state")
-   (optional-key :terminated) (describe (maybe ContainerTerminated) "The terminated container state")})
+   (optional-key :terminated) (describe (maybe ContainerStateTerminated) "The terminated container state")})
 
-(defschem ContainerStatus
+(defschema ContainerStatus
   {:name         (describe String "The name of the container")
    :ready        (describe Boolean "Whether or not the container is ready")
    :restartCount (describe Long "The number of times the container has restarted")
@@ -71,14 +71,38 @@
     {:data (describe Any "The data of the config map")}))
 
 (defschema ServicePort
-  {:name                         (describe String "The name of the port")
-   (optional-key :nodePort)      (describe (maybe Long) "The exposed port on the k8s nodes")
-   (optional-key :targetPort)    (describe (maybe Long) "The target port in the selected pods. Will not be present if targetPortName is set")
-   (optional-key :targetPortName (describe (maybe String) "The name of the target port on the selected pods. Will not be present if targetPort is set"))
-   :port                         (describe Long "The service port")
-   :protocol                     (describe String "The protocol the primary service port supports")})
+  {:name                          (describe String "The name of the port")
+   (optional-key :nodePort)       (describe (maybe Long) "The exposed port on the k8s nodes")
+   (optional-key :targetPort)     (describe (maybe Long) "The target port in the selected pods. Will not be present if targetPortName is set")
+   (optional-key :targetPortName) (describe (maybe String) "The name of the target port on the selected pods. Will not be present if targetPort is set")
+   :port                          (describe Long "The service port")
+   :protocol                      (describe String "The protocol the primary service port supports")})
 
 (defschema Service
    (merge
      BaseListing
      {:ports (describe [ServicePort] "The list of ports open in the service")}))
+
+(defschema IngressRule
+  {:host (describe String "The host the rule applies to")
+   :http (describe Any "The content of the rule")}) ; Yes, I got lazy and didn't want to model the entire thing.
+
+(defschema Ingress
+  (merge
+    BaseListing
+    {:rules (describe [IngressRule] "The list of rules making up the Ingress")}))
+
+(defschema FullResourceListing
+  {:deployments (describe [Deployment] "The list of deployments")
+   :pods        (describe [Pod] "The list of pods")
+   :configMaps  (describe [ConfigMap] "The list of config maps")
+   :services    (describe [Service] "The list of services")
+   :ingresses   (describe [Ingress] "The list of ingresses")})
+
+(defschema FilterParams
+  {:analysis-name (describe String "The name of the analysis")
+   :app-id        (describe UUID "The UUID of the running app for the analysis")
+   :app-name      (describe String "The name of the running app for the analysis")
+   :external-id   (describe UUID "The value of the external_id field in the job_steps table. Used widely in the API")
+   :user-id       (describe UUID "The UUID assigned to the user that launched the analysis")
+   :username      (describe String "The user of the user that launched the analysis")})

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -33,9 +33,9 @@
 
 (defschema ContainerStateTerminated
   {:exitCode    (describe Long "The exit code for the container")
-   :signal      (describe Long "The numerical signal sent to the container process")
+   (optional-key :signal)      (describe Long "The numerical signal sent to the container process")
    :reason      (describe (maybe String) "The reason the container terminated")
-   :message     (describe (maybe String) "The message associated with the container termination")
+   (optional-key :message)     (describe (maybe String) "The message associated with the container termination")
    :startedAt   (describe String "The time the container started")
    :finishedAt  (describe String "The time the container finished")
    :containerID (describe String "The ID of the container")})
@@ -54,16 +54,16 @@
    :image        (describe String "The image name used for the container")
    :imageID      (describe String "The image ID assocaited with the container")
    :containerID  (describe String "The ID associated with the container")
-   :started      (describe Boolean "Whether or not the container has started")})
+   (optional-key :started)      (describe Boolean "Whether or not the container has started")})
 
 (defschema Pod
   (merge
     BaseListing
-    {:phase               (describe String "The pod phase")
-     :message             (describe (maybe String) "The message associated with the current state/phase of the pod")
-     :reason              (describe (maybe String) "The reason the pod is in the phase")
-     :containerStatuses   (describe [ContainerStatus] "The list of container statuses for the pod")
-     :initContainerStatus (describe [ContainerStatus] "The list of container status for the init containers in the pod")}))
+    {:phase                 (describe String "The pod phase")
+     :message               (describe (maybe String) "The message associated with the current state/phase of the pod")
+     :reason                (describe (maybe String) "The reason the pod is in the phase")
+     :containerStatuses     (describe [ContainerStatus] "The list of container statuses for the pod")
+     :initContainerStatuses (describe [ContainerStatus] "The list of container status for the init containers in the pod")}))
 
 (defschema ConfigMap
   (merge
@@ -90,7 +90,8 @@
 (defschema Ingress
   (merge
     BaseListing
-    {:rules (describe [IngressRule] "The list of rules making up the Ingress")}))
+    {:rules (describe [IngressRule] "The list of rules making up the Ingress")
+     :defaultBackend (describe String "The default service that accepts ingress requests that match no rules")}))
 
 (defschema FullResourceListing
   {:deployments (describe [Deployment] "The list of deployments")
@@ -100,9 +101,9 @@
    :ingresses   (describe [Ingress] "The list of ingresses")})
 
 (defschema FilterParams
-  {:analysis-name (describe String "The name of the analysis")
-   :app-id        (describe UUID "The UUID of the running app for the analysis")
-   :app-name      (describe String "The name of the running app for the analysis")
-   :external-id   (describe UUID "The value of the external_id field in the job_steps table. Used widely in the API")
-   :user-id       (describe UUID "The UUID assigned to the user that launched the analysis")
-   :username      (describe String "The user of the user that launched the analysis")})
+  {(optional-key :analysis-name) (describe (maybe String) "The name of the analysis")
+   (optional-key :app-id)        (describe (maybe UUID) "The UUID of the running app for the analysis")
+   (optional-key :app-name)      (describe (maybe String) "The name of the running app for the analysis")
+   (optional-key :external-id)   (describe (maybe UUID) "The value of the external_id field in the job_steps table. Used widely in the API")
+   (optional-key :user-id)       (describe (maybe UUID) "The UUID assigned to the user that launched the analysis")
+   (optional-key :username)      (describe (maybe String) "The user of the user that launched the analysis")})

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -1,0 +1,24 @@
+(ns terrain.routes.vice
+  (:use [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]]
+        [terrain.auth.user-attributes :only [current-user]]
+        [terrain.services.user-info]
+        [terrain.util])
+  (:require [terrain.clients.app-exposer :as vice]
+            [terrain.routes.schemas.vice :as vice-schema]
+            [terrain.util.config :as config]))
+
+(defn admin-vice
+  []
+  (optional-routes
+    [config/app-routes-enabled]
+    
+    (context "/vice" []
+      :tags ["vice"]
+      
+      (GET "/resources" []
+        :query [filter vice-schema/FilterParams]
+        :return vice-schema/FullResourceListing
+        :summary "List Kubernetes resources deployed in the cluster"
+        :description "Lists all Kubernetes resources associated with an analysis running in the cluster."
+        (ok (vice/get-resources filter))))))

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -8,13 +8,13 @@
             [terrain.routes.schemas.vice :as vice-schema]
             [terrain.util.config :as config]))
 
-(defn admin-vice
+(defn admin-vice-routes
   []
   (optional-routes
     [config/app-routes-enabled]
     
     (context "/vice" []
-      :tags ["vice"]
+      :tags ["admin-vice"]
       
       (GET "/resources" []
         :query [filter vice-schema/FilterParams]


### PR DESCRIPTION
Adds an admin-only proxy endpoint at /admin/vice/resources in Terrain to app-exposer's /vice/listing endpoint.

By default it will list deployments, services, ingresses, configmaps, and pods for all running VICE analyses in the cluster. You can filter based on different fields, none of which are required.

Right now all of the requests are read-only. Future updates will allow for terminating and possibly editing resources.

