### PR TITLE
CORE-1009 Allow logged out users to use /filesystem/stat endpoint

### DIFF
--- a/src/terrain/clients/data_info.clj
+++ b/src/terrain/clients/data_info.clj
@@ -77,22 +77,11 @@
   [^String user ^String dir]
   (cr/ensure-created user dir))
 
-(defn get-public-data-user
-  "Returns the anonymous user for public data if a user is not provided"
-  [user paths]
-  (let [paths (if (sequential? paths) paths [paths])
-        has-private-paths? (some #(not (string/starts-with? % (cfg/fs-community-data))) paths)
-        request-user (if has-private-paths?
-                       user
-                       (or user "anonymous"))]
-    (or request-user (throw+ {:type :clojure-commons.exception/not-authorized
-                              :user user}))))
-
 (defn read-chunk
   "Uses the data-info read-chunk endpoint."
   [params body]
   (let [path      (:path body)
-        user      (get-public-data-user (:user params) path)
+        user      (st/get-public-data-user (:user params) path)
         path-uuid (uuid-for-path user path)]
     (raw/read-chunk user path-uuid (:position body) (:chunk-size body))))
 
@@ -100,7 +89,7 @@
   "Uses the data-info read-tabular-chunk endpoint."
   [params body]
   (let [path      (:path body)
-        user      (get-public-data-user (:user params) path)
+        user      (st/get-public-data-user (:user params) path)
         path-uuid (uuid-for-path user path)]
     (raw/read-tabular-chunk user path-uuid (:separator body) (:page body) (:chunk-size body))))
 
@@ -108,7 +97,7 @@
   "Uses the data-info manifest endpoint."
   [params]
   (let [path      (:path params)
-        user      (get-public-data-user (:user params) path)
+        user      (st/get-public-data-user (:user params) path)
         path-uuid (uuid-for-path user path)]
     (raw/manifest user path-uuid)))
 

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -76,6 +76,7 @@
   []
   (util/flagged-routes
    (dashboard-aggregator-routes)
+   (filesystem-stat-routes)
    (secured-data-routes)
    (secured-filesystem-routes)
    (secured-search-routes)))

--- a/src/terrain/routes/filesystem/stats.clj
+++ b/src/terrain/routes/filesystem/stats.clj
@@ -1,8 +1,8 @@
 (ns terrain.routes.filesystem.stats
   (:use [common-swagger-api.schema]
         [ring.util.http-response :only [ok]]
-        [terrain.util :only [optional-routes]]
-        [terrain.util.transformers :only [add-current-user-to-map]])
+        [terrain.auth.user-attributes :only [current-user]]
+        [terrain.util :only [optional-routes]])
   (:require [common-swagger-api.schema.data :as data-schema]
             [common-swagger-api.schema.stats :as schema]
             [terrain.services.filesystem.stat :as stat]
@@ -23,4 +23,4 @@
        :responses schema/StatResponses
        :summary schema/StatSummary
        :description schema/StatDocs
-       (ok (stat/do-stat (add-current-user-to-map {}) body))))))
+       (ok (stat/do-stat current-user body))))))

--- a/src/terrain/services/filesystem/directory.clj
+++ b/src/terrain/services/filesystem/directory.clj
@@ -12,6 +12,7 @@
             [clojure-commons.error-codes :as error]
             [terrain.clients.data-info :as data]
             [terrain.clients.data-info.raw :as data-raw]
+            [terrain.services.filesystem.stat :as st]
             [terrain.services.metadata.favorites :as favorites]
             [terrain.util.config :as cfg]
             [terrain.util.validators :as duv]
@@ -163,7 +164,7 @@
 (defn do-paged-listing
   "Entrypoint for the API that calls (paged-dir-listing)."
   [{user :shortUsername} {:keys [path] :as params}]
-  (let [listing-user (data/get-public-data-user user path)
+  (let [listing-user (st/get-public-data-user user path)
         params (dissoc params :path)]
     (->> (fix-paged-listing-params listing-user params)
          (data/list-folder-contents path)

--- a/src/terrain/services/filesystem/stat.clj
+++ b/src/terrain/services/filesystem/stat.clj
@@ -128,6 +128,9 @@
 
 (defn do-stat
   [{user :user} body]
-  (-> (data-raw/collect-stats user body)
-      :body
-      (json/decode true)))
+  (let [paths         (:paths body)
+        ids           (:ids body)
+        request-user  (if ids user (get-public-data-user user paths))]
+    (-> (data-raw/collect-stats request-user body)
+        :body
+        (json/decode true))))


### PR DESCRIPTION
This should be the last change for CORE-1009 - allowing logged out users to browse public data