### PR TITLE
Rearrange app-ontology-routes prior to apps-routes

### DIFF
--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -75,6 +75,7 @@
    the next set of routes (`secured-routes-no-context`) if nothing matches."
   []
   (util/flagged-routes
+   (app-ontology-routes)
    (apps-routes)
    (dashboard-aggregator-routes)
    (filesystem-stat-routes)
@@ -92,7 +93,6 @@
    (app-category-routes)
    (app-avu-routes)
    (app-comment-routes)
-   (app-ontology-routes)
    (app-community-routes)
    (app-community-tag-routes)
    (app-elements-routes)

--- a/src/terrain/routes/apps/categories.clj
+++ b/src/terrain/routes/apps/categories.clj
@@ -7,6 +7,7 @@
                                                      OntologyHierarchyFilterParams
                                                      OntologyHierarchyList]]
         [ring.util.http-response :only [ok]]
+        [terrain.auth.user-attributes :only [require-authentication]]
         [terrain.routes.schemas.categories]
         [terrain.util :only [optional-routes]])
   (:require [common-swagger-api.routes]                     ;; for :description-file
@@ -49,6 +50,7 @@
       :tags ["app-hierarchies"]
 
       (GET "/" []
+           :middleware [require-authentication]
            :return OntologyHierarchyList
            :summary schema/AppHierarchiesListingSummary
            :description schema/AppHierarchiesListingDocs
@@ -58,6 +60,7 @@
         :path-params [root-iri :- OntologyClassIRIParam]
 
         (GET "/" []
+             :middleware [require-authentication]
              :query [params OntologyHierarchyFilterParams]
              :return OntologyHierarchy
              :summary schema/AppCategoryHierarchyListingSummary
@@ -65,6 +68,7 @@
              (ok (apps/get-app-category-hierarchy root-iri params)))
 
         (GET "/apps" []
+             :middleware [require-authentication]
              :query [params OntologyAppListingPagingParams]
              :return AppListing
              :summary schema/AppCategoryAppListingSummary
@@ -72,6 +76,7 @@
              (ok (apps/get-hierarchy-app-listing root-iri params)))
 
         (GET "/unclassified" []
+             :middleware [require-authentication]
              :query [params OntologyAppListingPagingParams]
              :return AppListing
              :summary schema/AppHierarchyUnclassifiedListingSummary


### PR DESCRIPTION
Without this, it's possible for the /apps/hierarchies/:root-iri calls to match /apps/:system-id/:app-id instead