### PR TITLE
CORE-1031 Allow logged out users to get root listing and view community data

### DIFF
--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -1,6 +1,7 @@
 (ns terrain.routes.filesystem
   (:use [common-swagger-api.schema]
         [medley.core :only [update-existing-in]]
+        [ring.util.http-response :only [ok]]
         [terrain.auth.user-attributes :only [require-authentication current-user]]
         [terrain.util :only [controller optional-routes]])
   (:require [clojure.string :as string]
@@ -54,7 +55,7 @@
        :description (str "Provides a paged listing of the contents of a folder in the data store.")
        :return fs-schema/PagedFolderListing
        :coercion mw/no-response-coercion
-       (dir/do-paged-listing current-user params))
+       (ok (dir/do-paged-listing current-user params)))
 
      (POST "/path-list-creator" [:as req]
        :middleware [require-authentication]

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -1,7 +1,6 @@
 (ns terrain.routes.filesystem
   (:use [common-swagger-api.schema]
         [medley.core :only [update-existing-in]]
-        [ring.util.http-response :only [ok]]
         [terrain.auth.user-attributes :only [require-authentication current-user]]
         [terrain.util :only [controller optional-routes]])
   (:require [clojure.string :as string]
@@ -55,7 +54,7 @@
        :description (str "Provides a paged listing of the contents of a folder in the data store.")
        :return fs-schema/PagedFolderListing
        :coercion mw/no-response-coercion
-       (ok (dir/do-paged-listing current-user params)))
+       (dir/do-paged-listing current-user params))
 
      (POST "/path-list-creator" [:as req]
        :middleware [require-authentication]

--- a/src/terrain/services/filesystem/directory.clj
+++ b/src/terrain/services/filesystem/directory.clj
@@ -2,7 +2,6 @@
   (:use [clojure-commons.core :only [remove-nil-values]]
         [clojure-commons.validators]
         [kameleon.uuids :only [uuidify]]
-        [ring.util.http-response :only [ok]]
         [slingshot.slingshot :only [try+ throw+]])
   (:require [clojure.tools.logging :as log]
             [clojure.string :as string]
@@ -170,6 +169,6 @@
     (let [params (dissoc params :path)]
       (->> (fix-paged-listing-params listing-user params)
            (data/list-folder-contents path)
-           (format-page user)
-           (ok)))
-    (response/unauthorized "No authentication information found in the request")))
+           (format-page user)))
+    (throw+ {:type :clojure-commons.exception/not-authorized
+             :user user})))

--- a/src/terrain/services/filesystem/directory.clj
+++ b/src/terrain/services/filesystem/directory.clj
@@ -2,6 +2,7 @@
   (:use [clojure-commons.core :only [remove-nil-values]]
         [clojure-commons.validators]
         [kameleon.uuids :only [uuidify]]
+        [ring.util.http-response :only [ok]]
         [slingshot.slingshot :only [try+ throw+]])
   (:require [clojure.tools.logging :as log]
             [clojure.string :as string]
@@ -15,7 +16,8 @@
             [terrain.services.metadata.favorites :as favorites]
             [terrain.util.config :as cfg]
             [terrain.util.validators :as duv]
-            [terrain.services.filesystem.common-paths :as paths]))
+            [terrain.services.filesystem.common-paths :as paths]
+            [ring.util.http-response :as response]))
 
 (defn- is-favorite?
   [favorite-ids id]
@@ -162,7 +164,12 @@
 (defn do-paged-listing
   "Entrypoint for the API that calls (paged-dir-listing)."
   [{user :shortUsername} {:keys [path] :as params}]
-  (let [params (dissoc params :path)]
-    (->> (fix-paged-listing-params user params)
-         (data/list-folder-contents path)
-         (format-page user))))
+  (if-let [listing-user (if (= path (cfg/fs-community-data))
+                          (or user "anonymous")
+                          user)]
+    (let [params (dissoc params :path)]
+      (->> (fix-paged-listing-params listing-user params)
+           (data/list-folder-contents path)
+           (format-page user)
+           (ok)))
+    (response/unauthorized "No authentication information found in the request")))

--- a/src/terrain/services/filesystem/root.clj
+++ b/src/terrain/services/filesystem/root.clj
@@ -2,8 +2,7 @@
   (:use [clojure-commons.validators])
   (:require [clojure-commons.json :as json]
             [dire.core :refer [with-pre-hook! with-post-hook!]]
-            [terrain.clients.data-info.raw :as data-raw]
-            [terrain.services.filesystem.common-paths :as paths]))
+            [terrain.clients.data-info.raw :as data-raw]))
 
 (defn- format-roots
   [roots]
@@ -13,14 +12,7 @@
 
 (defn do-root-listing
   [{user :user}]
-  (-> (data-raw/list-roots user)
+  (-> (data-raw/list-roots (or user "anonymous"))
       :body
       (json/string->json true)
       format-roots))
-
-(with-pre-hook! #'do-root-listing
-  (fn [params]
-    (paths/log-call "do-root-listing" params)
-    (validate-map params {:user string?})))
-
-(with-post-hook! #'do-root-listing (paths/log-func "do-root-listing"))


### PR DESCRIPTION
The main request from the ticket was to have the root listing return all 4 roots (home, shared with me, community data, trash) even for logged out users.  On top of that, logged out users needed to get a 401 if they tried to navigate to (i.e. get a paged directory listing for) any root other than community data, so that work is also in this PR.