### PR TITLE
Bag support

### DIFF
--- a/src/terrain/clients/bags.clj
+++ b/src/terrain/clients/bags.clj
@@ -15,7 +15,7 @@
 
 (defn has-bags
   [username]
-  (<= 200 (:status (http/head (bags-url [username]))) 299))
+  (:body (http/head (bags-url [username]))))
 
 (defn get-bags
   [username]
@@ -30,7 +30,7 @@
 
 (defn delete-all-bags
   [username]
-  (<= 200 (:status (http/delete (bags-url [username]))) 299))
+  (:body (http/delete (bags-url [username]))))
 
 (defn get-bag
   [username id]
@@ -44,4 +44,4 @@
 
 (defn delete-bag
   [username id]
-  (<= 200 (:status (http/delete (bags-url [username id]))) 299))
+  (:body (http/delete (bags-url [username id]))))

--- a/src/terrain/clients/bags.clj
+++ b/src/terrain/clients/bags.clj
@@ -7,11 +7,9 @@
             [terrain.util.config :as config]))
 
 (defn- bags-url
-  ([]
-   (bags-url []))
-  ([components]
-   (-> (apply url (config/bags-base-url) components)
-       (str))))
+[& [components]]
+  (-> (apply url (config/bags-base-url) components)
+      (str)))
 
 (defn has-bags
   [username]

--- a/src/terrain/clients/bags.clj
+++ b/src/terrain/clients/bags.clj
@@ -1,0 +1,47 @@
+(ns terrain.clients.bags
+  (:use [clojure-commons.error-codes]
+        [slingshot.slingshot :only [try+ throw+]])
+  (:require [clj-http.client :as http]
+            [cemerick.url :refer [url]]
+            [clojure.tools.logging :as log]
+            [terrain.util.config :as config]))
+
+(defn- bags-url
+  ([]
+   (bags-url []))
+  ([components]
+   (-> (apply url (config/bags-base-url) components)
+       (str))))
+
+(defn has-bags
+  [username]
+  (<= 200 (:status (http/head (bags-url [username]))) 299))
+
+(defn get-bags
+  [username]
+  (:body (http/get (bags-url [username]) {:as :json})))
+
+(defn add-bag
+  [username contents]
+  (:body (http/put (bags-url [username])
+                   {:content-type :json
+                    :as           :json
+                    :form-params  contents})))
+
+(defn delete-all-bags
+  [username]
+  (<= 200 (:status (http/delete (bags-url [username]))) 299))
+
+(defn get-bag
+  [username id]
+  (:body (http/get (bags-url [username id]) {:as :json})))
+
+(defn update-bag
+  [username id contents]
+  (:body (http/post (bags-url [username id]) {:content-type :json
+                                              :as           :json
+                                              :form-params  contents})))
+
+(defn delete-bag
+  [username id]
+  (<= 200 (:status (http/delete (bags-url [username id]))) 299))

--- a/src/terrain/clients/bags.clj
+++ b/src/terrain/clients/bags.clj
@@ -13,7 +13,8 @@
 
 (defn has-bags
   [username]
-  (:body (http/head (bags-url [username]))))
+  (:body (http/head (bags-url [username])))
+  nil)
 
 (defn get-bags
   [username]
@@ -28,7 +29,8 @@
 
 (defn delete-all-bags
   [username]
-  (:body (http/delete (bags-url [username]))))
+  (:body (http/delete (bags-url [username])))
+  nil)
 
 (defn get-bag
   [username id]
@@ -42,4 +44,5 @@
 
 (defn delete-bag
   [username id]
-  (:body (http/delete (bags-url [username id]))))
+  (:body (http/delete (bags-url [username id])))
+  nil)

