### PR TITLE
Add new VICE admin endpoints

### DIFF
--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -81,7 +81,7 @@
 (defn admin-exit
   "Forces the analysis to exit without transferring output files"
   [analysis-id]
-  (:body (client/get (app-exposer-url ["vice" "admin" "analyses" analysis-id "exit"] {} :no-user true) {:as :json})))
+  (:body (client/post (app-exposer-url ["vice" "admin" "analyses" analysis-id "exit"] {} :no-user true) {:as :json})))
 
 (defn admin-save-output-files
   "Tells the vice-transfer-files tool to transfer outputs without terminating the analysis"

--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -33,10 +33,20 @@
   [analysis-id]
   (:body (client/get (app-exposer-url ["vice" analysis-id "time-limit"]) {:as :json})))
 
+(defn admin-get-time-limit
+  "Same as (get-time-limit), just with no user info and a different path"
+  [analysis-id]
+  (:body (client/get (app-exposer-url ["vice" "admin" "analyses" analysis-id "time-limit"] {} :no-user true) {:as :json})))
+
 (defn set-time-limit
   "Calls the endpoint that adds two days to the time limit for a VICE analysis"
   [analysis-id]
   (:body (client/post (app-exposer-url ["vice" analysis-id "time-limit"]) {:as :json})))
+
+(defn admin-set-time-limit
+  "Same as (set-time-limit), just with no user info and a different path"
+  [analysis-id]
+  (:body (client/post (app-exposer-url ["vice" "admin" "analyses" analysis-id "time-limit"] {} :no-user true) {:as :json})))
 
 (defn get-resources
   "Calls app-exposer's GET /vice/listing endpoint, with filter as the query filter map."
@@ -48,6 +58,11 @@
   [external-id]
   (:body (client/post (app-exposer-url ["vice", external-id, "save-and-exit"]) {:as :json})))
 
+(defn admin-cancel-analysis
+  "Same as (cancel-analysis), just with no user info and a different path and accepts the analysis-id"
+  [analysis-id]
+  (:body (client/post (app-exposer-url ["vice" "admin" "analyses" analysis-id "save-and-exit"] {} :no-user true) {:as :json})))
+
 (defn readiness
   "Calls app-exposer's GET /vice/{subdomain}/url-ready endpoint"
   [subdomain]
@@ -58,3 +73,22 @@
   [query]
   (:body (client/get (app-exposer-url ["vice" "async-data"] query) {:as :json})))
 
+(defn admin-external-id
+  "Gets the external-id for the provided analysis-id. VICE analyses only have a single external-id"
+  [analysis-id]
+  (:body (client/get (app-exposer-url ["vice" "admin" "analyses" analysis-id "external-id"] {} :no-user true) {:as :json})))
+
+(defn admin-exit
+  "Forces the analysis to exit without transferring output files"
+  [analysis-id]
+  (:body (client/get (app-exposer-url ["vice" "admin" "analyses" analysis-id "exit"] {} :no-user true) {:as :json})))
+
+(defn admin-save-output-files
+  "Tells the vice-transfer-files tool to transfer outputs without terminating the analysis"
+  [analysis-id]
+  (:body (client/post (app-exposer-url ["vice" "admin" "analyses" analysis-id "save-output-files"] {} :no-user true) {:as :json})))
+
+(defn admin-download-input-files
+  "Tells the vice-transfer-files tool to download inputs without affecting the analysis status"
+  [analysis-id]
+  (:body (client/post (app-exposer-url ["vice" "admin" "analyses" analysis-id "download-input-files"] {} :no-user true) {:as :json})))

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -16,6 +16,9 @@
 (defschema TimeLimit
   {:time_limit (describe (maybe String) "The scheduled end date as seconds since the epoch")})
 
