### PR TITLE
Fix arity errors in the time limit endpoints

### DIFF
--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -30,13 +30,13 @@
 
 (defn get-time-limit
   "Returns the time limit for a VICE analysis"
-  [analysis-id user]
-  (:body (client/get (app-exposer-url ["vice" analysis-id "time-limit"] {:user user} :no-user true) {:as :json})))
+  [analysis-id]
+  (:body (client/get (app-exposer-url ["vice" analysis-id "time-limit"]) {:as :json})))
 
 (defn set-time-limit
   "Calls the endpoint that adds two days to the time limit for a VICE analysis"
-  [analysis-id user]
-  (:body (client/post (app-exposer-url ["vice" analysis-id "time-limit"] {:user user} :no-user true) {:as :json})))
+  [analysis-id]
+  (:body (client/post (app-exposer-url ["vice" analysis-id "time-limit"]) {:as :json})))
 
 (defn get-resources
   "Calls app-exposer's GET /vice/listing endpoint, with filter as the query filter map."

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -42,7 +42,7 @@
         :return vice-schema/TimeLimit
         :summary "Get current time limit"
         :description "Gets the current time limit set for the analysis"
-        (ok (vice/get-time-limit analysis-id (:user params))))
+        (ok (vice/get-time-limit analysis-id)))
         
       (POST "/analyses/:analysis-id/time-limit" []
         :path-params [analysis-id :- vice-schema/AnalysisID]
@@ -50,5 +50,5 @@
         :return vice-schema/TimeLimit
         :summary "Extend the time limit"
         :description "Extends the time limit for the analysis by 3 days"
-        (ok (vice/set-time-limit analysis-id (:user params)))))))
+        (ok (vice/set-time-limit analysis-id))))))
 


### PR DESCRIPTION
When I modified the time-limit endpoints (non-admin), I accidentally broke them by attempting to manually set the username in the requests, rather than just using the shortUsername of the logged in user. This resulted in errors popping up in QA. This PR should fix them.