### PR TITLE
Add rudimentary opentelemetry instrumentation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,6 +43,7 @@
                  [org.cyverse/kameleon "3.0.4"]
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/metadata-files "1.0.3"]
+                 [org.cyverse/otel "0.2.1"]
                  [org.cyverse/permissions-client "2.8.1"]
                  [org.cyverse/service-logging "2.8.2"]]
   :eastwood {:exclude-namespaces [terrain.util.jwt :test-paths]

--- a/src/terrain/clients/keycloak.clj
+++ b/src/terrain/clients/keycloak.clj
@@ -1,6 +1,7 @@
 (ns terrain.clients.keycloak
   (:require [cemerick.url :as curl]
             [clj-http.client :as http]
+            [otel.otel :as otel]
             [terrain.util.config :as config]))
 
 (defn- keycloak-url
@@ -11,30 +12,33 @@
 (defn get-oidc-certs
   "Retrieves a list of active public certificates from Keycloak."
   []
-  (-> (http/get (keycloak-url "protocol" "openid-connect" "certs")
-                {:as :json})
-      :body
-      :keys))
+  (otel/with-span [s ["get-oidc-certs" {:kind :client}]]
+    (-> (http/get (keycloak-url "protocol" "openid-connect" "certs")
+                  {:as :json})
+        :body
+        :keys)))
 
 (defn get-token
   "Obtains an authorization token."
   [username password]
-  (:body (http/post (keycloak-url "protocol" "openid-connect" "token")
-                    {:form-params {:grant_type    "password"
-                                   :client_id     (config/keycloak-client-id)
-                                   :client_secret (config/keycloak-client-secret)
-                                   :username      username
-                                   :password      password}
-                     :as          :json})))
+  (otel/with-span [s ["get-token" {:kind :client}]]
+    (:body (http/post (keycloak-url "protocol" "openid-connect" "token")
+                      {:form-params {:grant_type    "password"
+                                     :client_id     (config/keycloak-client-id)
+                                     :client_secret (config/keycloak-client-secret)
+                                     :username      username
+                                     :password      password}
+                       :as          :json}))))
 
 (defn get-impersonation-token
   "Obtains an impersonation token for troubleshooting purposes."
   [subject-token username]
-  (:body (http/post (keycloak-url "protocol" "openid-connect" "token")
-                    {:form-params {:grant_type           "urn:ietf:params:oauth:grant-type:token-exchange"
-                                   :client_id            (config/keycloak-client-id)
-                                   :client_secret        (config/keycloak-client-secret)
-                                   :subject_token        subject-token
-                                   :requested_token_type "urn:ietf:params:oauth:token-type:access_token"
-                                   :requested_subject    username}
-                     :as          :json})))
+  (otel/with-span [s ["get-impersonation-token" {:kind :client}]]
+    (:body (http/post (keycloak-url "protocol" "openid-connect" "token")
+                      {:form-params {:grant_type           "urn:ietf:params:oauth:grant-type:token-exchange"
+                                     :client_id            (config/keycloak-client-id)
+                                     :client_secret        (config/keycloak-client-secret)
+                                     :subject_token        subject-token
+                                     :requested_token_type "urn:ietf:params:oauth:token-type:access_token"
+                                     :requested_subject    username}
+                       :as          :json}))))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -3,6 +3,7 @@
         [clojure-commons.lcase-params :only [wrap-lcase-params]]
         [clojure-commons.query-params :only [wrap-query-params]]
         [common-swagger-api.schema]
+        [otel.middleware :only [otel-middleware]]
         [ring.middleware.keyword-params :only [wrap-keyword-params]]
         [service-logging.middleware :only [wrap-logging clean-context]]
         [terrain.auth.user-attributes]
@@ -293,7 +294,8 @@
                                      {:name "webhooks", :description "Webhook Endpoints"}]
                :securityDefinitions security-definitions}})
   (middleware
-   [[wrap-query-param-remover "ip-address" #{#"^/terrain/secured/bootstrap"
+   [otel-middleware
+    [wrap-query-param-remover "ip-address" #{#"^/terrain/secured/bootstrap"
                                              #"^/terrain/secured/logout"}]
     wrap-query-params
     wrap-lcase-params


### PR DESCRIPTION
This means that if terrain is set up with a proper tracer (usually, using the java autoinstrumentation), it'll create spans and send the trace parent information when it makes HTTP calls, as well as parse trace parents out of HTTP headers. I also added some specific spans for authentication-related code, mostly because when I was testing this I was curious where some time was going.