--- a/src/terrain/clients/bags.clj
+++ b/src/terrain/clients/bags.clj
@@ -24,9 +24,9 @@
 (defn add-bag
   [username contents]
   (:body (http/put (bags-url [username])
-                   {:content-type :json
-                    :as           :json
-                    :form-params  contents})))
+                   {:form-params  contents
+                    :content-type :json
+                    :as           :json})))
 
 (defn delete-all-bags
   [username]
@@ -38,9 +38,9 @@
 
 (defn update-bag
   [username id contents]
-  (:body (http/post (bags-url [username id]) {:content-type :json
-                                              :as           :json
-                                              :form-params  contents})))
+  (:body (http/post (bags-url [username id]) {:form-params  contents
+                                              :content-type :json
+                                              :as           :json})))
 
 (defn delete-bag
   [username id]

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -19,6 +19,7 @@
         [terrain.routes.apps.pipelines]
         [terrain.routes.apps.reference-genomes]
         [terrain.routes.apps.tools]
+        [terrain.routes.bags]
         [terrain.routes.bootstrap]
         [terrain.routes.dashboard-aggregator]
         [terrain.routes.data]
@@ -74,9 +75,9 @@
    the next set of routes (`secured-routes-no-context`) if nothing matches."
   []
   (util/flagged-routes
-    (dashboard-aggregator-routes)
-    (filesystem-navigation-routes)
-    (secured-filesystem-routes)))
+   (dashboard-aggregator-routes)
+   (filesystem-navigation-routes)
+   (secured-filesystem-routes)))
 
 ; Add new secured routes to this function, not to (secured-routes).
 ; This function allows for secured routes without the /secured content/prefix,
@@ -108,6 +109,7 @@
    (oauth-routes)
    (quicklaunch-routes)
    (request-routes)
+   (bag-routes)
    (route/not-found (service/unrecognized-path-response))))
 
 ; The old way of adding secured routes. Prepends /secured to the URL

--- a/src/terrain/routes/bags.clj
+++ b/src/terrain/routes/bags.clj
@@ -1,0 +1,57 @@
+(ns terrain.routes.bags
+  (:use [common-swagger-api.schema]
+        [terrain.routes.schemas.bags]
+        [terrain.auth.user-attributes :only [current-user]]
+        [terrain.services.bags]
+        [terrain.util :only [optional-routes]])
+  (:require [terrain.util.config :as config]))
+
+(defn bag-routes
+  []
+  (optional-routes
+   [config/bag-routes-enabled]
+
+   (context "/bags" []
+     :tags ["bags"]
+
+     (HEAD "/" []
+       :summary     HasBagsSummary
+       :description HasBagsDescription
+       (has-bags (:username current-user)))
+
+     (GET "/" []
+       :summary     BagListSummary
+       :description BagListDescription
+       :return      BagList
+       (get-bags (:username current-user)))
+
+     (PUT "/" [:as {body :body}]
+       :summary     AddBagSummary
+       :description AddBagDescription
+       :body        [body Bag]
+       :return      AddBagResponse
+       (add-bag (:username current-user) (slurp body)))
+
+     (DELETE "/" []
+       :summary     DeleteAllBagsSummary
+       :description DeleteAllBagsDescription
+       (delete-all-bags (:username current-user)))
+
+     (context "/:bag-id" []
+       :path-params [bag-id :- BagIDPathParam]
+
+       (GET "/" []
+         :summary     GetBagSummary
+         :description GetBagDescription
+         (get-bag (:username current-user) bag-id))
+
+       (POST "/" []
+         :summary     UpdateBagSummary
+         :description UpdateBagDescription
+         :body        [body Bag]
+         (update-bag (:username current-user) bag-id body))
+
+       (DELETE "/" []
+         :summary     DeleteBagSummary
+         :description DeleteBagDescription
+         (delete-bag (:username current-user) bag-id))))))

--- a/src/terrain/routes/bags.clj
+++ b/src/terrain/routes/bags.clj
@@ -1,10 +1,12 @@
 (ns terrain.routes.bags
   (:use [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]]
         [terrain.routes.schemas.bags]
         [terrain.auth.user-attributes :only [current-user]]
         [terrain.services.bags]
         [terrain.util :only [optional-routes]])
