### PR TITLE
CORE-1027: allow administrators to impersonate users for troubleshooting

### DIFF
--- a/resources/docs/get-admin-token.md
+++ b/resources/docs/get-admin-token.md
@@ -1,0 +1,27 @@
+This service allows administrative users to obtain an impersonation token in order to act on behalf of another
+user. This feature is useful for troubleshooting in cases where a user is seeing a problem that the administrator can't
+reproduce. You must be logged in using HTTP basic authorization to use this endpoint. The token endpoints are the only
+endpoints that use basic authorization. To log in, click the Authorize button above, enter your username and password
+under `Basic authentication`, and click the Authorize button underneath the password text box.
+
+Once you have the access token, you can use it to authorize calls to other endpoints in the Swagger UI.  First, remove
+the basic authentication credentials by clicking the Authorize button above and clicking the Logout button in the `Basic
+authenitcation` section of authorization window. Second, click the Authorization button again and type the word `Bearer`
+followed by a single space in the Value text box of the `Api key authorization` section of the window. Paste in the
+access token from this endpoint's response body then click the Authorize button underneath the Value text box.
+
+You can use `curl` and `jq`, which is available from [the jq web site](https://stedolan.github.io/jq/), to obtain an
+access token from the command line. The easiest way to do this on Unix-like operating systems is to define an
+environment variable containing the authorization header:
+
+```
+export AUTH_HEADER=\"Authorization: Bearer $(curl -su username https://de.cyverse.org/terrain/admin/token?username=foo \
+    | jq -r .access_token)\"
+```
+
+Once you have the authorization header stored in an environment variable, you can include it in calls to other Terrain
+endpoints:
+
+```
+curl -sH \"$AUTH_HEADER\" \"https://de.cyverse.org/terrain/apps?search=word\"
+```

--- a/resources/docs/get-token.md
+++ b/resources/docs/get-token.md
@@ -1,7 +1,7 @@
-This service allows users to obtain OAuth tokens for accessing other API endpoints. You must be logged in using HTTP
-basic authorization to use this endpoint. This is the only endpoint that uses basic authorization. To log in, click the
-Authorize button above, enter your username and password under `Basic authentication`, and click the Authorize button
-underneath the password text box.
+This service allows users to obtain OAuth or OIDC tokens for accessing other API endpoints. You must be logged in using
+HTTP basic authorization to use this endpoint. The token endpoints are the only endpoints that use basic
+authorization. To log in, click the Authorize button above, enter your username and password under `Basic
+authentication`, and click the Authorize button underneath the password text box.
 
 Once you have the access token, you can use it to authorize calls to other endpoints in the Swagger UI.  First, remove
 the basic authentication credentials by clicking the Authorize button above and clicking the Logout button in the `Basic

--- a/src/terrain/clients/keycloak.clj
+++ b/src/terrain/clients/keycloak.clj
@@ -26,3 +26,15 @@
                                    :username      username
                                    :password      password}
                      :as          :json})))
+
+(defn get-impersonation-token
+  "Obtains an impersonation token for troubleshooting purposes."
+  [subject-token username]
+  (:body (http/post (keycloak-url "protocol" "openid-connect" "token")
+                    {:form-params {:grant_type           "urn:ietf:params:oauth:grant-type:token-exchange"
+                                   :client_id            (config/keycloak-client-id)
+                                   :client_secret        (config/keycloak-client-secret)
+                                   :subject_token        subject-token
+                                   :requested_token_type "urn:ietf:params:oauth:token-type:access_token"
+                                   :requested_subject    username}
+                     :as          :json})))

--- a/src/terrain/clients/keycloak.clj
+++ b/src/terrain/clients/keycloak.clj
@@ -6,7 +6,7 @@
 (defn- keycloak-url
   "Builds a Keycloak URL with the given path components."
   [& components]
-  (str (apply curl/url (config/keycloak-base-uri) "auth" "realms" (config/keycloak-realm) components)))
+  (str (apply curl/url (config/keycloak-base-uri) "realms" (config/keycloak-realm) components)))
 
 (defn get-oidc-certs
   "Retrieves a list of active public certificates from Keycloak."
@@ -15,3 +15,14 @@
                 {:as :json})
       :body
       :keys))
+
+(defn get-token
+  "Obtains an authorization token."
+  [username password]
+  (:body (http/post (keycloak-url "protocol" "openid-connect" "token")
+                    {:form-params {:grant_type    "password"
+                                   :client_id     (config/keycloak-client-id)
+                                   :client_secret (config/keycloak-client-secret)
+                                   :username      username
+                                   :password      password}
+                     :as          :json})))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -167,6 +167,7 @@
 (defn unsecured-routes
   []
   (util/flagged-routes
+   (admin-token-routes)
    (token-routes)
    (unsecured-misc-routes)
    (unsecured-notification-routes)))
@@ -247,6 +248,7 @@
                                      {:name "admin-reference-genomes", :description "Admin Reference Genome Endpoints"}
                                      {:name "admin-requests", :description "Admin Request Endpoints"}
                                      {:name "admin-settings", :description "Admin Setting Endpoints"}
+                                     {:name "admin-token", :description "Admin OAuth Tokens"}
                                      {:name "admin-tools", :description "Admin Tool Endpoints"}
                                      {:name "admin-tool-requests", :description "Admin Tool Request Endpoints"}
                                      {:name "admin-user-info", :description "User Info Administration Endpoints"}

--- a/src/terrain/routes/schemas/token.clj
+++ b/src/terrain/routes/schemas/token.clj
@@ -1,7 +1,28 @@
 (ns terrain.routes.schemas.token
   (:use [common-swagger-api.schema :only [describe]]
-        [schema.core :only [defschema]]))
+        [schema.core :only [defschema optional-key]]))
 
 (defschema AccessTokenResponse
-  {:access_token (describe String "The access token")
-   :expires_in   (describe String "The lifetime of the token in seconds")})
+  {:access_token
+   (describe String "The access token")
+
+   :expires_in
+   (describe Integer "The lifetime of the token in seconds")
+
+   (optional-key :refresh_expires_in)
+   (describe Integer "The lifetime of the refresh token in seconds")
+
+   (optional-key :refresh_token)
+   (describe String "The refresh token")
+
+   (optional-key :token_type)
+   (describe String "The type of the access token")
+
+   (optional-key :not-before-policy)
+   (describe Integer "The number of seconds before the token can be used")
+
+   (optional-key :session_state)
+   (describe String "A string representing the login state of the user")
+
+   (optional-key :scope)
+   (describe String "The scopes granted to the access token")})

--- a/src/terrain/routes/schemas/token.clj
+++ b/src/terrain/routes/schemas/token.clj
@@ -26,3 +26,6 @@
 
    (optional-key :scope)
    (describe String "The scopes granted to the access token")})
+
+(defschema AdminKeycloakTokenParams
+  {:username (describe String "The username of the person to impersonate")})

--- a/src/terrain/routes/token.clj
+++ b/src/terrain/routes/token.clj
@@ -27,3 +27,23 @@
        :return AccessTokenResponse
        :description-file "docs/get-token.md"
        (oauth/get-keycloak-token authorization)))))
+
+(defn admin-token-routes
+  []
+  (routes
+   (context "/admin/token" []
+     :tags ["admin-token"]
+
+     (GET "/" [:as {{:strs [authorization]} :headers}]
+       :query [{:keys [username]} AdminKeycloakTokenParams]
+       :summary "Obtain Impersonation Tokens"
+       :return AccessTokenResponse
+       :description-file "docs/get-admin-token.md"
+       (oauth/get-admin-token authorization username))
+
+     (GET "/keycloak" [:as {{:strs [authorization]} :headers}]
+       :query [{:keys [username]} AdminKeycloakTokenParams]
+       :summary "Obtain Keycloak OIDC Impersonation Tokens"
+       :return AccessTokenResponse
+       :description-file "docs/get-admin-token.md"
+       (oauth/get-keycloak-admin-token authorization username)))))

--- a/src/terrain/routes/token.clj
+++ b/src/terrain/routes/token.clj
@@ -1,7 +1,7 @@
 (ns terrain.routes.token
   (:use [common-swagger-api.schema :only [context routes GET]]
         [terrain.routes.schemas.token]
-        [terrain.services.oauth :only [get-token]])
+        [terrain.services.oauth :as oauth])
   (:require [common-swagger-api.routes]))                   ;; Required for :description-file
 
 (defn token-routes
@@ -14,4 +14,16 @@
        :summary "Obtain OAuth Tokens"
        :return AccessTokenResponse
        :description-file "docs/get-token.md"
-       (get-token authorization)))))
+       (oauth/get-token authorization))
+
+     (GET "/cas" [:as {{:strs [authorization]} :headers}]
+       :summary "Obtain OAuth Tokens"
+       :return AccessTokenResponse
+       :description-file "docs/get-token.md"
+       (oauth/get-cas-token authorization))
+
+     (GET "/keycloak" [:as {{:strs [authorization]} :headers}]
+       :summary "Obtain Keycloak OIDC Tokens"
+       :return AccessTokenResponse
+       :description-file "docs/get-token.md"
+       (oauth/get-keycloak-token authorization)))))

--- a/src/terrain/services/oauth.clj
+++ b/src/terrain/services/oauth.clj
@@ -2,6 +2,7 @@
   (:require [clojure.data.codec.base64 :as base64]
             [clojure.string :as string]
             [ring.util.http-response :as http-response]
+            [terrain.clients.keycloak :as keycloak]
             [terrain.clients.oauth :as client]
             [terrain.util.service :as service]))
 
@@ -14,7 +15,15 @@
               (String.)
               (string/split #":" 2)))))
 
-(defn get-token [authorization]
+(defn get-cas-token [authorization]
   (if-let [[username password] (get-basic-auth-credentials authorization)]
-    (http-response/ok (client/get-token username password))
+    (http-response/ok (update (client/get-token username password) :expires_in #(Integer/parseInt %)))
     (http-response/unauthorized)))
+
+(defn get-keycloak-token [authorization]
+  (if-let [[username password] (get-basic-auth-credentials authorization)]
+    (http-response/ok (keycloak/get-token username password))
+    (http-response/unauthorized)))
+
+;; Make CAS the default identity provider for now.
+(def get-token get-cas-token)

--- a/src/terrain/services/oauth.clj
+++ b/src/terrain/services/oauth.clj
@@ -25,5 +25,15 @@
     (http-response/ok (keycloak/get-token username password))
     (http-response/unauthorized)))
 
-;; Make CAS the default identity provider for now.
+;; Make CAS the default identity provider for standard tokens for now.
 (def get-token get-cas-token)
+
+(defn get-keycloak-admin-token [authorization username]
+  (if-let [[username password] (get-basic-auth-credentials authorization)]
+    (http-response/ok (-> (keycloak/get-token username password)
+                          :access_token
+                          (keycloak/get-impersonation-token username)))
+    (http-response/unauthorized)))
+
+;; Make Keycloak the default identity provider for impersonation tokens.
+(def get-admin-token get-keycloak-admin-token)

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -521,12 +521,22 @@
 (cc/defprop-optstr keycloak-base-uri
   "The base URI for the Keycloak server."
   [props config-valid configs]
-  "terrain.keycloak.base-uri" "https://kc.cyverse.org")
+  "terrain.keycloak.base-uri" "https://kc.cyverse.org/auth")
 
 (cc/defprop-optstr keycloak-realm
   "The Keycloak realm to use."
   [props config-valid configs]
   "terrain.keycloak.realm" "CyVerse")
+
+(cc/defprop-str keycloak-client-id
+  "The Keycloak client ID to use."
+  [props config-valid configs]
+  "terrain.keycloak.client-id")
+
+(cc/defprop-str keycloak-client-secret
+  "The keycloak client secret to use."
+  [props config-valid configs]
+  "terrain.keycloak.client-secret")
 
 (cc/defprop-optstr dashboard-aggregator-url
   "The URL to the dashboard-aggregator service."


### PR DESCRIPTION
This PR finally adds the ability for administrators to impersonate users without having to run terrain locally and jump through a bunch of hoops. The administrative token endpoints use HTTP basic authentication, and they don't do any authorization checks themselves. Instead, they pass the information to Keycloak and allow Keycloak to do the validation. The drawback to this approach is that it means that we'll have to maintain administrative privileges for impersonation tokens separately through Keycloak. The advantage is that we can be more selective about which users have the ability to impersonate other users.
