### PR TITLE
Loosen up the schema for ContainerStateTerminated

### DIFF
--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -51,15 +51,15 @@
 
 (defschema ContainerStateRunning
   {:startedAt (describe String "The time the container started running")})
-      
+
 (defschema ContainerStateTerminated
-  {:exitCode               (describe Long "The exit code for the container")
-   (optional-key :signal)  (describe Long "The numerical signal sent to the container process")
-   :reason                 (describe (maybe String) "The reason the container terminated")
-   (optional-key :message) (describe (maybe String) "The message associated with the container termination")
-   :startedAt              (describe String "The time the container started")
-   :finishedAt             (describe String "The time the container finished")
-   :containerID            (describe String "The ID of the container")})
+  {(optional-key :exitCode)    (describe Long "The exit code for the container")
+   (optional-key :signal)      (describe Long "The numerical signal sent to the container process")
+   (optional-key :reason)      (describe (maybe String) "The reason the container terminated")
+   (optional-key :message)     (describe (maybe String) "The message associated with the container termination")
+   (optional-key :startedAt)   (describe String "The time the container started")
+   (optional-key :finishedAt)  (describe String "The time the container finished")
+   (optional-key :containerID) (describe String "The ID of the container")})
 
 (defschema ContainerState
   {(optional-key :waiting)    (describe (maybe ContainerStateWaiting) "The waiting container state")

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -57,8 +57,8 @@
    (optional-key :signal)      (describe Long "The numerical signal sent to the container process")
    (optional-key :reason)      (describe (maybe String) "The reason the container terminated")
    (optional-key :message)     (describe (maybe String) "The message associated with the container termination")
-   (optional-key :startedAt)   (describe String "The time the container started")
-   (optional-key :finishedAt)  (describe String "The time the container finished")
+   (optional-key :startedAt)   (describe (maybe String) "The time the container started")
+   (optional-key :finishedAt)  (describe (maybe String) "The time the container finished")
    (optional-key :containerID) (describe String "The ID of the container")})
 
 (defschema ContainerState

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -38,12 +38,12 @@
 
 (defschema Deployment
   (merge
-    BaseListing
-    {:image   (describe String "The container image name used in the K8s Deployment")
-     :port    (describe Long "The port number the pods in the deployment are listening on")
-     :user    (describe Long "The user ID of the analysis process")
-     :group   (describe Long "The group ID of the analysis process")
-     :command (describe [String] "The command used to start the analysis")}))
+   BaseListing
+   {:image   (describe String "The container image name used in the K8s Deployment")
+    :port    (describe Long "The port number the pods in the deployment are listening on")
+    :user    (describe Long "The user ID of the analysis process")
+    :group   (describe Long "The group ID of the analysis process")
+    :command (describe [String] "The command used to start the analysis")}))
 
 (defschema ContainerStateWaiting
   {:reason                 (describe (maybe String) "The reason the container is in the waiting state")
@@ -79,17 +79,17 @@
 
 (defschema Pod
   (merge
-    BaseListing
-    {:phase                 (describe String "The pod phase")
-     :message               (describe (maybe String) "The message associated with the current state/phase of the pod")
-     :reason                (describe (maybe String) "The reason the pod is in the phase")
-     :containerStatuses     (describe [ContainerStatus] "The list of container statuses for the pod")
-     :initContainerStatuses (describe [ContainerStatus] "The list of container status for the init containers in the pod")}))
+   BaseListing
+   {:phase                 (describe String "The pod phase")
+    :message               (describe (maybe String) "The message associated with the current state/phase of the pod")
+    :reason                (describe (maybe String) "The reason the pod is in the phase")
+    :containerStatuses     (describe [ContainerStatus] "The list of container statuses for the pod")
+    :initContainerStatuses (describe [ContainerStatus] "The list of container status for the init containers in the pod")}))
 
 (defschema ConfigMap
   (merge
-    BaseListing
-    {:data (describe Any "The data of the config map")}))
+   BaseListing
+   {:data (describe Any "The data of the config map")}))
 
 (defschema ServicePort
   {:name                          (describe String "The name of the port")
@@ -100,9 +100,9 @@
    :protocol                      (describe String "The protocol the primary service port supports")})
 
 (defschema Service
-   (merge
-     BaseListing
-     {:ports (describe [ServicePort] "The list of ports open in the service")}))
+  (merge
+   BaseListing
+   {:ports (describe [ServicePort] "The list of ports open in the service")}))
 
 (defschema IngressRule
   {:host (describe String "The host the rule applies to")
@@ -110,9 +110,9 @@
 
 (defschema Ingress
   (merge
-    BaseListing
-    {:rules (describe [IngressRule] "The list of rules making up the Ingress")
-     :defaultBackend (describe String "The default service that accepts ingress requests that match no rules")}))
+   BaseListing
+   {:rules (describe [IngressRule] "The list of rules making up the Ingress")
+    :defaultBackend (describe String "The default service that accepts ingress requests that match no rules")}))
 
 (defschema FullResourceListing
   {:deployments (describe [Deployment] "The list of deployments")


### PR DESCRIPTION
Makes the keys in the ContainerStateTerminated schema optional because there seem to be various termination states where one or more of them could be omitted entirely. The startedAt and finishedAt values were made optionally a string since those were the specific fields the error report mentioned.