### PR TITLE
Fix default bag returns

### DIFF
--- a/src/terrain/clients/bags.clj
+++ b/src/terrain/clients/bags.clj
@@ -60,5 +60,4 @@
 
 (defn delete-default-bag
   [username]
-  (:body (http/delete (bags-url [username "default"])))
-  nil)
+  (:body (http/delete (bags-url [username "default"]) {:as :json})))

--- a/src/terrain/routes/bags.clj
+++ b/src/terrain/routes/bags.clj
@@ -53,13 +53,14 @@
          :summary     UpdateDefaultBagSummary
          :description UpdateDefaultBagDescription
          :body        [body BagContents]
+         :return      Bag
          (ok (update-default-bag (:username current-user) body)))
 
        (DELETE "/" []
          :summary     DeleteDefaultBagSummary
          :description DeleteDefaultBagDescription
-         (delete-default-bag (:username current-user))
-         (ok)))
+         :return      Bag
+         (ok (delete-default-bag (:username current-user)))))
 
      (context "/:bag-id" []
        :path-params [bag-id :- BagIDPathParam]


### PR DESCRIPTION
Depends on https://github.com/cyverse-de/user-info/pull/6 being merged.

Updates the expected return values for default bag operations to always return the new state of the bag. Specifically done for integration with react-query, but it's a practice that I should have done in the first place regardless.