### PR TITLE
CORE-1216: bumped the common-swagger-api version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.5"]
+                 [org.cyverse/common-swagger-api "3.0.6"]
                  [org.cyverse/kameleon "3.0.4"]
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/metadata-files "1.0.3"]


### PR DESCRIPTION
This PR is also tiny. I'm going to merge it immediately.