### PR TITLE
Instant Launch Proof-of-Concept

### DIFF
--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -9,7 +9,6 @@
             [clojure.java.io :as io]
             [terrain.auth.user-attributes :refer [current-user]]))
 
-
 (defn- augment-query
   [query {:keys [no-user]}]
   (as-> query q
@@ -17,11 +16,11 @@
 
 (defn- app-exposer-url
   ([components]
-    (app-exposer-url components {}))
+   (app-exposer-url components {}))
   ([components query & {:as opts}]
-    (-> (apply curl/url (config/app-exposer-base-uri) components)
-        (assoc :query (augment-query query opts))
-        str)))
+   (-> (apply curl/url (config/app-exposer-base-uri) components)
+       (assoc :query (augment-query query opts))
+       str)))
 
 (defn get-pod-logs
   "Returns the logs for a pod"
@@ -92,3 +91,7 @@
   "Tells the vice-transfer-files tool to download inputs without affecting the analysis status"
   [analysis-id]
   (:body (client/post (app-exposer-url ["vice" "admin" "analyses" analysis-id "download-input-files"] {} :no-user true) {:as :json})))
+
+(defn latest-instant-launch-mappings-defaults
+  []
+  (:body (client/get (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true) {:as :json})))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -30,6 +30,7 @@
         [terrain.routes.filesystem.stats]
         [terrain.routes.filesystem.tickets]
         [terrain.routes.groups]
+        [terrain.routes.instantlaunches]
         [terrain.routes.metadata]
         [terrain.routes.misc]
         [terrain.routes.notification]
@@ -112,6 +113,7 @@
    (oauth-routes)
    (request-routes)
    (bag-routes)
+   (instant-launch-routes)
    (route/not-found (service/unrecognized-path-response))))
 
 ; The old way of adding secured routes. Prepends /secured to the URL

--- a/src/terrain/routes/instantlaunches.clj
+++ b/src/terrain/routes/instantlaunches.clj
@@ -1,0 +1,26 @@
+(ns terrain.routes.instantlaunches
+  (:use [common-swagger-api.schema]
+        [ring.util.http-response :only [ok]]
+        [terrain.routes.schemas.instantlaunches]
+        [terrain.auth.user-attributes :only [current-user]]
+        [terrain.clients.app-exposer :only [latest-instant-launch-mappings-defaults]]
+        [terrain.util :only [optional-routes]])
+  (:require [terrain.util.config :as config]
+            [clojure.tools.logging :as log]))
+
+(defn instant-launch-routes
+  []
+  (optional-routes
+   [config/app-routes-enabled]
+
+   (context "/instantlaunches" []
+     :tags ["instantlaunches"]
+
+     (context "/mappings" []
+       (context "/defaults" []
+
+         (GET "/latest" []
+           :summary LatestILMappingsDefaultsSummary
+           :description LatestILMappingsDefaultsDescription
+           :return DefaultInstantLaunchMapping
+           (ok (latest-instant-launch-mappings-defaults))))))))

--- a/src/terrain/routes/schemas/instantlaunch.clj
+++ b/src/terrain/routes/schemas/instantlaunch.clj
@@ -1,0 +1,25 @@
+(ns terrain.routes.schemas.instantlaunch
+  (:use [common-swagger-api.schema :only [describe NonBlankString]]
+        [schema.core :only [defschema Any Keyword optional-key]])
+  (:import [java.util UUID]))
+
+(defschema InstantLaunch
+  {:id              (describe UUID "The UUID of the instant launch")
+   :quick_launch_id (describe UUID "The UUID for the quick launch used for the instant launch")
+   :added_by        (describe String "The username of the user that created the instant launch")
+   :added_on        (describe String "The date and time when the instant launch was created")})
+
+(defschema InstantLaunchSelector
+  {:pattern    (describe String "The pattern used to match against the file. Interpretation is defined by the 'kind' field")
+   :kind       (describe String "The kind of selector. Freeform for now")
+   :default    (describe InstantLaunch "The default instant launch for the file")
+   :compatible (describe [InstantLaunch] "Instant launches that are compatible with the file, but are not the default")})
+
+(defschema InstantLaunchMapping
+  {(describe Keyword "Instant Launch pattern key") (describe InstantLaunchSelector "Instant Launch pattern definition")})
+
+(defschema DefaultInstantLaunchMapping
+  {:id      (describe UUID "The UUID of the default instant launch mapping")
+   :version (describe String "The format version of the instant launch mapping")
+   :mapping (describe InstantLaunchMapping "The set of patterns use to match files to instant launches")})
+

--- a/src/terrain/routes/schemas/instantlaunches.clj
+++ b/src/terrain/routes/schemas/instantlaunches.clj
@@ -1,4 +1,4 @@
-(ns terrain.routes.schemas.instantlaunch
+(ns terrain.routes.schemas.instantlaunches
   (:use [common-swagger-api.schema :only [describe NonBlankString]]
         [schema.core :only [defschema Any Keyword optional-key]])
   (:import [java.util UUID]))
@@ -22,4 +22,7 @@
   {:id      (describe UUID "The UUID of the default instant launch mapping")
    :version (describe String "The format version of the instant launch mapping")
    :mapping (describe InstantLaunchMapping "The set of patterns use to match files to instant launches")})
+
+(def LatestILMappingsDefaultsSummary "The latest defaults for instant launch mappings")
+(def LatestILMappingsDefaultsDescription "The latest defaults for instant launch mappings, which determine which files can be used with a particular instant launch")
 

--- a/src/terrain/routes/schemas/instantlaunches.clj
+++ b/src/terrain/routes/schemas/instantlaunches.clj
@@ -24,5 +24,6 @@
    :mapping (describe InstantLaunchMapping "The set of patterns use to match files to instant launches")})
 
 (def LatestILMappingsDefaultsSummary "The latest defaults for instant launch mappings")
-(def LatestILMappingsDefaultsDescription "The latest defaults for instant launch mappings, which determine which files can be used with a particular instant launch")
+(def LatestILMappingsDefaultsDescription "The latest defaults for instant launch mappings,
+   which determine which files can be used with a particular instant launch")
 


### PR DESCRIPTION
Adds a single endpoint along with some schema definitions for instant launch support. This is what's expected to be needed for the basic proof-of-concept of instant launches (along with a whole bunch of unexposed backend API changes that have gone into app-exposer).