### PR TITLE
CORE-1112: modified terrain so that it uses a command-line option rat…

### DIFF
--- a/src/terrain/clients/iplant_groups/subjects.clj
+++ b/src/terrain/clients/iplant_groups/subjects.clj
@@ -1,0 +1,18 @@
+(ns terrain.clients.iplant-groups.subjects
+  "Functions to perform subject lookups using the iplant-groups service. This namespace was originally created to
+   avoid a cirucular dependency in terrain.auth.user-attributes when terrain.clients.iplant-groups was added as a
+   dependency to that namespace."
+  (:require [cemerick.url :as curl]
+            [clj-http.client :as http]
+            [terrain.util.config :as config]))
+
+(defn- lookup-subject-url
+  [short-username]
+  (str (curl/url (config/ipg-base) "subjects" short-username)))
+
+(defn lookup-subject
+  "Uses iplant-groups's subject lookup by ID endpoint to retrieve user details."
+  [user short-username]
+  (:body (http/get (lookup-subject-url short-username)
+                   {:query-params {:user user}
+                    :as           :json})))

--- a/src/terrain/middleware.clj
+++ b/src/terrain/middleware.clj
@@ -1,5 +1,6 @@
 (ns terrain.middleware
-  (:require [clojure.string :as string]))
+  (:require [clojure.string :as string]
+            [terrain.auth.user-attributes :as user-attributes]))
 
 (defn- add-context-path
   "Adds a context path to the start of a URI path if it's not present."
@@ -25,3 +26,13 @@
             (update-in [:params] dissoc query-param (keyword query-param))
             (update-in [:query-params] dissoc query-param (keyword query-param))
             handler)))))
+
+(defn wrap-fake-user
+  "Middleware that configures fake authentication for development testing. If the fake user is falsey,
+   the handler function is not wrapped at all."
+  [handler fake-user]
+  (if fake-user
+    (fn [request]
+      (binding [user-attributes/fake-user fake-user]
+        (handler request)))
+    handler))


### PR DESCRIPTION
…her than environment variables to enable fake authentication

This change eliminates the use of fake authentication environment variables completely. Instead, a username will be passed to `terrain` on the command line using the new `--fake-user` or `-u` option. If this option is specified then fake authentication will be enabled, and the specified username will be used for all requests. To eliminate some of the burden on the developer, it is only necessary to specify the username when fake authentication is enabled. The rest of the required information will be obtained from the `iplant-groups` service. Also, the user attributes will be obtained from the `iplant-groups` service for each request. This adds a tiny bit of overhead to each request when fake authentication is enabled, but it also means that terrain doesn't have to be restarted if, for example, `iplant-groups` isn't available when `terrain` starts.

A new option, `--port` or `-p`, has also been added to make it easier to specify the port number on the command line when using `lein run`. Prior to this change, it would have been necessary to update the terrain configuration file to change the listen port. If the new command-line option is not provided on the command line then the port number will still be obtained from the configuration file.

