### PR TITLE
Add routes to manage VICE analyses

### DIFF
--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -45,8 +45,8 @@
 
 (defn cancel-analysis
   "Calls app-exposer's POST /vice/{id}/save-and-exit endpoint"
-  [analysis-id]
-  (:body (client/post (app-exposer-url ["vice", analysis-id, "save-and-exit"]) {:as :json})))
+  [external-id]
+  (:body (client/post (app-exposer-url ["vice", external-id, "save-and-exit"]) {:as :json})))
 
 (defn readiness
   "Calls app-exposer's GET /vice/{subdomain}/url-ready endpoint"

--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -42,3 +42,13 @@
   "Calls app-exposer's GET /vice/listing endpoint, with filter as the query filter map."
   [filter]
   (:body (client/get (app-exposer-url ["vice" "listing"] filter :no-user true) {:as :json})))
+
+(defn cancel-analysis
+  "Calls app-exposer's POST /vice/{id}/save-and-exit endpoint"
+  [analysis-id]
+  (:body (client/post (app-exposer-url ["vice", analysis-id, "save-and-exit"]) {:as :json})))
+
+(defn readiness
+  "Calls app-exposer's GET /vice/{subdomain}/url-ready endpoint"
+  [subdomain]
+  (:body (client/get (app-exposer-url ["vice", subdomain, "url-ready"]) {:as :json})))

--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -52,3 +52,9 @@
   "Calls app-exposer's GET /vice/{subdomain}/url-ready endpoint"
   [subdomain]
   (:body (client/get (app-exposer-url ["vice", subdomain, "url-ready"]) {:as :json})))
+
+(defn async-data
+  "Calls app-exposer's GET /vice/async-data endpoint"
+  [external-id]
+  (:body (client/get (app-exposer-url ["vice" "async-data"] {:external-id external-id}) {:as :json})))
+

