### PR TITLE
Add more of the Instant Launch API

### DIFF
--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -138,7 +138,7 @@
   (-> (app-exposer-url ["instantlaunches/"] {} :no-user true)
       (client/put {:content-type :json
                    :as           :json
-                   :form-params  (update il :added_by #(if (not %1) username %1))})
+                   :form-params  (update il :added_by #(or %1 username))})
       (:body)))
 
 (defn update-instant-launch

--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -97,16 +97,16 @@
   (:body (client/get (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true) {:as :json})))
 
 (defn add-latest-instant-launch-mappings-defaults
-  [latest]
-  (:body (client/put (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true) {:as           :json
-                                                                                                            :content-type :json
-                                                                                                            :form-params  latest})))
+  [username latest]
+  (:body (client/put (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {:username username} :no-user true) {:as           :json
+                                                                                                                              :content-type :json
+                                                                                                                              :form-params  latest})))
 
 (defn update-latest-instant-launch-mappings-defaults
-  [latest]
-  (:body (client/post (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true) {:as           :json
-                                                                                                             :content-type :json
-                                                                                                             :form-params  latest})))
+  [username latest]
+  (:body (client/post (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {:username username} :no-user true) {:as           :json
+                                                                                                                               :content-type :json
+                                                                                                                               :form-params  latest})))
 
 (defn delete-latest-instant-launch-mappings-defaults
   []
@@ -114,17 +114,19 @@
 
 (defn get-instant-launch-list
   []
-  (:body (client/get (app-exposer-url ["instantlaunches"] {} :no-user true) {:as :json})))
+  {:instant_launches (:body (client/get (app-exposer-url ["instantlaunches"] {} :no-user true) {:as :json}))})
 
 (defn get-instant-launch
   [id]
-  (:body (client/get (app-exposer-url ["instantlaunches"] {} :no-user true) {:as :json})))
+  (:body (client/get (app-exposer-url ["instantlaunches" id] {} :no-user true) {:as :json})))
 
 (defn add-instant-launch
   [username il]
-  (:body (client/put (app-exposer-url ["instantlaunches"] {} :no-user true) {:content-type :json
-                                                                             :as           :json
-                                                                             :form-params  (update il :added_by #(if (not %1) username %1))})))
+  (let [u (app-exposer-url ["instantlaunches/"] {} :no-user true)]
+    (println u)
+    (:body (client/put u {:content-type :json
+                          :as           :json
+                          :form-params  (update il :added_by #(if (not %1) username %1))}))))
 
 (defn update-instant-launch
   [id il]

--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -94,46 +94,63 @@
 
 (defn latest-instant-launch-mappings-defaults
   []
-  (:body (client/get (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true) {:as :json})))
+  (-> (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true)
+      (client/get {:as :json})
+      (:body)))
 
 (defn add-latest-instant-launch-mappings-defaults
   [username latest]
-  (:body (client/put (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {:username username} :no-user true) {:as           :json
-                                                                                                                              :content-type :json
-                                                                                                                              :form-params  latest})))
+  (-> (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {:username username} :no-user true)
+      (client/put {:as           :json
+                   :content-type :json
+                   :form-params  latest})
+      (:body)))
 
 (defn update-latest-instant-launch-mappings-defaults
   [username latest]
-  (:body (client/post (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {:username username} :no-user true) {:as           :json
-                                                                                                                               :content-type :json
-                                                                                                                               :form-params  latest})))
+  (-> (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {:username username} :no-user true)
+      (client/post {:as           :json
+                    :content-type :json
+                    :form-params  latest})
+      (:body)))
 
 (defn delete-latest-instant-launch-mappings-defaults
   []
-  (:body (client/delete (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true) {:as :json})))
+  (-> (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true)
+      (client/delete {:as :json})
+      (:body)))
 
 (defn get-instant-launch-list
   []
-  {:instant_launches (:body (client/get (app-exposer-url ["instantlaunches"] {} :no-user true) {:as :json}))})
+  {:instant_launches
+   (-> (app-exposer-url ["instantlaunches"] {} :no-user true)
+       (client/get {:as :json})
+       (:body))})
 
 (defn get-instant-launch
   [id]
-  (:body (client/get (app-exposer-url ["instantlaunches" id] {} :no-user true) {:as :json})))
+  (-> (app-exposer-url ["instantlaunches" id] {} :no-user true)
+      (client/get {:as :json})
+      (:body)))
 
 (defn add-instant-launch
   [username il]
-  (let [u (app-exposer-url ["instantlaunches/"] {} :no-user true)]
-    (println u)
-    (:body (client/put u {:content-type :json
-                          :as           :json
-                          :form-params  (update il :added_by #(if (not %1) username %1))}))))
+  (-> (app-exposer-url ["instantlaunches/"] {} :no-user true)
+      (client/put {:content-type :json
+                   :as           :json
+                   :form-params  (update il :added_by #(if (not %1) username %1))})
+      (:body)))
 
 (defn update-instant-launch
   [id il]
-  (:body (client/post (app-exposer-url ["instantlaunches" id] {} :no-user true) {:content-type :json
-                                                                                 :as           :json
-                                                                                 :form-params  il})))
+  (-> (app-exposer-url ["instantlaunches" id] {} :no-user true)
+      (client/post {:content-type :json
+                    :as           :json
+                    :form-params  il})
+      (:body)))
 
 (defn delete-instant-launch
   [id]
-  (:body (client/delete (app-exposer-url ["instantlaunches" id] {} :no-user true) {:as :json})))
+  (-> (app-exposer-url ["instantlaunches" id] {} :no-user true)
+      (client/delete {:as :json})
+      (:body)))

--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -95,3 +95,43 @@
 (defn latest-instant-launch-mappings-defaults
   []
   (:body (client/get (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true) {:as :json})))
+
+(defn add-latest-instant-launch-mappings-defaults
+  [latest]
+  (:body (client/put (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true) {:as           :json
+                                                                                                            :content-type :json
+                                                                                                            :form-params  latest})))
+
+(defn update-latest-instant-launch-mappings-defaults
+  [latest]
+  (:body (client/post (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true) {:as           :json
+                                                                                                             :content-type :json
+                                                                                                             :form-params  latest})))
+
+(defn delete-latest-instant-launch-mappings-defaults
+  []
+  (:body (client/delete (app-exposer-url ["instantlaunches" "mappings" "defaults" "latest"] {} :no-user true) {:as :json})))
+
+(defn get-instant-launch-list
+  []
+  (:body (client/get (app-exposer-url ["instantlaunches"] {} :no-user true) {:as :json})))
+
+(defn get-instant-launch
+  [id]
+  (:body (client/get (app-exposer-url ["instantlaunches"] {} :no-user true) {:as :json})))
+
+(defn add-instant-launch
+  [username il]
+  (:body (client/put (app-exposer-url ["instantlaunches"] {} :no-user true) {:content-type :json
+                                                                             :as           :json
+                                                                             :form-params  (update il :added_by #(if (not %1) username %1))})))
+
+(defn update-instant-launch
+  [id il]
+  (:body (client/post (app-exposer-url ["instantlaunches" id] {} :no-user true) {:content-type :json
+                                                                                 :as           :json
+                                                                                 :form-params  il})))
+
+(defn delete-instant-launch
+  [id]
+  (:body (client/delete (app-exposer-url ["instantlaunches" id] {} :no-user true) {:as :json})))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -157,6 +157,7 @@
    (admin-community-routes)
    (admin-filesystem-metadata-routes)
    (admin-groups-routes)
+   (admin-instant-launch-routes)
    (admin-notification-routes)
    (admin-ontology-routes)
    (admin-reference-genomes-routes)
@@ -253,6 +254,7 @@
                                      {:name "admin-comments", :description "Comment Administration Endpoints"}
                                      {:name "admin-communities", :description "Community Administration Endpoints"}
                                      {:name "admin-filesystem", :description "File System Administration Endpoints"}
+                                     {:name "admin-instant-launches", :description "Instant Launch Administration Endpoints"}
                                      {:name "admin-reference-genomes", :description "Admin Reference Genome Endpoints"}
                                      {:name "admin-requests", :description "Admin Request Endpoints"}
                                      {:name "admin-settings", :description "Admin Setting Endpoints"}

--- a/src/terrain/routes/instantlaunches.clj
+++ b/src/terrain/routes/instantlaunches.clj
@@ -45,26 +45,26 @@
   (optional-routes
    [config/app-routes-enabled]
 
-   (context "instant-launches" []
+   (context "/instant-launches" []
      :tags ["admin-instant-launches"]
 
      (context "/mappings" []
        (context "/defaults" []
-         (PUT "/" []
+         (PUT "/latest" []
            :summary AddLatestILMappingsDefaultsSummary
            :description AddLatestILMappingsDefaultsDescription
-           :body [body DefaultInstantLaunchMapping]
-           :return DefaultInstantLaunchMapping
-           (ok (add-latest-instant-launch-mappings-defaults body)))
+           :body [body InstantLaunchMapping]
+           :return InstantLaunchMapping
+           (ok (add-latest-instant-launch-mappings-defaults (:username current-user) body)))
 
-         (POST "/" []
+         (POST "/latest" []
            :summary UpdateLatestILMappingsDefaultsSummary
            :description UpdateLatestILMappingsDefaultsDescription
-           :body [body DefaultInstantLaunchMapping]
-           :return DefaultInstantLaunchMapping
-           (ok (update-latest-instant-launch-mappings-defaults body)))
+           :body [body InstantLaunchMapping]
+           :return InstantLaunchMapping
+           (ok (update-latest-instant-launch-mappings-defaults (:username current-user) body)))
 
-         (DELETE "/" []
+         (DELETE "/latest" []
            :summary DeleteLatestILMappingsDefaultsSummary
            :description DeleteLatestILMappingsDefaultsDescription
            (ok (delete-latest-instant-launch-mappings-defaults)))))

--- a/src/terrain/routes/instantlaunches.clj
+++ b/src/terrain/routes/instantlaunches.clj
@@ -40,7 +40,7 @@
          :return InstantLaunch
          (ok (get-instant-launch id)))))))
 
-(defn instant-launch-admin-routes
+(defn admin-instant-launch-routes
   []
   (optional-routes
    [config/app-routes-enabled]

--- a/src/terrain/routes/instantlaunches.clj
+++ b/src/terrain/routes/instantlaunches.clj
@@ -3,7 +3,7 @@
         [ring.util.http-response :only [ok]]
         [terrain.routes.schemas.instantlaunches]
         [terrain.auth.user-attributes :only [current-user]]
-        [terrain.clients.app-exposer :only [latest-instant-launch-mappings-defaults]]
+        [terrain.clients.app-exposer]
         [terrain.util :only [optional-routes]])
   (:require [terrain.util.config :as config]
             [clojure.tools.logging :as log]))
@@ -23,4 +23,70 @@
            :summary LatestILMappingsDefaultsSummary
            :description LatestILMappingsDefaultsDescription
            :return DefaultInstantLaunchMapping
-           (ok (latest-instant-launch-mappings-defaults))))))))
+           (ok (latest-instant-launch-mappings-defaults)))))
+
+     (GET "/" []
+       :summary ListInstantLaunchesSummary
+       :description ListInstantLaunchesDescription
+       :return InstantLaunchList
+       (ok (get-instant-launch-list)))
+
+     (context "/:id" []
+       :path-params [id :- InstantLaunchIDParam]
+
+       (GET "/" []
+         :summary GetInstantLaunchSummary
+         :description GetInstantLaunchDescription
+         :return InstantLaunch
+         (ok (get-instant-launch id)))))))
+
+(defn instant-launch-admin-routes
+  []
+  (optional-routes
+   [config/app-routes-enabled]
+
+   (context "instant-launches" []
+     :tags ["admin-instant-launches"]
+
+     (context "/mappings" []
+       (context "/defaults" []
+         (PUT "/" []
+           :summary AddLatestILMappingsDefaultsSummary
+           :description AddLatestILMappingsDefaultsDescription
+           :body [body DefaultInstantLaunchMapping]
+           :return DefaultInstantLaunchMapping
+           (ok (add-latest-instant-launch-mappings-defaults body)))
+
+         (POST "/" []
+           :summary UpdateLatestILMappingsDefaultsSummary
+           :description UpdateLatestILMappingsDefaultsDescription
+           :body [body DefaultInstantLaunchMapping]
+           :return DefaultInstantLaunchMapping
+           (ok (update-latest-instant-launch-mappings-defaults body)))
+
+         (DELETE "/" []
+           :summary DeleteLatestILMappingsDefaultsSummary
+           :description DeleteLatestILMappingsDefaultsDescription
+           (ok (delete-latest-instant-launch-mappings-defaults)))))
+
+     (PUT "/" []
+       :summary AddInstantLaunchSummary
+       :description AddInstantLaunchDescription
+       :body [body InstantLaunch]
+       :return InstantLaunch
+       (ok (add-instant-launch (:username current-user) body)))
+
+     (context "/:id" []
+       :path-params [id :- InstantLaunchIDParam]
+
+       (POST "/" []
+         :summary UpdateInstantLaunchSummary
+         :description UpdateInstantLaunchDescription
+         :body [body InstantLaunch]
+         :return InstantLaunch
+         (ok (update-instant-launch id body)))
+
+       (DELETE "/" []
+         :summary DeleteInstantLaunchSummary
+         :description DeleteInstantLaunchDescription
+         (ok (delete-instant-launch id)))))))

--- a/src/terrain/routes/schemas/instantlaunches.clj
+++ b/src/terrain/routes/schemas/instantlaunches.clj
@@ -28,7 +28,7 @@
 (defschema InstantLaunch
   {(optional-key :id)              (describe UUID "The UUID of the instant launch")
    :quick_launch_id                (describe UUID "The UUID for the quick launch used for the instant launch")
-   (optional-key :added_by)        (describe String "The username of the user that created the instant launch")
+   (optional-key :added_by)        (describe String "The username of the user who created the instant launch")
    (optional-key :added_on)        (describe String "The date and time when the instant launch was created")})
 
 (defschema InstantLaunchList

--- a/src/terrain/routes/schemas/instantlaunches.clj
+++ b/src/terrain/routes/schemas/instantlaunches.clj
@@ -3,11 +3,36 @@
         [schema.core :only [defschema Any Keyword optional-key]])
   (:import [java.util UUID]))
 
+(def InstantLaunchIDParam (describe String "The ID of the instant launch"))
+
+(def ListInstantLaunchesSummary "Lists instant launches")
+(def ListInstantLaunchesDescription "Lists the instant launches available in the system")
+(def AddInstantLaunchSummary "Adds an instant launch")
+(def AddInstantLaunchDescription "Creates a new instant launch")
+(def GetInstantLaunchSummary "Returns an instant launch")
+(def GetInstantLaunchDescription "Returns an instant launch based on its UUID")
+(def UpdateInstantLaunchSummary "Updates an instant launch")
+(def UpdateInstantLaunchDescription "Updates an instant launch's fields")
+(def DeleteInstantLaunchSummary "Deletes an instant launch")
+(def DeleteInstantLaunchDescription "Deletes an instant launch by its UUID")
+(def AddLatestILMappingsDefaultsSummary "Adds a new mapping as the latest")
+(def AddLatestILMappingsDefaultsDescription "Adds a new mapping as the latest, incrementing the version number")
+(def UpdateLatestILMappingsDefaultsSummary "Updates the latest mapping")
+(def UpdateLatestILMappingsDefaultsDescription "Updates the latest mapping without changing the version number")
+(def DeleteLatestILMappingsDefaultsSummary "Deletes the latest mapping")
+(def DeleteLatestILMappingsDefaultsDescription "Deletes the latest mapping, effectively rolling back to the previous version")
+(def LatestILMappingsDefaultsSummary "The latest defaults for instant launch mappings")
+(def LatestILMappingsDefaultsDescription "The latest defaults for instant launch mappings,
+   which determine which files can be used with a particular instant launch")
+
 (defschema InstantLaunch
-  {:id              (describe UUID "The UUID of the instant launch")
-   :quick_launch_id (describe UUID "The UUID for the quick launch used for the instant launch")
-   :added_by        (describe String "The username of the user that created the instant launch")
-   :added_on        (describe String "The date and time when the instant launch was created")})
+  {(optional-key :id)              (describe UUID "The UUID of the instant launch")
+   :quick_launch_id                (describe UUID "The UUID for the quick launch used for the instant launch")
+   (optional-key :added_by)        (describe String "The username of the user that created the instant launch")
+   (optional-key :added_on)        (describe String "The date and time when the instant launch was created")})
+
+(defschema InstantLaunchList
+  {:instant_launches (describe [InstantLaunch] "A list of instant launches")})
 
 (defschema InstantLaunchSelector
   {:pattern    (describe String "The pattern used to match against the file. Interpretation is defined by the 'kind' field")
@@ -23,7 +48,5 @@
    :version (describe String "The format version of the instant launch mapping")
    :mapping (describe InstantLaunchMapping "The set of patterns use to match files to instant launches")})
 
-(def LatestILMappingsDefaultsSummary "The latest defaults for instant launch mappings")
-(def LatestILMappingsDefaultsDescription "The latest defaults for instant launch mappings,
-   which determine which files can be used with a particular instant launch")
+
 


### PR DESCRIPTION
All of this will be needed for administrating instant launches in Sonora. Adds the ability to manage the instant-launch to file mapping, along with the instant launch objects themselves.