### PR TITLE
CORE-1213: allow unauthenticated users to call the /support-email end…

### DIFF
--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -91,7 +91,8 @@
    (app-community-tag-routes)
    (app-elements-routes)
    (app-pipeline-routes)
-   (apps-routes)))
+   (apps-routes)
+   (misc-metadata-routes)))
 
 ; Add new secured routes to this function, not to (secured-routes).
 ; This function allows for secured routes without the /secured content/prefix,
@@ -110,7 +111,6 @@
    (tool-request-routes)
    (permanent-id-request-routes)
    (webhook-routes)
-   (misc-metadata-routes)
    (oauth-routes)
    (request-routes)
    (bag-routes)
@@ -285,6 +285,7 @@
                                      {:name "reference-genomes", :description "Reference Genome Endpoints"}
                                      {:name "requests", :description "Request Endpoints"}
                                      {:name "subjects", :description "Subject Endpoints"}
+                                     {:name "support", :description "Support Endpoints"}
                                      {:name "tags", :description "Tag Endpoints"}
                                      {:name "teams", :description "Team Endpoints"}
                                      {:name "tools", :description "Tool Endpoints"}

--- a/src/terrain/routes/metadata.clj
+++ b/src/terrain/routes/metadata.clj
@@ -325,7 +325,12 @@
    [config/app-routes-enabled]
 
    (POST "/support-email" [:as {body :body}]
-     (send-support-email body))))
+     :tags ["support"]
+     :body [body SupportEmailRequest]
+     :summary SupportEmailSummary
+     :description SupportEmailDescription
+     (send-support-email body)
+     (ok))))
 
 (defn admin-integration-data-routes
   []

--- a/src/terrain/routes/schemas/apps.clj
+++ b/src/terrain/routes/schemas/apps.clj
@@ -1,6 +1,6 @@
 (ns terrain.routes.schemas.apps
   (:use [common-swagger-api.schema]
-        [schema.core :only [defschema enum]])
+        [schema.core :only [Any defschema enum optional-key]])
   (:require [common-swagger-api.schema.apps :as apps-schema]))
 
 ;; Convert the keywords in AppSearchValidSortFields to strings,
@@ -10,3 +10,19 @@
          {SortFieldOptionalKey
           (describe (apply enum (map name apps-schema/AppSearchValidSortFields))
                     SortFieldDocs)}))
+
+(def SupportEmailSummary "Send an Email to Support")
+(def SupportEmailDescription "Sends an email to the Support team.")
+
+;; The request body for the support-email endpoint.
+(defschema SupportEmailRequest
+  {(optional-key :email)
+   (describe String (str "The email address to use in the FROM field of the email to Support. If no email address "
+                         "is specified but the user is authenticated then the user's primary email address will be "
+                         "used. Otherwise, a default email address will be used"))
+
+   :fields
+   (describe Any "Arbitrary key/value pairs to include in the email to Support")
+
+   (optional-key :subject)
+   (describe String "The email subject. If no subject is provided, a default subject will be used")})

--- a/src/terrain/services/metadata/apps.clj
+++ b/src/terrain/services/metadata/apps.clj
@@ -30,5 +30,4 @@
 (defn send-support-email
   "Sends a support email from the user."
   [body]
-  (email/send-support-email (cheshire/decode-stream (reader body)))
-  (success-response))
+  (email/send-support-email body))

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -156,6 +156,11 @@
   [props config-valid configs app-routes-enabled]
   "terrain.email.support-email-dest")
 
+(cc/defprop-str support-email-src-addr
+  "The default source email address for DE support request messages."
+  [props config-valid configs app-routes-enabled]
+  "terrain.email.support-email-src")
+
 (cc/defprop-optstr apps-base-url
   "The base URL to use when connecting to secured Apps services."
   [props config-valid configs app-routes-enabled]

--- a/src/terrain/util/email.clj
+++ b/src/terrain/util/email.clj
@@ -100,16 +100,16 @@
   [[k v]]
   (str (->> (if (sequential? v) v [v])
             (mapv (partial str " - "))
-            (concat [k])
+            (concat [(name k)])
             (string/join "\n"))
        "\n\n"))
 
 (defn send-support-email
   "Sends email messages containing information about a request for support."
-  [{:strs [email fields subject]}]
+  [{:keys [email fields subject]}]
   (send-email
    :to        (config/support-email-dest-addr)
-   :from-addr (or email (:email current-user))
+   :from-addr (or email (:email current-user) (config/support-email-src-addr))
    :subject   (or subject "DE Support Request")
    :template  "blank"
    :values    {:contents (apply str (mapv format-field fields))}))


### PR DESCRIPTION
…point

I tested these changes using the following `curl` commands (with different email addresses when they're explicitly specified):

```
$ curl -sH "$AUTH_HEADER" -H 'Content-Type: application/json' "http://localhost:31325/support-email" -d '{"fields":{"foo":"bar"},"subject":"Something Strange"}'
$ curl -sH 'Content-Type: application/json' "http://localhost:31325/support-email" -d '{"fields":{"foo":"bar"},"subject":"Something Strange"}'
$ curl -sH 'Content-Type: application/json' "http://localhost:31325/support-email" -d '{"email":"nobody@example.org","fields":{"foo":"bar"},"subject":"Something Strange"}'
$ curl -sH "$AUTH_HEADER" -H 'Content-Type: application/json' "http://localhost:31325/support-email" -d '{"fields":{"foo":"bar"}}'
$ curl -sH 'Content-Type: application/json' "http://localhost:31325/support-email" -d '{"fields":{"foo":"bar"}}'
$ curl -sH 'Content-Type: application/json' "http://localhost:31325/support-email" -d '{"email":"nobody@example.org","fields":{"foo":"bar"}}'
```