-  (:require [terrain.util.config :as config]))
+  (:require [terrain.util.config :as config]
+            [clojure.tools.logging :as log]))
 
 (defn bag-routes
   []
@@ -17,25 +19,25 @@
      (HEAD "/" []
        :summary     HasBagsSummary
        :description HasBagsDescription
-       (has-bags (:username current-user)))
+       (ok (has-bags (:username current-user))))
 
      (GET "/" []
        :summary     BagListSummary
        :description BagListDescription
        :return      BagList
-       (get-bags (:username current-user)))
+       (ok (get-bags (:username current-user))))
 
-     (PUT "/" [:as {body :body}]
+     (PUT "/" []
        :summary     AddBagSummary
        :description AddBagDescription
-       :body        [body Bag]
+       :body        [body BagContents]
        :return      AddBagResponse
-       (add-bag (:username current-user) (slurp body)))
+       (ok (add-bag (:username current-user) (log/spy body))))
 
      (DELETE "/" []
        :summary     DeleteAllBagsSummary
        :description DeleteAllBagsDescription
-       (delete-all-bags (:username current-user)))
+       (ok (delete-all-bags (:username current-user))))
 
      (context "/:bag-id" []
        :path-params [bag-id :- BagIDPathParam]
@@ -43,15 +45,15 @@
        (GET "/" []
          :summary     GetBagSummary
          :description GetBagDescription
-         (get-bag (:username current-user) bag-id))
+         (ok (get-bag (:username current-user) bag-id)))
 
        (POST "/" []
          :summary     UpdateBagSummary
          :description UpdateBagDescription
          :body        [body Bag]
-         (update-bag (:username current-user) bag-id body))
+         (ok (update-bag (:username current-user) bag-id body)))
 
        (DELETE "/" []
          :summary     DeleteBagSummary
          :description DeleteBagDescription
-         (delete-bag (:username current-user) bag-id))))))
+         (ok (delete-bag (:username current-user) bag-id)))))))

--- a/src/terrain/routes/bags.clj
+++ b/src/terrain/routes/bags.clj
@@ -32,7 +32,7 @@
        :description AddBagDescription
        :body        [body BagContents]
        :return      AddBagResponse
-       (ok (add-bag (:username current-user) (log/spy body))))
+       (ok (add-bag (:username current-user) body)))
 
      (DELETE "/" []
        :summary     DeleteAllBagsSummary
@@ -50,7 +50,7 @@
        (POST "/" []
          :summary     UpdateBagSummary
          :description UpdateBagDescription
-         :body        [body Bag]
+         :body        [body BagContents]
          (ok (update-bag (:username current-user) bag-id body)))
 
        (DELETE "/" []

--- a/src/terrain/routes/bags.clj
+++ b/src/terrain/routes/bags.clj
@@ -19,7 +19,8 @@
      (HEAD "/" []
        :summary     HasBagsSummary
        :description HasBagsDescription
-       (ok (has-bags (:username current-user))))
+       (has-bags (:username current-user))
+       (ok))
 
      (GET "/" []
        :summary     BagListSummary
@@ -37,7 +38,8 @@
      (DELETE "/" []
        :summary     DeleteAllBagsSummary
        :description DeleteAllBagsDescription
-       (ok (delete-all-bags (:username current-user))))
+       (delete-all-bags (:username current-user))
+       (ok))
 
      (context "/:bag-id" []
        :path-params [bag-id :- BagIDPathParam]
@@ -56,4 +58,5 @@
        (DELETE "/" []
          :summary     DeleteBagSummary
          :description DeleteBagDescription
-         (ok (delete-bag (:username current-user) bag-id)))))))
+         (delete-bag (:username current-user) bag-id)
+         (ok))))))

--- a/src/terrain/routes/schemas/bags.clj
+++ b/src/terrain/routes/schemas/bags.clj
@@ -1,0 +1,11 @@
+(ns terrain.routes.schemas.bags
+  (:use [common-swagger-api.schema :only [describe]]
+        [schema.core :only [defschema Any Keyword optional-key]]))
+
+(defschema Bag
+  {:id       (describe String "The bag id")
+   :user_id  (describe String "The user's id")
+   :contents (describe String "JSON-encoded bag")})
+
+(defschema BagList
+  {:bags (describe [Bag] "The list of bags associated with the user")})

