### PR TITLE
CORE-1031 Add filesystem roots to optionally-authenticated-routes

### DIFF
--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -75,6 +75,7 @@
   []
   (util/flagged-routes
     (dashboard-aggregator-routes)
+    (filesystem-navigation-routes)
     (secured-filesystem-routes)))
 
 ; Add new secured routes to this function, not to (secured-routes).

--- a/src/terrain/routes/filesystem/navigation.clj
+++ b/src/terrain/routes/filesystem/navigation.clj
@@ -1,6 +1,7 @@
 (ns terrain.routes.filesystem.navigation
   (:use [common-swagger-api.schema]
         [ring.util.http-response :only [ok]]
+        [terrain.auth.user-attributes :only [require-authentication]]
         [terrain.util :only [optional-routes]]
         [terrain.util.transformers :only [add-current-user-to-map]])
   (:require [common-swagger-api.schema.data.navigation :as schema]
@@ -26,6 +27,7 @@
            (ok (root/do-root-listing (add-current-user-to-map {}))))
 
       (GET "/directory" [:as {:keys [params]}]
+           :middleware [require-authentication]
            :query [params terrain-nav-schema/DirectoryQueryParams]
            :responses terrain-nav-schema/DirectoryResponses
            :summary schema/NavigationSummary


### PR DESCRIPTION
This effectively creates GET /filesystem/roots which can be used without auth, but still allows GET /secured/filesystem/roots to work as usual.

This means for Sonora to pick up the changes, it will have to be updated to hit the non-secured route.