+(defschema ExternalIDResponse
+  {:externalID (describe ExternalID "The single external ID associated with the VICE analysis")})
+
 (defschema AsyncData
   {:analysisID (describe (maybe AnalysisID) "The UUID assigned to the analysis")
    :ipAddr     (describe (maybe String) "The IP address of the user that launched the analysis")

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -66,5 +66,12 @@
         :path-params [analysis-id :- vice-schema/AnalysisID]
         :summary "Download input files"
         :description "Downloads input files to the analysis container without changing the status of the analysis"
-        (ok (vice/admin-download-input-files analysis-id))))))
+        (ok (vice/admin-download-input-files analysis-id)))
+        
+      (GET "/analyses/:analysis-id/external-id" []
+        :path-params [analysis-id :- vice-schema/AnalysisID]
+        :return vice-schema/ExternalIDResponse
+        :summary "Get external UUID"
+        :description "Returns the external UUID associated with the analysis. VICE analyses only have a single external UUID"
+        (ok (vice/admin-external-id analysis-id))))))
 

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -30,25 +30,41 @@
         :description "Get data for the VICE analysis that is generated asynchronously"
         (ok (vice/async-data params)))
       
-      (DELETE "/analyses/:external-id" []
-        :path-params [external-id :- vice-schema/ExternalID]
-        :summary "Cancel VICE analysis, send outputs to data store"
-        :description "Cancels the VICE analysis after triggering the transfers of the output to the data store and waiting for them to complete"
-        (ok (vice/cancel-analysis external-id)))
-      
       (GET "/analyses/:analysis-id/time-limit" []
         :path-params [analysis-id :- vice-schema/AnalysisID]
-        :query [params vice-schema/TimeLimitQueryParams]
         :return vice-schema/TimeLimit
         :summary "Get current time limit"
         :description "Gets the current time limit set for the analysis"
-        (ok (vice/get-time-limit analysis-id)))
+        (ok (vice/admin-get-time-limit analysis-id)))
         
       (POST "/analyses/:analysis-id/time-limit" []
         :path-params [analysis-id :- vice-schema/AnalysisID]
-        :query [params vice-schema/TimeLimitQueryParams]
         :return vice-schema/TimeLimit
         :summary "Extend the time limit"
         :description "Extends the time limit for the analysis by 3 days"
-        (ok (vice/set-time-limit analysis-id))))))
+        (ok (vice/admin-set-time-limit analysis-id)))
+        
+      (POST "/analyses/:analysis-id/save-and-exit" []
+        :path-params [analysis-id :- vice-schema/AnalysisID]
+        :summary "Upload outputs and exit"
+        :description "Terminates the analysis after uploading the output files to the data store"
+        (ok (vice/admin-cancel-analysis analysis-id)))
+      
+      (POST "/analyses/:analysis-id/exit" []
+        :path-params [analysis-id :- vice-schema/AnalysisID]
+        :summary "Exit without saving"
+        :description "Terminates the analysis without uploading files to the data store"
+        (ok (vice/admin-exit analysis-id)))
+      
+      (POST "/analyses/:analysis-id/save-output-files" []
+        :path-params [analysis-id :- vice-schema/AnalysisID]
+        :summary "Upload files without exiting"
+        :description "Uploads output files for the analysis to the data store without terminating the analysis"
+        (ok (vice/admin-save-output-files analysis-id)))
+      
+      (POST "/analyses/:analysis-id/download-input-files" []
+        :path-params [analysis-id :- vice-schema/AnalysisID]
+        :summary "Download input files"
+        :description "Downloads input files to the analysis container without changing the status of the analysis"
+        (ok (vice/admin-download-input-files analysis-id))))))
 


### PR DESCRIPTION
This PR changes the VICE time-limit endpoints to use the new admin versions in app-exposer (which takes the analysisID instead of the externalID) along with adding the following VICE admin endpoints
* POST /vice/analyses/:analysisID/save-and-exit
* POST /vice/analyses/:analysisID/exit
* POST /vice/analyses/:analysisID/save-output-files
* POST /vice/analyses/:analysisID/download-input-files
* GET /vice/analyses/:analysisID/external-id