--- a/src/terrain/routes/schemas/bags.clj
+++ b/src/terrain/routes/schemas/bags.clj
@@ -5,10 +5,13 @@
 
 (def BagIDPathParam (describe String "The ID of the bag located in the path of the URL"))
 
+(defschema BagContents
+  {(describe Keyword "Bag key") (describe Any "Bag value")})
+
 (defschema Bag
   {:id       (describe UUID "The bag id")
    :user_id  (describe UUID "The user's id")
-   :contents (describe String "JSON-encoded bag")})
+   :contents (describe BagContents "JSON-encoded bag")})
 
 (defschema AddBagResponse
   {:id (describe UUID "The UUID assigned to the bag")})
@@ -21,9 +24,6 @@
 
 (defschema BagList
   {:bags (describe [Bag] "The list of bags associated with the user")})
-
-(defschema BagContents
-  {(describe Keyword "Bag key") (describe Any "Bag value")})
 
 (def HasBagsSummary "Tells whether a user has a bag")
 (def HasBagsDescription "Tells whether a user has one or more bags in the database")

--- a/src/terrain/routes/schemas/bags.clj
+++ b/src/terrain/routes/schemas/bags.clj
@@ -38,4 +38,4 @@
 (def DeleteAllBagsDescription "Deletes all of a user's bags")
 
 (def DeleteBagSummary "Delete a bag")
-(def DeleteBagDescription "Delete's a bag for a user based on its UUID")
+(def DeleteBagDescription "Deletes a bag for a user based on its UUID")

--- a/src/terrain/routes/schemas/bags.clj
+++ b/src/terrain/routes/schemas/bags.clj
@@ -22,6 +22,9 @@
 (defschema BagList
   {:bags (describe [Bag] "The list of bags associated with the user")})
 
+(defschema BagContents
+  {(describe Keyword "Bag key") (describe Any "Bag value")})
+
 (def HasBagsSummary "Tells whether a user has a bag")
 (def HasBagsDescription "Tells whether a user has one or more bags in the database")
 

--- a/src/terrain/routes/schemas/bags.clj
+++ b/src/terrain/routes/schemas/bags.clj
@@ -1,11 +1,38 @@
 (ns terrain.routes.schemas.bags
   (:use [common-swagger-api.schema :only [describe]]
-        [schema.core :only [defschema Any Keyword optional-key]]))
+        [schema.core :only [defschema Any Keyword optional-key]])
+  (:import [java.util UUID]))
+
+(def BagIDPathParam (describe String "The ID of the bag located in the path of the URL"))
 
 (defschema Bag
-  {:id       (describe String "The bag id")
-   :user_id  (describe String "The user's id")
+  {:id       (describe UUID "The bag id")
+   :user_id  (describe UUID "The user's id")
    :contents (describe String "JSON-encoded bag")})
+
+(defschema AddBagResponse
+  {:id (describe UUID "The UUID assigned to the bag")})
+
+(def AddBagDescription "Adds a new bag to the list for the user")
+(def AddBagSummary "Adds a new bag")
+
+(def UpdateBagSummary "Update a bag")
+(def UpdateBagDescription "Updates a bag for a user based on its UUID")
 
 (defschema BagList
   {:bags (describe [Bag] "The list of bags associated with the user")})
+
+(def HasBagsSummary "Tells whether a user has a bag")
+(def HasBagsDescription "Tells whether a user has one or more bags in the database")
+
+(def BagListSummary "List user bags")
+(def BagListDescription "List all of the bags for the user")
+
+(def GetBagSummary "Gets a bag")
+(def GetBagDescription "Gets a single bag for a user by its UUID")
+
+(def DeleteAllBagsSummary "Deletes all of a user's bags")
+(def DeleteAllBagsDescription "Deletes all of a user's bags")
+
+(def DeleteBagSummary "Delete a bag")
+(def DeleteBagDescription "Delete's a bag for a user based on its UUID")

--- a/src/terrain/services/bags.clj
+++ b/src/terrain/services/bags.clj
@@ -1,25 +1,33 @@
 (ns terrain.services.bags
-  (:use [terrain.util.service]))
+  (:use [terrain.util.service])
+  (:require [terrain.clients.bags :as bags]))
 
 (defn has-bags
-  [username])
+  [username]
+  (bags/has-bags username))
 
 (defn get-bags
-  [username])
+  [username]
+  (bags/get-bags username))
 
 (defn get-bag
-  [username bag-id])
+  [username bag-id]
+  (bags/get-bag username bag-id))
 
 (defn add-bag
-  [username contents])
+  [username contents]
+  (bags/add-bag username contents))
 
 (defn update-bag
-  [username bag-id contents])
+  [username bag-id contents]
+  (bags/update-bag username bag-id contents))
 
 (defn delete-all-bags
-  [username])
+  [username]
+  (bags/delete-all-bags username))
 
 (defn delete-bag
-  [username bag-id])
+  [username bag-id]
+  (bags/delete-bag username bag-id))
 
 

