### PR TITLE
CORE-1219: switched to common-swagger-api version 3.0.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.6"]
+                 [org.cyverse/common-swagger-api "3.0.7"]
                  [org.cyverse/kameleon "3.0.4"]
                  [org.cyverse/metadata-client "3.1.1"]
                  [org.cyverse/metadata-files "1.0.3"]


### PR DESCRIPTION
This is just a dependency update, so I'm going to merge it immediately.
