### PR TITLE
CORE-1045 Add async folder move support to DOI Request endpoints.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,6 +32,7 @@
                  [org.apache.tika/tika-core "1.23"]
                  [ring/ring-jetty-adapter "1.8.0"]
                  [slingshot "0.12.2"]
+                 [org.cyverse/async-tasks-client "0.0.3"]
                  [org.cyverse/clj-icat-direct "2.8.6"]
                  [org.cyverse/clj-jargon "2.8.9"]
                  [org.cyverse/clojure-commons "3.0.5"]

--- a/src/terrain/clients/async_tasks.clj
+++ b/src/terrain/clients/async_tasks.clj
@@ -1,0 +1,14 @@
+(ns terrain.clients.async-tasks
+  (:require [async-tasks-client.core :as async-tasks-client]
+            [clojure.string :as string]
+            [terrain.util.config :as config]))
+
+(defn run-async-thread
+  [async-task-id thread-function prefix]
+  (let [^Runnable task-thread (fn [] (thread-function))]
+    (.start (Thread. task-thread (str prefix "-" async-task-id))))
+  async-task-id)
+
+(defn get-by-id
+  [id]
+  (async-tasks-client/get-by-id (config/async-tasks-client) id))

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -1,6 +1,7 @@
 (ns terrain.util.config
   (:use [slingshot.slingshot :only [throw+]])
-  (:require [clojure-commons.config :as cc]
+  (:require [async-tasks-client.core :as async-tasks-client]
+            [clojure-commons.config :as cc]
             [clojure-commons.error-codes :as ce]
             [metadata-client.core :as metadata-client]))
 
@@ -154,6 +155,11 @@
   "The base URL to use when connecting to secured Apps services."
   [props config-valid configs app-routes-enabled]
   "terrain.apps.base-url" "http://apps")
+
+(cc/defprop-optstr async-tasks-base-url
+  "The base URL to use when connecting to the async-tasks services."
+  [props config-valid configs]
+  "terrain.async-tasks.base-url" "http://async-tasks:60000")
 
 (cc/defprop-optstr metadata-base-url
   "The base URL to use when connecting to the metadata services."
@@ -413,6 +419,13 @@
   [props config-valid configs]
   "terrain.job-exec.default-output-folder" "analyses")
 
+(cc/defprop-optint permanent-id-async-move-wait-seconds-max
+  "The max amount of time to wait for async folder moves, in seconds.
+   By default, 1023 = (2^10-1) seconds, since the waiting thread doubles its
+   sleep-seconds each time it polls until the async task completes."
+  [props config-valid configs]
+  "terrain.permanent-id.async-move.wait-seconds.max" 1023)  ;; Just over 17 minutes
+
 (cc/defprop-optstr permanent-id-curators-group
   "The data store group that manages permanent ID request data."
   [props config-valid configs]
@@ -542,6 +555,9 @@
   "The URL to the dashboard-aggregator service."
   [props config-valid configs]
   "terrain.dashboard-aggregator.base-uri" "http://dashboard-aggregator")
+
+(def async-tasks-client
+  (memoize #(async-tasks-client/new-async-tasks-client (async-tasks-base-url))))
 
 (def metadata-client
   (memoize #(metadata-client/new-metadata-client (metadata-base-url))))


### PR DESCRIPTION
This PR will add async folder move support to DOI Request endpoints.

Currently the DOI Request endpoints are trying to move the user's folder to the staging or curated directory as the irods proxy user, and then immediately share the moved folder with the DOI curators group using the destination path, which doesn't exist yet since the async task service takes a few seconds to perform the move.

This PR updates these endpoints to spawn a thread that polls the async tasks service until the async move is complete, and then the thread will update the permissions on the moved folder. In the meantime the DOI request or creation will continue as normal while the move happens in the background.

If the move fails for any reason, the permissions will still be updated on the source folder so the DOI curators (or some other admin) can look into the issue and move the folder later.