--- a/src/terrain/services/bags.clj
+++ b/src/terrain/services/bags.clj
@@ -1,0 +1,25 @@
+(ns terrain.services.bags
+  (:use [terrain.util.service]))
+
+(defn has-bags
+  [username])
+
+(defn get-bags
+  [username])
+
+(defn get-bag
+  [username bag-id])
+
+(defn add-bag
+  [username contents])
+
+(defn update-bag
+  [username bag-id contents])
+
+(defn delete-all-bags
+  [username])
+
+(defn delete-bag
+  [username bag-id])
+
+

--- a/src/terrain/services/bags.clj
+++ b/src/terrain/services/bags.clj
@@ -29,5 +29,3 @@
 (defn delete-bag
   [username bag-id]
   (bags/delete-bag username bag-id))
-
-

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -61,6 +61,11 @@
   [props config-valid configs]
   "terrain.routes.apps" true)
 
+(cc/defprop-optboolean bag-routes-enabled
+  "Enables or disables bag endpoints."
+  [props config-valid configs]
+  "terrain.routes.bags" true)
+
 (cc/defprop-optboolean metadata-routes-enabled
   "Enables or disables metadata endpoints."
   [props config-valid configs]
@@ -203,6 +208,8 @@
 
 
 ;;;iRODS connection information
+
+
 (cc/defprop-optstr irods-home
   "Returns the path to the home directory in iRODS. Usually /iplant/home"
   [props config-valid configs data-routes-enabled]

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -496,7 +496,7 @@
 (cc/defprop-optstr prefs-base-url
   "The hostname of the user-preferences service"
   [props config-valid configs]
-  "terrain.preferences.host" "http://user-preferences")
+  "terrain.preferences.host" "http://user-info/preferences")
 
 (cc/defprop-optstr search-base-url
   "The hostname of the search service"
@@ -506,12 +506,17 @@
 (cc/defprop-optstr sessions-base-url
   "The hostname of the user-sessions service"
   [props config-valid configs]
-  "terrain.sessions.host" "http://user-sessions")
+  "terrain.sessions.host" "http://user-info/sessions")
 
 (cc/defprop-optstr saved-searches-base-url
   "The base URL of the saved-searches service"
   [props config-valid configs]
-  "terrain.saved-searches.host" "http://saved-searches")
+  "terrain.saved-searches.host" "http://user-info/searches")
+
+(cc/defprop-optstr bags-base-url
+  "The base URL for accessing bag information"
+  [props config-valid configs]
+  "terrain.bags.host" "http://user-info/bags")
 
 (cc/defprop-optstr oauth-base-uri
   "The base URI for the OAuth API endpoints."


### PR DESCRIPTION
Add routes, a service, a client, and configuration values for bag-related endpoints. The routes are swaggerized.

Fixes the default values for the sessions, preferences, and saved-searches config settings so they hit user-info.
