### PR TITLE
CORE-600 Add analyses job status endpoint, and status count to analyses listing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.2"]
+                 [org.cyverse/common-swagger-api "3.0.3-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.4"]
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.3-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "3.0.3"]
                  [org.cyverse/kameleon "3.0.4"]
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/metadata-files "1.0.3"]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -464,6 +464,14 @@
                 {:query-params (secured-params params)
                  :as           :json}))))
 
+(defn list-job-stats
+  [params]
+  (:body
+    (client/get (apps-url "analyses" "stats")
+                (disable-redirects
+                  {:query-params (secured-params params)
+                   :as           :json}))))
+
 (defn list-job-permissions
   [body params]
   (:body

--- a/src/terrain/routes/analyses.clj
+++ b/src/terrain/routes/analyses.clj
@@ -42,6 +42,13 @@
        :description listing-schema/AnalysesListingDocs
        (ok (apps/list-jobs params)))
 
+     (GET "/stats" []
+       :query [params schema/AnalysisStatParams]
+       :return schema/AnalysisStats
+       :summary schema/AnalysisStatSummary
+       :description schema/AnalysisStatDescription
+       (ok (apps/list-job-stats params)))
+
      (POST "/" []
        :middleware [schema/coerce-analysis-submission-requirements]
        :body [body schema/AnalysisSubmission]


### PR DESCRIPTION
I timed the analyses listing endpoint before and after adding the status counts, based on production data for Tyson since I figure he's an active user.  Looks like there's no significant change to adding the status counts.

Before:
"Elapsed time: 11405.267379 msecs"
"Elapsed time: 11353.308928 msecs"
"Elapsed time: 10605.780889 msecs"

After:
"Elapsed time: 11938.507988 msecs"
"Elapsed time: 11914.46379 msecs"
"Elapsed time: 10687.588213 msecs"
