### PR TITLE
Add Default Bag Support

### DIFF
--- a/src/terrain/clients/bags.clj
+++ b/src/terrain/clients/bags.clj
@@ -7,7 +7,7 @@
             [terrain.util.config :as config]))
 
 (defn- bags-url
-[& [components]]
+  [& [components]]
   (-> (apply url (config/bags-base-url) components)
       (str)))
 
@@ -45,4 +45,20 @@
 (defn delete-bag
   [username id]
   (:body (http/delete (bags-url [username id])))
+  nil)
+
+(defn get-default-bag
+  [username]
+  [username]
+  (:body (http/delete (bags-url [username]) {:as :json})))
+
+(defn update-default-bag
+  [username contents]
+  (:body (http/post (bags-url [username]) {:form-params  contents
+                                           :content-type :json
+                                           :as           :json})))
+
+(defn delete-default-bag
+  [username]
+  (:body (http/delete (bags-url [username])))
   nil)

--- a/src/terrain/clients/bags.clj
+++ b/src/terrain/clients/bags.clj
@@ -50,15 +50,15 @@
 (defn get-default-bag
   [username]
   [username]
-  (:body (http/delete (bags-url [username]) {:as :json})))
+  (:body (http/get (bags-url [username "default"]) {:as :json})))
 
 (defn update-default-bag
   [username contents]
-  (:body (http/post (bags-url [username]) {:form-params  contents
-                                           :content-type :json
-                                           :as           :json})))
+  (:body (http/post (bags-url [username "default"]) {:form-params  contents
+                                                     :content-type :json
+                                                     :as           :json})))
 
 (defn delete-default-bag
   [username]
-  (:body (http/delete (bags-url [username])))
+  (:body (http/delete (bags-url [username "default"])))
   nil)

--- a/src/terrain/routes/bags.clj
+++ b/src/terrain/routes/bags.clj
@@ -41,6 +41,25 @@
        (delete-all-bags (:username current-user))
        (ok))
 
+     (context "/default" []
+
+       (GET "/" []
+         :summary     GetDefaultBagSummary
+         :description GetDefaultBagDescription
+         (ok (get-default-bag (:username current-user))))
+
+       (POST "/" []
+         :summary     UpdateDefaultBagSummary
+         :description UpdateDefaultBagDescription
+         :body        [body BagContents]
+         (ok (update-default-bag (:username current-user) body)))
+
+       (DELETE "/" []
+         :summary     DeleteDefaultBagSummary
+         :description DeleteDefaultBagDescription
+         (delete-default-bag (:username current-user))
+         (ok)))
+
      (context "/:bag-id" []
        :path-params [bag-id :- BagIDPathParam]
 

--- a/src/terrain/routes/bags.clj
+++ b/src/terrain/routes/bags.clj
@@ -46,6 +46,7 @@
        (GET "/" []
          :summary     GetDefaultBagSummary
          :description GetDefaultBagDescription
+         :return      Bag
          (ok (get-default-bag (:username current-user))))
 
        (POST "/" []

--- a/src/terrain/routes/schemas/bags.clj
+++ b/src/terrain/routes/schemas/bags.clj
@@ -39,3 +39,12 @@
 
 (def DeleteBagSummary "Delete a bag")
 (def DeleteBagDescription "Deletes a bag for a user based on its UUID")
+
+(def GetDefaultBagSummary "Get the user's default bag")
+(def GetDefaultBagDescription "Get the user's default bag. Most interactions should go through the default bag. Creates the bag with default contents if it doesn't already exist")
+
+(def UpdateDefaultBagSummary "Updates the contents of the user's default bag")
+(def UpdateDefaultBagDescription "Updates the contents of the user's default bag. Must be JSON. Will create the bag if it doesn't yet exist")
+
+(def DeleteDefaultBagSummary "Delete the default bag for the user")
+(def DeleteDefaultBagDescription "Deletes the default bag for the user. If you try to retrieve the bag after this, it will return a new, empty bag")

--- a/src/terrain/services/bags.clj
+++ b/src/terrain/services/bags.clj
@@ -29,3 +29,15 @@
 (defn delete-bag
   [username bag-id]
   (bags/delete-bag username bag-id))
+
+(defn get-default-bag
+  [username]
+  (bags/get-default-bag username))
+
+(defn update-default-bag
+  [username contents]
+  (bags/update-default-bag username contents))
+
+(defn delete-default-bag
+  [username]
+  (bags/delete-default-bag username))


### PR DESCRIPTION
Adds support for default bag handling, which allows callers to ignore the multiple bag support if they so wish.

This is dependent on https://github.com/cyverse-de/user-info/pull/5 getting merge.