### PR TITLE
Preserve ordering of all app routes

### DIFF
--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -75,14 +75,21 @@
    the next set of routes (`secured-routes-no-context`) if nothing matches."
   []
   (util/flagged-routes
-   (app-ontology-routes)
-   (apps-routes)
    (dashboard-aggregator-routes)
    (filesystem-stat-routes)
    (quicklaunch-routes)
    (secured-data-routes)
    (secured-filesystem-routes)
-   (secured-search-routes)))
+   (secured-search-routes)
+   (app-category-routes)
+   (app-avu-routes)
+   (app-comment-routes)
+   (app-ontology-routes)
+   (app-community-routes)
+   (app-community-tag-routes)
+   (app-elements-routes)
+   (app-pipeline-routes)
+   (apps-routes)))
 
 ; Add new secured routes to this function, not to (secured-routes).
 ; This function allows for secured routes without the /secured content/prefix,
@@ -90,13 +97,6 @@
 (defn secured-routes-no-context
   []
   (util/flagged-routes
-   (app-category-routes)
-   (app-avu-routes)
-   (app-comment-routes)
-   (app-community-routes)
-   (app-community-tag-routes)
-   (app-elements-routes)
-   (app-pipeline-routes)
    (analysis-routes)
    (coge-routes)
    (collaborator-list-routes)

--- a/src/terrain/routes/apps/categories.clj
+++ b/src/terrain/routes/apps/categories.clj
@@ -25,6 +25,7 @@
       :tags ["app-categories"]
 
       (GET "/" []
+           :middleware [require-authentication]
            :query [params schema/CategoryListingParams]
            :return schema/AppCategoryListing
            :summary schema/AppCategoryListingSummary
@@ -32,6 +33,7 @@
            (ok (apps/get-app-categories params)))
 
       (GET "/:system-id/:category-id" []
+           :middleware [require-authentication]
            :path-params [system-id :- apps-schema/SystemId
                          category-id :- apps-schema/AppCategoryIdPathParam]
            :query [params AppListingPagingParams]
@@ -93,6 +95,7 @@
       :tags ["app-communities"]
 
       (GET "/:community-id/apps" []
+           :middleware [require-authentication]
            :path-params [community-id :- schema/AppCommunityGroupNameParam]
            :query [params AppListingPagingParams]
            :return AppListing

--- a/src/terrain/routes/apps/communities.clj
+++ b/src/terrain/routes/apps/communities.clj
@@ -6,6 +6,7 @@
                 AppIdParam]]
         [common-swagger-api.schema.metadata :only [AvuList]]
         [ring.util.http-response :only [ok]]
+        [terrain.auth.user-attributes :only [require-authentication]]
         [terrain.util :only [optional-routes]])
   (:require [common-swagger-api.schema.apps.communities :as schema]
             [terrain.clients.apps.raw :as apps]
@@ -22,12 +23,14 @@
       :path-params [app-id :- AppIdParam]
 
       (DELETE "/" []
+              :middleware [require-authentication]
               :body [body AppCategoryMetadataDeleteRequest]
               :summary schema/AppCommunityMetadataDeleteSummary
               :description schema/AppCommunityMetadataDeleteDocs
               (ok (apps/remove-app-from-communities app-id body)))
 
       (POST "/" []
+            :middleware [require-authentication]
             :body [body AppCategoryMetadataAddRequest]
             :return AvuList
             :summary schema/AppCommunityMetadataAddSummary

--- a/src/terrain/routes/apps/elements.clj
+++ b/src/terrain/routes/apps/elements.clj
@@ -3,6 +3,7 @@
         [common-swagger-api.schema.common :only [IncludeHiddenParams]]
         [common-swagger-api.schema.apps.elements]
         [ring.util.http-response :only [ok]]
+        [terrain.auth.user-attributes :only [require-authentication]]
         [terrain.util])
   (:require [terrain.clients.apps.raw :as apps]
             [terrain.util.config :as config]))
@@ -16,30 +17,35 @@
       :tags ["app-element-types"]
 
       (GET "/" []
+           :middleware [require-authentication]
            :query [params IncludeHiddenParams]
            :summary AppElementsListingSummary
            :description AppElementsListingDocs
            (ok (apps/get-all-workflow-elements params)))
 
       (GET "/data-sources" []
+           :middleware [require-authentication]
            :return DataSourceListing
            :summary AppElementsDataSourceListingSummary
            :description AppElementsDataSourceListingDocs
            (ok (apps/get-workflow-elements "data-sources" nil)))
 
       (GET "/file-formats" []
+           :middleware [require-authentication]
            :return FileFormatListing
            :summary AppElementsFileFormatListingSummary
            :description AppElementsFileFormatListingDocs
            (ok (apps/get-workflow-elements "file-formats" nil)))
 
       (GET "/info-types" []
+           :middleware [require-authentication]
            :return InfoTypeListing
            :summary AppElementsInfoTypeListingSummary
            :description AppElementsInfoTypeListingDocs
            (ok (apps/get-workflow-elements "info-types" nil)))
 
       (GET "/parameter-types" []
+           :middleware [require-authentication]
            :query [params AppParameterTypeParams]
            :return ParameterTypeListing
            :summary AppElementsParameterTypeListingSummary
@@ -47,18 +53,21 @@
            (ok (apps/get-workflow-elements "parameter-types" params)))
 
       (GET "/rule-types" []
+           :middleware [require-authentication]
            :return RuleTypeListing
            :summary AppElementsRuleTypeListingSummary
            :description AppElementsRuleTypeListingDocs
            (ok (apps/get-workflow-elements "rule-types" nil)))
 
       (GET "/tool-types" []
+           :middleware [require-authentication]
            :return ToolTypeListing
            :summary AppElementsToolTypeListingSummary
            :description AppElementsToolTypeListingDocs
            (ok (apps/get-workflow-elements "tool-types" nil)))
 
       (GET "/value-types" []
+           :middleware [require-authentication]
            :return ValueTypeListing
            :summary AppElementsValueTypeListingSummary
            :description AppElementsValueTypeListingDocs

--- a/src/terrain/routes/apps/metadata.clj
+++ b/src/terrain/routes/apps/metadata.clj
@@ -6,6 +6,7 @@
                 AvuListRequest
                 SetAvuRequest]]
         [ring.util.http-response :only [ok]]
