### PR TITLE
Remove unauthd access to data roots endpoint

### DIFF
--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -76,7 +76,6 @@
   []
   (util/flagged-routes
    (dashboard-aggregator-routes)
-   (filesystem-navigation-routes)
    (secured-data-routes)
    (secured-filesystem-routes)
    (secured-search-routes)))

--- a/src/terrain/routes/filesystem/navigation.clj
+++ b/src/terrain/routes/filesystem/navigation.clj
@@ -1,7 +1,6 @@
 (ns terrain.routes.filesystem.navigation
   (:use [common-swagger-api.schema]
         [ring.util.http-response :only [ok]]
-        [terrain.auth.user-attributes :only [require-authentication]]
         [terrain.util :only [optional-routes]]
         [terrain.util.transformers :only [add-current-user-to-map]])
   (:require [common-swagger-api.schema.data.navigation :as schema]
@@ -27,7 +26,6 @@
            (ok (root/do-root-listing (add-current-user-to-map {}))))
 
       (GET "/directory" [:as {:keys [params]}]
-           :middleware [require-authentication]
            :query [params terrain-nav-schema/DirectoryQueryParams]
            :responses terrain-nav-schema/DirectoryResponses
            :summary schema/NavigationSummary

--- a/src/terrain/services/filesystem/root.clj
+++ b/src/terrain/services/filesystem/root.clj
@@ -12,7 +12,7 @@
 
 (defn do-root-listing
   [{user :user}]
-  (-> (data-raw/list-roots (or user "anonymous"))
+  (-> (data-raw/list-roots user)
       :body
       (json/string->json true)
       format-roots))


### PR DESCRIPTION
Since sonora will no longer need to hit the data roots endpoint unauthenticated, I removed the logic for it.