### PR TITLE
Revert do-stat to use add-current-user-to-map with no default user

### DIFF
--- a/src/terrain/routes/filesystem/stats.clj
+++ b/src/terrain/routes/filesystem/stats.clj
@@ -1,8 +1,8 @@
 (ns terrain.routes.filesystem.stats
   (:use [common-swagger-api.schema]
         [ring.util.http-response :only [ok]]
-        [terrain.auth.user-attributes :only [current-user]]
-        [terrain.util :only [optional-routes]])
+        [terrain.util :only [optional-routes]]
+        [terrain.util.transformers :only [add-current-user-to-map]])
   (:require [common-swagger-api.schema.data :as data-schema]
             [common-swagger-api.schema.stats :as schema]
             [terrain.services.filesystem.stat :as stat]
@@ -23,4 +23,4 @@
        :responses schema/StatResponses
        :summary schema/StatSummary
        :description schema/StatDocs
-       (ok (stat/do-stat current-user body))))))
+       (ok (stat/do-stat (add-current-user-to-map {} nil) body))))))

--- a/src/terrain/services/filesystem/stat.clj
+++ b/src/terrain/services/filesystem/stat.clj
@@ -129,7 +129,7 @@
      (can-create-dir? cm user path))))
 
 (defn do-stat
-  [{user :shortUsername} body]
+  [{user :user} body]
   (let [paths         (:paths body)
         ids           (:ids body)
         request-user  (get-public-data-user user paths ids)]


### PR DESCRIPTION
The /filesystem/directory/create endpoint also uses this logic so the user param needs to be consistent