+        [terrain.auth.user-attributes :only [require-authentication]]
         [terrain.util :only [optional-routes]])
   (:require [common-swagger-api.schema.apps.metadata :as schema]
             [terrain.clients.apps.raw :as apps]
@@ -22,12 +23,14 @@
       :path-params [app-id :- AppIdParam]
 
       (GET "/" []
+           :middleware [require-authentication]
            :return AvuList
            :summary schema/AppMetadataListingSummary
            :description schema/AppMetadataListingDocs
            (ok (apps/list-avus app-id)))
 
       (POST "/" []
+            :middleware [require-authentication]
             :body [body AvuListRequest]
             :return AvuList
             :summary schema/AppMetadataUpdateSummary
@@ -35,6 +38,7 @@
             (ok (apps/update-avus app-id body)))
 
       (PUT "/" []
+           :middleware [require-authentication]
            :body [body SetAvuRequest]
            :return AvuList
            :summary schema/AppMetadataSetSummary

--- a/src/terrain/routes/apps/pipelines.clj
+++ b/src/terrain/routes/apps/pipelines.clj
@@ -3,6 +3,7 @@
         [common-swagger-api.schema.apps :only [AppIdParam]]
         [common-swagger-api.schema.apps.pipeline]
         [ring.util.http-response :only [ok]]
+        [terrain.auth.user-attributes :only [require-authentication]]
         [terrain.util :only [optional-routes]])
   (:require [terrain.clients.apps.raw :as apps]
             [terrain.util.config :as config]))
@@ -16,6 +17,7 @@
       :tags ["app-pipelines"]
 
       (POST "/" []
+            :middleware [require-authentication]
             :body [body PipelineCreateRequest]
             :return Pipeline
             :summary PipelineCreateSummary
@@ -26,6 +28,7 @@
         :path-params [app-id :- AppIdParam]
 
         (PUT "/" []
+             :middleware [require-authentication]
              :body [body PipelineUpdateRequest]
              :return Pipeline
              :summary PipelineUpdateSummary
@@ -33,12 +36,14 @@
              (ok (apps/update-pipeline app-id body)))
 
         (POST "/copy" []
+              :middleware [require-authentication]
               :return Pipeline
               :summary PipelineCopySummary
               :description PipelineCopyDocs
               (ok (apps/copy-pipeline app-id)))
 
         (GET "/ui" []
+             :middleware [require-authentication]
              :return Pipeline
              :summary PipelineEditingViewSummary
              :description PipelineEditingViewDocs

--- a/src/terrain/routes/comments.clj
+++ b/src/terrain/routes/comments.clj
@@ -1,6 +1,7 @@
 (ns terrain.routes.comments
   (:use [common-swagger-api.schema]
         [ring.util.http-response :only [ok]]
+        [terrain.auth.user-attributes :only [require-authentication]]
         [terrain.routes.schemas.comments]
         [terrain.routes.schemas.filesystem])
   (:require [common-swagger-api.routes]                     ;; Required for :description-file
@@ -66,12 +67,14 @@
       :tags ["apps"]
 
       (GET "/" []
+        :middleware [require-authentication]
         :summary "Get App Comments"
         :return comment-schema/CommentList
         :description "Lists all of the comments associated with an app."
         (ok (comments/list-app-comments app-id)))
 
       (POST "/" []
+        :middleware [require-authentication]
         :summary "Add an App Comment"
         :body [body (describe comment-schema/CommentRequest "The comment to add")]
         :return comment-schema/CommentResponse
@@ -79,6 +82,7 @@
         (ok (comments/add-app-comment app-id body)))
 
       (PATCH "/:comment-id" []
+        :middleware [require-authentication]
         :summary "Retract or Readmit an App Comment"
         :path-params [comment-id :- comment-schema/CommentIdPathParam]
         :query [{:keys [retracted]} RetractCommentQueryParams]


### PR DESCRIPTION
This should be the same order as before where all routes that came before `apps-routes` are now correctly before `apps-routes` again.  This is to workaround an issue where some fixed routes (e.g. /apps/hierarchies/:root-iri) are being caught by more dynamic routes (e.g. /apps/:system-id/:app-id)