--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -30,13 +30,13 @@
 
 (defn get-time-limit
   "Returns the time limit for a VICE analysis"
-  [analysis-id]
-  (:body (client/get (app-exposer-url ["vice" analysis-id "time-limit"]) {:as :json})))
+  [analysis-id user]
+  (:body (client/get (app-exposer-url ["vice" analysis-id "time-limit"] {:user user} :no-user true) {:as :json})))
 
 (defn set-time-limit
   "Calls the endpoint that adds two days to the time limit for a VICE analysis"
-  [analysis-id]
-  (:body (client/post (app-exposer-url ["vice" analysis-id "time-limit"]) {:as :json})))
+  [analysis-id user]
+  (:body (client/post (app-exposer-url ["vice" analysis-id "time-limit"] {:user user} :no-user true) {:as :json})))
 
 (defn get-resources
   "Calls app-exposer's GET /vice/listing endpoint, with filter as the query filter map."
@@ -55,6 +55,6 @@
 
 (defn async-data
   "Calls app-exposer's GET /vice/async-data endpoint"
-  [external-id]
-  (:body (client/get (app-exposer-url ["vice" "async-data"] {:external-id external-id}) {:as :json})))
+  [query]
+  (:body (client/get (app-exposer-url ["vice" "async-data"] query) {:as :json})))
 

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -1,7 +1,10 @@
 (ns terrain.routes.schemas.vice
-  (:use [common-swagger-api.schema :only [describe]]
+  (:use [common-swagger-api.schema :only [describe NonBlankString]]
         [schema.core :only [defschema Any maybe optional-key]])
   (:import [java.util UUID]))
+
+(def AnalysisID (describe UUID "The UUID assigned to the analysis"))
+(def Subdomain (describe NonBlankString "The subdomain assigned to the analysis"))
 
 (defschema BaseListing
   {:name                      (describe String "The name of the resource")

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -7,6 +7,9 @@
 (def Subdomain (describe NonBlankString "The subdomain assigned to the analysis"))
 (def ExternalID (describe NonBlankString "The external ID assigned to the analysis step"))
 
+(defschema AsyncDataParams
+  {:external-id (describe ExternalID "The external ID assigned to the analysis step")})
+
 (defschema AsyncData
   {:analysisID (describe (maybe AnalysisID) "The UUID assigned to the analysis")
    :ipAddr     (describe (maybe String) "The IP address of the user that launched the analysis")

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -5,6 +5,12 @@
 
 (def AnalysisID (describe UUID "The UUID assigned to the analysis"))
 (def Subdomain (describe NonBlankString "The subdomain assigned to the analysis"))
+(def ExternalID (describe NonBlankString "The external ID assigned to the analysis step"))
+
+(defschema AsyncData
+  {:analysisID (describe (maybe AnalysisID) "The UUID assigned to the analysis")
+   :ipAddr     (describe (maybe String) "The IP address of the user that launched the analysis")
+   :subdomain  (describe (maybe Subdomain) "The subdomain assigned to the VICE analysis")})
 
 (defschema BaseListing
   {:name                      (describe String "The name of the resource")

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -10,6 +10,12 @@
 (defschema AsyncDataParams
   {:external-id (describe ExternalID "The external ID assigned to the analysis step")})
 
+(defschema TimeLimitQueryParams
+  {:user (describe NonBlankString "The username for the user that started the analysis, not the logged in user")})
+
+(defschema TimeLimit
+  {:time_limit (describe (maybe String) "The scheduled end date as seconds since the epoch")})
+
 (defschema AsyncData
   {:analysisID (describe (maybe AnalysisID) "The UUID assigned to the analysis")
    :ipAddr     (describe (maybe String) "The IP address of the user that launched the analysis")

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -22,6 +22,13 @@
         :summary "List Kubernetes resources deployed in the cluster"
         :description "Lists all Kubernetes resources associated with an analysis running in the cluster."
         (ok (vice/get-resources filter)))
+
+      (GET "/async-data" []
+        :query [external-id :- vice-schema/ExternalID]
+        :return vice-schema/AsyncData
+        :summary "Get data that is generated asynchronously"
+        :description "Get data for a VICE analysis that is generated asynchronously. The call itself is synchronous"
+        (ok (vice/async-data external-id)))
       
       (DELETE "/analyses/:analysis-id" []
         :path-params [analysis-id :- vice-schema/AnalysisID]

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -30,7 +30,7 @@
         :description "Get data for the VICE analysis that is generated asynchronously"
         (ok (vice/async-data params)))
       
-      (DELETE "/analyses/:analysis-id" []
+      (DELETE "/analyses/:external-id" []
         :path-params [external-id :- vice-schema/ExternalID]
         :summary "Cancel VICE analysis, send outputs to data store"
         :description "Cancels the VICE analysis after triggering the transfers of the output to the data store and waiting for them to complete"

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -28,7 +28,7 @@
         :return vice-schema/AsyncData
         :summary "Get data that is generated asynchronously"
         :description "Get data for the VICE analysis that is generated asynchronously"
-        (ok (vice/async-data (:external-id params))))
+        (ok (vice/async-data params)))
       
       (DELETE "/analyses/:analysis-id" []
         :path-params [analysis-id :- vice-schema/AnalysisID]
@@ -38,13 +38,17 @@
       
       (GET "/analyses/:analysis-id/time-limit" []
         :path-params [analysis-id :- vice-schema/AnalysisID]
+        :query [params vice-schema/TimeLimitQueryParams]
+        :return vice-schema/TimeLimit
         :summary "Get current time limit"
         :description "Gets the current time limit set for the analysis"
-        (ok (vice/get-time-limit analysis-id)))
+        (ok (vice/get-time-limit analysis-id (:user params))))
         
       (POST "/analyses/:analysis-id/time-limit" []
         :path-params [analysis-id :- vice-schema/AnalysisID]
+        :query [params vice-schema/TimeLimitQueryParams]
+        :return vice-schema/TimeLimit
         :summary "Extend the time limit"
         :description "Extends the time limit for the analysis by 3 days"
-        (ok (vice/set-time-limit analysis-id))))))
+        (ok (vice/set-time-limit analysis-id (:user params)))))))
 

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -21,4 +21,23 @@
         :return vice-schema/FullResourceListing
         :summary "List Kubernetes resources deployed in the cluster"
         :description "Lists all Kubernetes resources associated with an analysis running in the cluster."
-        (ok (vice/get-resources filter))))))
+        (ok (vice/get-resources filter)))
+      
+      (DELETE "/analyses/:analysis-id" []
+        :path-params [analysis-id :- vice-schema/AnalysisID]
+        :summary "Cancel VICE analysis, send outputs to data store"
+        :description "Cancels the VICE analysis after triggering the transfers of the output to the data store and waiting for them to complete"
+        (ok (vice/cancel-analysis analysis-id)))
+      
+      (GET "/analyses/:analysis-id/time-limit" []
+        :path-params [analysis-id :- vice-schema/AnalysisID]
+        :summary "Get current time limit"
+        :description "Gets the current time limit set for the analysis"
+        (ok (vice/get-time-limit analysis-id)))
+        
+      (POST "/analyses/:analysis-id/time-limit" []
+        :path-params [analysis-id :- vice-schema/AnalysisID]
+        :summary "Extend the time limit"
+        :description "Extends the time limit for the analysis by 3 days"
+        (ok (vice/set-time-limit analysis-id))))))
+

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -24,11 +24,11 @@
         (ok (vice/get-resources filter)))
 
       (GET "/async-data" []
-        :query [external-id :- vice-schema/ExternalID]
+        :query [params vice-schema/AsyncDataParams]
         :return vice-schema/AsyncData
         :summary "Get data that is generated asynchronously"
-        :description "Get data for a VICE analysis that is generated asynchronously. The call itself is synchronous"
-        (ok (vice/async-data external-id)))
+        :description "Get data for the VICE analysis that is generated asynchronously"
+        (ok (vice/async-data (:external-id params))))
       
       (DELETE "/analyses/:analysis-id" []
         :path-params [analysis-id :- vice-schema/AnalysisID]

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -31,10 +31,10 @@
         (ok (vice/async-data params)))
       
       (DELETE "/analyses/:analysis-id" []
-        :path-params [analysis-id :- vice-schema/AnalysisID]
+        :path-params [external-id :- vice-schema/ExternalID]
         :summary "Cancel VICE analysis, send outputs to data store"
         :description "Cancels the VICE analysis after triggering the transfers of the output to the data store and waiting for them to complete"
-        (ok (vice/cancel-analysis analysis-id)))
+        (ok (vice/cancel-analysis external-id)))
       
       (GET "/analyses/:analysis-id/time-limit" []
         :path-params [analysis-id :- vice-schema/AnalysisID]


### PR DESCRIPTION
Adds administrative endpoints for managing VICE analyses. Provides endpoints for getting and extending the time limit, triggering save-and-exit, and getting async data (IP addr, Analysis UUID, and subdomain).

These differ from the existing endpoints in that they require the logged in user to have administrative permissions and allows them to perform operations on VICE analyses submitted by normal users.