### PR TITLE
Make :containerID and :message fields optional

### DIFF
--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -46,12 +46,12 @@
      :command (describe [String] "The command used to start the analysis")}))
 
 (defschema ContainerStateWaiting
-  {:reason  (describe (maybe String) "The reason the container is in the waiting state")
-   :message (describe (maybe String) "The message associated with the waiting state")})
+  {:reason                 (describe (maybe String) "The reason the container is in the waiting state")
+   (optional-key :message) (describe (maybe String) "The message associated with the waiting state")})
 
 (defschema ContainerStateRunning
   {:startedAt (describe String "The time the container started running")})
-
+      
 (defschema ContainerStateTerminated
   {:exitCode               (describe Long "The exit code for the container")
    (optional-key :signal)  (describe Long "The numerical signal sent to the container process")
@@ -67,15 +67,15 @@
    (optional-key :terminated) (describe (maybe ContainerStateTerminated) "The terminated container state")})
 
 (defschema ContainerStatus
-  {:name         (describe String "The name of the container")
-   :ready        (describe Boolean "Whether or not the container is ready")
-   :restartCount (describe Long "The number of times the container has restarted")
-   :state        (describe ContainerState "The current state of the container")
-   :lastState    (describe ContainerState "The previous state of the container")
-   :image        (describe String "The image name used for the container")
-   :imageID      (describe String "The image ID assocaited with the container")
-   :containerID  (describe String "The ID associated with the container")
-   (optional-key :started)      (describe Boolean "Whether or not the container has started")})
+  {:name                       (describe String "The name of the container")
+   :ready                      (describe Boolean "Whether or not the container is ready")
+   :restartCount               (describe Long "The number of times the container has restarted")
+   :state                      (describe ContainerState "The current state of the container")
+   :lastState                  (describe ContainerState "The previous state of the container")
+   :image                      (describe String "The image name used for the container")
+   :imageID                    (describe String "The image ID assocaited with the container")
+   (optional-key :containerID) (describe String "The ID associated with the container")
+   (optional-key :started)     (describe Boolean "Whether or not the container has started")})
 
 (defschema Pod
   (merge


### PR DESCRIPTION
A couple of the fields in the VICE schema cause issues in the admin UI when they're not optional. This PR should fix that.