### PR TITLE
CORE-1009 User can view community data without logging in

### DIFF
--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -77,6 +77,16 @@
   [^String user ^String dir]
   (cr/ensure-created user dir))
 
+(defn get-request-user
+  "Returns the anonymous user for public data if a user is not provided"
+  [user path]
+  (if-let [request-user (if (string/starts-with? path (cfg/fs-community-data))
+                          (or user "anonymous")
+                          user)]
+    request-user
+    (throw+ {:type :clojure-commons.exception/not-authorized
+             :user user})))
+
 (defn read-chunk
   "Uses the data-info read-chunk endpoint."
   [params body]

--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -102,8 +102,10 @@
 (defn manifest
   "Uses the data-info manifest endpoint."
   [params]
-  (let [path-uuid (uuid-for-path (:user params) (:path params))]
-    (raw/manifest (:user params) path-uuid)))
+  (let [path      (:path params)
+        user      (get-request-user (:user params) path)
+        path-uuid (uuid-for-path user path)]
+    (raw/manifest user path-uuid)))
 
 (defn create-dirs
   [{:keys [user]} {:keys [paths]}]

--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -90,8 +90,10 @@
 (defn read-chunk
   "Uses the data-info read-chunk endpoint."
   [params body]
-  (let [path-uuid (uuid-for-path (:user params) (:path body))]
-    (raw/read-chunk (:user params) path-uuid (:position body) (:chunk-size body))))
+  (let [path      (:path body)
+        user      (get-request-user (:user params) path)
+        path-uuid (uuid-for-path user path)]
+    (raw/read-chunk user path-uuid (:position body) (:chunk-size body))))
 
 (defn read-tabular-chunk
   "Uses the data-info read-tabular-chunk endpoint."

--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -79,13 +79,16 @@
 
 (defn get-request-user
   "Returns the anonymous user for public data if a user is not provided"
-  [user path]
-  (if-let [request-user (if (string/starts-with? path (cfg/fs-community-data))
-                          (or user "anonymous")
-                          user)]
-    request-user
-    (throw+ {:type :clojure-commons.exception/not-authorized
-             :user user})))
+  [user paths]
+  (let [paths (if (= (type paths) String)
+                [paths]
+                paths)
+        has-private-paths? (some #(not (string/starts-with? % (cfg/fs-community-data))) paths)
+        request-user (if has-private-paths?
+                       user
+                       (or user "anonymous"))]
+    (or request-user (throw+ {:type :clojure-commons.exception/not-authorized
+                              :user user}))))
 
 (defn read-chunk
   "Uses the data-info read-chunk endpoint."

--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -77,7 +77,7 @@
   [^String user ^String dir]
   (cr/ensure-created user dir))
 
-(defn get-request-user
+(defn get-public-data-user
   "Returns the anonymous user for public data if a user is not provided"
   [user paths]
   (let [paths (if (= (type paths) String)
@@ -94,7 +94,7 @@
   "Uses the data-info read-chunk endpoint."
   [params body]
   (let [path      (:path body)
-        user      (get-request-user (:user params) path)
+        user      (get-public-data-user (:user params) path)
         path-uuid (uuid-for-path user path)]
     (raw/read-chunk user path-uuid (:position body) (:chunk-size body))))
 
@@ -102,7 +102,7 @@
   "Uses the data-info read-tabular-chunk endpoint."
   [params body]
   (let [path      (:path body)
-        user      (get-request-user (:user params) path)
+        user      (get-public-data-user (:user params) path)
         path-uuid (uuid-for-path user path)]
     (raw/read-tabular-chunk user path-uuid (:separator body) (:page body) (:chunk-size body))))
 
@@ -110,7 +110,7 @@
   "Uses the data-info manifest endpoint."
   [params]
   (let [path      (:path params)
-        user      (get-request-user (:user params) path)
+        user      (get-public-data-user (:user params) path)
         path-uuid (uuid-for-path user path)]
     (raw/manifest user path-uuid)))
 

--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -80,9 +80,7 @@
 (defn get-public-data-user
   "Returns the anonymous user for public data if a user is not provided"
   [user paths]
-  (let [paths (if (= (type paths) String)
-                [paths]
-                paths)
+  (let [paths (if (sequential? paths) paths [paths])
         has-private-paths? (some #(not (string/starts-with? % (cfg/fs-community-data))) paths)
         request-user (if has-private-paths?
                        user

--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -98,8 +98,10 @@
 (defn read-tabular-chunk
   "Uses the data-info read-tabular-chunk endpoint."
   [params body]
-  (let [path-uuid (uuid-for-path (:user params) (:path body))]
-    (raw/read-tabular-chunk (:user params) path-uuid (:separator body) (:page body) (:chunk-size body))))
+  (let [path      (:path body)
+        user      (get-request-user (:user params) path)
+        path-uuid (uuid-for-path user path)]
+    (raw/read-tabular-chunk user path-uuid (:separator body) (:page body) (:chunk-size body))))
 
 (defn manifest
   "Uses the data-info manifest endpoint."

--- a/src/terrain/clients/search.clj
+++ b/src/terrain/clients/search.clj
@@ -1,13 +1,14 @@
 (ns terrain.clients.search
   (:use [terrain.util.config :only [search-base-url]]
-        [terrain.util.transformers :only [secured-params]])
+        [terrain.util.transformers :only [add-current-user-to-map]])
   (:require [clj-http.client :as http]
             [cemerick.url :refer [url]]))
 
 (defn do-data-search
   [body]
-  (let [req-options  {:form-params  body
-                      :query-params (secured-params)
+  (let [query-params {:user (or (:user (add-current-user-to-map {})) "anonymous")}
+        req-options  {:form-params  body
+                      :query-params query-params
                       :as           :json
                       :content-type :json}]
     (:body (http/post (str (url (search-base-url) "data" "search")) req-options))))

--- a/src/terrain/clients/search.clj
+++ b/src/terrain/clients/search.clj
@@ -1,14 +1,13 @@
 (ns terrain.clients.search
   (:use [terrain.util.config :only [search-base-url]]
-        [terrain.util.transformers :only [add-current-user-to-map]])
+        [terrain.util.transformers :only [secured-params]])
   (:require [clj-http.client :as http]
             [cemerick.url :refer [url]]))
 
 (defn do-data-search
   [body]
-  (let [query-params {:user (or (:user (add-current-user-to-map {})) "anonymous")}
-        req-options  {:form-params  body
-                      :query-params query-params
+  (let [req-options  {:form-params  body
+                      :query-params (secured-params)
                       :as           :json
                       :content-type :json}]
     (:body (http/post (str (url (search-base-url) "data" "search")) req-options))))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -77,6 +77,7 @@
   (util/flagged-routes
    (dashboard-aggregator-routes)
    (filesystem-navigation-routes)
+   (secured-data-routes)
    (secured-filesystem-routes)))
 
 ; Add new secured routes to this function, not to (secured-routes).

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -78,7 +78,8 @@
    (dashboard-aggregator-routes)
    (filesystem-navigation-routes)
    (secured-data-routes)
-   (secured-filesystem-routes)))
+   (secured-filesystem-routes)
+   (secured-search-routes)))
 
 ; Add new secured routes to this function, not to (secured-routes).
 ; This function allows for secured routes without the /secured content/prefix,

--- a/src/terrain/routes/data.clj
+++ b/src/terrain/routes/data.clj
@@ -23,6 +23,7 @@
      :tags ["data"]
 
      (POST "/type" []
+       :middleware [require-authentication]
        :summary "Set or Remove File Type Labels"
        :body [body (describe FileType "The file type to set")]
        :return FileTypeReturn
@@ -36,6 +37,7 @@
        (ok (data/get-type-list))))
 
    (POST "/share" []
+     :middleware [require-authentication]
      :tags ["data"]
      :summary "Share Files or Folders"
      :body [body SharingRequest]
@@ -44,6 +46,7 @@
      (ok (share body)))
 
    (POST "/unshare" [:as req]
+     :middleware [require-authentication]
      :tags ["data"]
      :summary "Unshare Files or Folders"
      :body [body UnshareRequest]
@@ -55,12 +58,14 @@
      :tags ["data"]
 
      (GET "/" []
+       :middleware [require-authentication]
        :summary "Get Saved Searches"
        :return (describe s/Any "Previously stored saved searches")
        :description-file "docs/get-saved-searches.md"
        (ok (saved/get-saved-searches (:username current-user))))
 
      (POST "/" []
+       :middleware [require-authentication]
        :summary "Set Saved Searches"
        :body [body (describe s/Any "The saved searches to store")]
        :description-file "docs/post-saved-searches.md"
@@ -68,6 +73,7 @@
        (ok))
 
      (DELETE "/" []
+       :middleware [require-authentication]
        :summary "Delete Saved Searches"
        :description "Deletes all previously saved searches for the authenticated user."
        (saved/delete-saved-searches (:username current-user))

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -112,7 +112,6 @@
        (controller req data/read-chunk :params :body))
 
      (POST "/read-csv-chunk" [:as req]
-       :middleware [require-authentication]
        (controller req data/read-tabular-chunk :params :body))
 
      (POST "/anon-files" [:as req]

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -109,7 +109,6 @@
        (controller req data/delete-trash :params))
 
      (POST "/read-chunk" [:as req]
-       :middleware [require-authentication]
        (controller req data/read-chunk :params :body))
 
      (POST "/read-csv-chunk" [:as req]

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -90,7 +90,6 @@
        (controller req data/move-contents :params :body))
 
      (GET "/file/manifest" [:as req]
-       :middleware [require-authentication]
        (controller req data/manifest :params))
 
      (POST "/user-permissions" [:as req]

--- a/src/terrain/services/filesystem/directory.clj
+++ b/src/terrain/services/filesystem/directory.clj
@@ -163,12 +163,8 @@
 (defn do-paged-listing
   "Entrypoint for the API that calls (paged-dir-listing)."
   [{user :shortUsername} {:keys [path] :as params}]
-  (if-let [listing-user (if (= path (cfg/fs-community-data))
-                          (or user "anonymous")
-                          user)]
-    (let [params (dissoc params :path)]
-      (->> (fix-paged-listing-params listing-user params)
-           (data/list-folder-contents path)
-           (format-page user)))
-    (throw+ {:type :clojure-commons.exception/not-authorized
-             :user user})))
+  (let [listing-user (data/get-request-user user path)
+        params (dissoc params :path)]
+    (->> (fix-paged-listing-params listing-user params)
+         (data/list-folder-contents path)
+         (format-page user))))

--- a/src/terrain/services/filesystem/directory.clj
+++ b/src/terrain/services/filesystem/directory.clj
@@ -163,7 +163,7 @@
 (defn do-paged-listing
   "Entrypoint for the API that calls (paged-dir-listing)."
   [{user :shortUsername} {:keys [path] :as params}]
-  (let [listing-user (data/get-request-user user path)
+  (let [listing-user (data/get-public-data-user user path)
         params (dissoc params :path)]
     (->> (fix-paged-listing-params listing-user params)
          (data/list-folder-contents path)

--- a/src/terrain/util/transformers.clj
+++ b/src/terrain/util/transformers.clj
@@ -13,14 +13,18 @@
 
 (defn add-current-user-to-map
   "Adds the name and e-mail address of the currently authenticated user to a
-   map that can be used to generate a query string."
-  [query]
-  (->> (assoc query
-         :user       (:shortUsername current-user)
-         :email      (:email current-user)
-         :first-name (:firstName current-user)
-         :last-name  (:lastName current-user))
-       (remove-vals invalid-query-param-value?)))
+   map that can be used to generate a query string. If no user is authenticated,
+   the `user` parameter is set to `anonymous` and the rest of the user attribute
+   parameters are omitted."
+  ([query]
+    (add-current-user-to-map query "anonymous"))
+  ([query default-username]
+    (->> (assoc query
+           :user       (or (:shortUsername current-user) default-username)
+           :email      (:email current-user)
+           :first-name (:firstName current-user)
+           :last-name  (:lastName current-user))
+         (remove-vals invalid-query-param-value?))))
 
 (defn secured-params
   "Generates a set of query parameters to pass to a remote service that requires


### PR DESCRIPTION
With these changes, in Sonora users should be able to browse community data, read files (textual and tabular), and search community data without logging in.  

Still To Do:
* View details - this involves the stats endpoint which can accept an array of paths and/or an array of UUIDs
* View metadata - requires a UUID
There was talk about converting all the data endpoints over to using paths instead of UUIDs and I didn't want to overlap with that effort.
