### PR TITLE
Loading Page API

### DIFF
--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -48,9 +48,52 @@
   (:body (client/post (app-exposer-url ["vice" "admin" "analyses" analysis-id "time-limit"] {} :no-user true) {:as :json})))
 
 (defn get-resources
-  "Calls app-exposer's GET /vice/listing endpoint, with filter as the query filter map."
+  "Calls app-exposer's GET /vice/listing endpoint, with filter as the query filter map. 
+  Returns only results applicable to the user."
   [filter]
-  (:body (client/get (app-exposer-url ["vice" "listing"] filter :no-user true) {:as :json})))
+  (:body (client/get (app-exposer-url ["vice" "listing"] filter) {:as :json})))
+
+(defn admin-get-resources
+  "Calls app-exposer's GET /vice/admin/listing endpoint, with the filter as the
+   query parameter map. Bypasses the user filter present in the non-admin version."
+  [filter]
+  (-> (app-exposer-url ["vice" "admin" "listing"] filter :no-user true)
+      (client/get  {:as :json})
+      (:body)))
+
+(defn url-ready
+  "Calls app-exposer's GET /vice/:host/url-ready endpoint, which returns a map
+   containing a boolean that tells whether the analysis is ready for browser access.
+   Checks if the logged in user has permission to access the analysis before returning
+   a result."
+  [host]
+  (-> (app-exposer-url ["vice" host "url-ready"] {})
+      (client/get  {:as :json})
+      (:body)))
+
+(defn admin-url-ready
+  "Same as url-ready, but calls the admin version that bypasses the permissions check
+   present in the non-admin version of the call."
+  [host]
+  (-> (app-exposer-url ["vice" "admin" host "url-ready"] {} :no-user true)
+      (client/get {:as :json})
+      (:body)))
+
+(defn get-description-by-host
+  "Returns a JSON description of the resources created for the analyis with the supplied
+   host/subdomain."
+  [host]
+  (-> (app-exposer-url ["vice" host "description"] {})
+      (client/get {:as :json})
+      (:body)))
+
+(defn admin-get-description-by-host
+  "Returns a JSON description of the resources created for the analysis with the supplied
+   host/subdomain. Bypasses the permissions check present in the non-admin version of this call."
+  [host]
+  (-> (app-exposer-url ["vice" "admin" host "description"] {} :no-user true)
+      (client/get {:as :json})
+      (:body)))
 
 (defn cancel-analysis
   "Calls app-exposer's POST /vice/{id}/save-and-exit endpoint"

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -115,6 +115,7 @@
    (request-routes)
    (bag-routes)
    (instant-launch-routes)
+   (vice-routes)
    (route/not-found (service/unrecognized-path-response))))
 
 ; The old way of adding secured routes. Prepends /secured to the URL

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -295,7 +295,8 @@
                                      {:name "tool-requests", :description "Tool Request Endpoints"}
                                      {:name "token", :description "OAuth Tokens"}
                                      {:name "user-info", :description "User Information Endpoints"}
-                                     {:name "webhooks", :description "Webhook Endpoints"}]
+                                     {:name "webhooks", :description "Webhook Endpoints"}
+                                     {:name "vice", :description "VICE Endpoints"}]
                :securityDefinitions security-definitions}})
   (middleware
    [otel-middleware

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -129,6 +129,9 @@
    (optional-key :user-id)       (describe (maybe UUID) "The UUID assigned to the user that launched the analysis")
    (optional-key :username)      (describe (maybe String) "The user of the user that launched the analysis")})
 
+(defschema NonAdminFilterParams
+  (dissoc FilterParams (optional-key :user-id) (optional-key :username)))
+
 (def URLReadySummary "Whether or not a VICE analysis is browser accessible")
 (def URLReadyDescription "Returns a map detailing whether or not the VICE analysis is ready to be accessed through a browser")
 (def AdminURLReadySummary "Whether or not a VICE analysis is browser accessible. No permissions checks")
@@ -141,4 +144,4 @@
 (def Host (describe String "The hostname/subdomain of a VICE analysis"))
 
 (defschema URLReady
-  {:url-ready (describe Boolean "Whether or not the analysis is ready to be accessed.")})
+  {:ready (describe Boolean "Whether or not the analysis is ready to be accessed.")})

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -128,3 +128,17 @@
    (optional-key :external-id)   (describe (maybe UUID) "The value of the external_id field in the job_steps table. Used widely in the API")
    (optional-key :user-id)       (describe (maybe UUID) "The UUID assigned to the user that launched the analysis")
    (optional-key :username)      (describe (maybe String) "The user of the user that launched the analysis")})
+
+(def URLReadySummary "Whether or not a VICE analysis is browser accessible")
+(def URLReadyDescription "Returns a map detailing whether or not the VICE analysis is ready to be accessed through a browser")
+(def AdminURLReadySummary "Whether or not a VICE analysis is browser accessible. No permissions checks")
+(def AdminURLReadyDescription "Returns a map detailing whether or not the VICE analysis is ready to be accessed through a browser. No permissions checks.")
+
+(def DescriptionSummary "Returns a JSON description of the VICE analysis")
+(def DescriptionDescription "Returns a JSON description of the VICE analysis after verifying the user has access to it")
+(def AdminDescriptionDescription "Returns a JSON description of the VICE analysis, bypassing permissions checks")
+
+(def Host (describe String "The hostname/subdomain of a VICE analysis"))
+
+(defschema URLReady
+  {:url-ready (describe Boolean "Whether or not the analysis is ready to be accessed.")})

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -97,7 +97,7 @@
      :tags ["vice"]
 
      (GET "/resources" []
-       :query [filter vice-schema/FilterParams]
+       :query [filter vice-schema/NonAdminFilterParams]
        :return vice-schema/FullResourceListing
        :summary "List Kubernetes resources deployed in the cluster"
        :description "Lists all Kubernetes resources associated with an analysis running in the cluster for a user"

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -16,77 +16,76 @@
    (context "/vice" []
      :tags ["admin-vice"]
 
-     (context "/admin" []
-       (GET "/resources" []
-         :query [filter vice-schema/FilterParams]
+     (GET "/resources" []
+       :query [filter vice-schema/FilterParams]
+       :return vice-schema/FullResourceListing
+       :summary "List Kubernetes resources deployed in the cluster"
+       :description "Lists all Kubernetes resources associated with an analysis running in the cluster."
+       (ok (vice/admin-get-resources filter)))
+
+     (GET "/async-data" []
+       :query [params vice-schema/AsyncDataParams]
+       :return vice-schema/AsyncData
+       :summary "Get data that is generated asynchronously"
+       :description "Get data for the VICE analysis that is generated asynchronously"
+       (ok (vice/async-data params)))
+
+     (context "/analyses" []
+       (context "/:analysis-id" []
+         :path-params [analysis-id :- vice-schema/AnalysisID]
+
+         (GET "/time-limit" []
+           :return vice-schema/TimeLimit
+           :summary "Get current time limit"
+           :description "Gets the current time limit set for the analysis"
+           (ok (vice/admin-get-time-limit analysis-id)))
+
+         (POST "/time-limit" []
+           :return vice-schema/TimeLimit
+           :summary "Extend the time limit"
+           :description "Extends the time limit for the analysis by 3 days"
+           (ok (vice/admin-set-time-limit analysis-id)))
+
+         (POST "/save-and-exit" []
+           :summary "Upload outputs and exit"
+           :description "Terminates the analysis after uploading the output files to the data store"
+           (ok (vice/admin-cancel-analysis analysis-id)))
+
+         (POST "/exit" []
+           :summary "Exit without saving"
+           :description "Terminates the analysis without uploading files to the data store"
+           (ok (vice/admin-exit analysis-id)))
+
+         (POST "/save-output-files" []
+           :summary "Upload files without exiting"
+           :description "Uploads output files for the analysis to the data store without terminating the analysis"
+           (ok (vice/admin-save-output-files analysis-id)))
+
+         (POST "/download-input-files" []
+           :summary "Download input files"
+           :description "Downloads input files to the analysis container without changing the status of the analysis"
+           (ok (vice/admin-download-input-files analysis-id)))
+
+         (GET "/external-id" []
+           :return vice-schema/ExternalIDResponse
+           :summary "Get external UUID"
+           :description "Returns the external UUID associated with the analysis. VICE analyses only have a single external UUID"
+           (ok (vice/admin-external-id analysis-id)))))
+
+     (context "/:host" []
+       :path-params [host :- vice-schema/Host]
+
+       (GET "/url-ready" []
+         :return vice-schema/URLReady
+         :summary vice-schema/URLReadySummary
+         :description vice-schema/URLReadyDescription
+         (ok (vice/admin-url-ready host)))
+
+       (GET "/description" []
          :return vice-schema/FullResourceListing
-         :summary "List Kubernetes resources deployed in the cluster"
-         :description "Lists all Kubernetes resources associated with an analysis running in the cluster."
-         (ok (vice/admin-get-resources filter)))
-
-       (GET "/async-data" []
-         :query [params vice-schema/AsyncDataParams]
-         :return vice-schema/AsyncData
-         :summary "Get data that is generated asynchronously"
-         :description "Get data for the VICE analysis that is generated asynchronously"
-         (ok (vice/async-data params)))
-
-       (context "/analyses" []
-         (context "/:analysis-id" []
-           :path-params [analysis-id :- vice-schema/AnalysisID]
-
-           (GET "/time-limit" []
-             :return vice-schema/TimeLimit
-             :summary "Get current time limit"
-             :description "Gets the current time limit set for the analysis"
-             (ok (vice/admin-get-time-limit analysis-id)))
-
-           (POST "/time-limit" []
-             :return vice-schema/TimeLimit
-             :summary "Extend the time limit"
-             :description "Extends the time limit for the analysis by 3 days"
-             (ok (vice/admin-set-time-limit analysis-id)))
-
-           (POST "/save-and-exit" []
-             :summary "Upload outputs and exit"
-             :description "Terminates the analysis after uploading the output files to the data store"
-             (ok (vice/admin-cancel-analysis analysis-id)))
-
-           (POST "/exit" []
-             :summary "Exit without saving"
-             :description "Terminates the analysis without uploading files to the data store"
-             (ok (vice/admin-exit analysis-id)))
-
-           (POST "/save-output-files" []
-             :summary "Upload files without exiting"
-             :description "Uploads output files for the analysis to the data store without terminating the analysis"
-             (ok (vice/admin-save-output-files analysis-id)))
-
-           (POST "/download-input-files" []
-             :summary "Download input files"
-             :description "Downloads input files to the analysis container without changing the status of the analysis"
-             (ok (vice/admin-download-input-files analysis-id)))
-
-           (GET "/external-id" []
-             :return vice-schema/ExternalIDResponse
-             :summary "Get external UUID"
-             :description "Returns the external UUID associated with the analysis. VICE analyses only have a single external UUID"
-             (ok (vice/admin-external-id analysis-id)))))
-
-       (context "/:host" []
-         :path-params [host :- vice-schema/Host]
-
-         (GET "/url-ready" []
-           :return vice-schema/URLReady
-           :summary vice-schema/URLReadySummary
-           :description vice-schema/URLReadyDescription
-           (ok (vice/admin-url-ready host)))
-
-         (GET "/description" []
-           :return vice-schema/FullResourceListing
-           :summary vice-schema/DescriptionSummary
-           :description vice-schema/AdminDescriptionDescription
-           (ok (vice/admin-get-description-by-host host))))))))
+         :summary vice-schema/DescriptionSummary
+         :description vice-schema/AdminDescriptionDescription
+         (ok (vice/admin-get-description-by-host host)))))))
 
 (defn vice-routes
   []

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -11,67 +11,110 @@
 (defn admin-vice-routes
   []
   (optional-routes
-    [config/app-routes-enabled]
-    
-    (context "/vice" []
-      :tags ["admin-vice"]
-      
-      (GET "/resources" []
-        :query [filter vice-schema/FilterParams]
-        :return vice-schema/FullResourceListing
-        :summary "List Kubernetes resources deployed in the cluster"
-        :description "Lists all Kubernetes resources associated with an analysis running in the cluster."
-        (ok (vice/get-resources filter)))
+   [config/app-routes-enabled]
 
-      (GET "/async-data" []
-        :query [params vice-schema/AsyncDataParams]
-        :return vice-schema/AsyncData
-        :summary "Get data that is generated asynchronously"
-        :description "Get data for the VICE analysis that is generated asynchronously"
-        (ok (vice/async-data params)))
-      
-      (GET "/analyses/:analysis-id/time-limit" []
-        :path-params [analysis-id :- vice-schema/AnalysisID]
-        :return vice-schema/TimeLimit
-        :summary "Get current time limit"
-        :description "Gets the current time limit set for the analysis"
-        (ok (vice/admin-get-time-limit analysis-id)))
-        
-      (POST "/analyses/:analysis-id/time-limit" []
-        :path-params [analysis-id :- vice-schema/AnalysisID]
-        :return vice-schema/TimeLimit
-        :summary "Extend the time limit"
-        :description "Extends the time limit for the analysis by 3 days"
-        (ok (vice/admin-set-time-limit analysis-id)))
-        
-      (POST "/analyses/:analysis-id/save-and-exit" []
-        :path-params [analysis-id :- vice-schema/AnalysisID]
-        :summary "Upload outputs and exit"
-        :description "Terminates the analysis after uploading the output files to the data store"
-        (ok (vice/admin-cancel-analysis analysis-id)))
-      
-      (POST "/analyses/:analysis-id/exit" []
-        :path-params [analysis-id :- vice-schema/AnalysisID]
-        :summary "Exit without saving"
-        :description "Terminates the analysis without uploading files to the data store"
-        (ok (vice/admin-exit analysis-id)))
-      
-      (POST "/analyses/:analysis-id/save-output-files" []
-        :path-params [analysis-id :- vice-schema/AnalysisID]
-        :summary "Upload files without exiting"
-        :description "Uploads output files for the analysis to the data store without terminating the analysis"
-        (ok (vice/admin-save-output-files analysis-id)))
-      
-      (POST "/analyses/:analysis-id/download-input-files" []
-        :path-params [analysis-id :- vice-schema/AnalysisID]
-        :summary "Download input files"
-        :description "Downloads input files to the analysis container without changing the status of the analysis"
-        (ok (vice/admin-download-input-files analysis-id)))
-        
-      (GET "/analyses/:analysis-id/external-id" []
-        :path-params [analysis-id :- vice-schema/AnalysisID]
-        :return vice-schema/ExternalIDResponse
-        :summary "Get external UUID"
-        :description "Returns the external UUID associated with the analysis. VICE analyses only have a single external UUID"
-        (ok (vice/admin-external-id analysis-id))))))
+   (context "/vice" []
+     :tags ["admin-vice"]
+
+     (context "/admin" []
+       (GET "/resources" []
+         :query [filter vice-schema/FilterParams]
+         :return vice-schema/FullResourceListing
+         :summary "List Kubernetes resources deployed in the cluster"
+         :description "Lists all Kubernetes resources associated with an analysis running in the cluster."
+         (ok (vice/admin-get-resources filter)))
+
+       (GET "/async-data" []
+         :query [params vice-schema/AsyncDataParams]
+         :return vice-schema/AsyncData
+         :summary "Get data that is generated asynchronously"
+         :description "Get data for the VICE analysis that is generated asynchronously"
+         (ok (vice/async-data params)))
+
+       (context "/analyses" []
+         (context "/:analysis-id" []
+           :path-params [analysis-id :- vice-schema/AnalysisID]
+
+           (GET "/time-limit" []
+             :return vice-schema/TimeLimit
+             :summary "Get current time limit"
+             :description "Gets the current time limit set for the analysis"
+             (ok (vice/admin-get-time-limit analysis-id)))
+
+           (POST "/time-limit" []
+             :return vice-schema/TimeLimit
+             :summary "Extend the time limit"
+             :description "Extends the time limit for the analysis by 3 days"
+             (ok (vice/admin-set-time-limit analysis-id)))
+
+           (POST "/save-and-exit" []
+             :summary "Upload outputs and exit"
+             :description "Terminates the analysis after uploading the output files to the data store"
+             (ok (vice/admin-cancel-analysis analysis-id)))
+
+           (POST "/exit" []
+             :summary "Exit without saving"
+             :description "Terminates the analysis without uploading files to the data store"
+             (ok (vice/admin-exit analysis-id)))
+
+           (POST "/save-output-files" []
+             :summary "Upload files without exiting"
+             :description "Uploads output files for the analysis to the data store without terminating the analysis"
+             (ok (vice/admin-save-output-files analysis-id)))
+
+           (POST "/download-input-files" []
+             :summary "Download input files"
+             :description "Downloads input files to the analysis container without changing the status of the analysis"
+             (ok (vice/admin-download-input-files analysis-id)))
+
+           (GET "/external-id" []
+             :return vice-schema/ExternalIDResponse
+             :summary "Get external UUID"
+             :description "Returns the external UUID associated with the analysis. VICE analyses only have a single external UUID"
+             (ok (vice/admin-external-id analysis-id)))))
+
+       (context "/:host" []
+         :path-params [host :- vice-schema/Host]
+
+         (GET "/url-ready" []
+           :return vice-schema/URLReady
+           :summary vice-schema/URLReadySummary
+           :description vice-schema/URLReadyDescription
+           (ok (vice/admin-url-ready host)))
+
+         (GET "/description" []
+           :return vice-schema/FullResourceListing
+           :summary vice-schema/DescriptionSummary
+           :description vice-schema/AdminDescriptionDescription
+           (ok (vice/admin-get-description-by-host host))))))))
+
+(defn vice-routes
+  []
+  (optional-routes
+   [config/app-routes-enabled]
+
+   (context "/vice" []
+     :tags ["vice"]
+
+     (GET "/resources" []
+       :query [filter vice-schema/FilterParams]
+       :return vice-schema/FullResourceListing
+       :summary "List Kubernetes resources deployed in the cluster"
+       :description "Lists all Kubernetes resources associated with an analysis running in the cluster for a user"
+       (ok (vice/get-resources filter)))
+
+     (context "/:host" []
+       :path-params [host :- vice-schema/Host]
+
+       (GET "/url-ready" []
+         :return vice-schema/URLReady
+         :summary vice-schema/URLReadySummary
+         :description vice-schema/URLReadyDescription
+         (ok (vice/url-ready host)))
+
+       (GET "/description" []
+         :return vice-schema/FullResourceListing
+         :summary vice-schema/DescriptionSummary
+         :description vice-schema/DescriptionDescription
+         (ok (vice/get-description-by-host host)))))))
 


### PR DESCRIPTION
Requires that the changes in https://github.com/cyverse-de/app-exposer/pull/18 be merged. 

Contains the following changes:
* Proxies GET /vice/:host/description to the new call in app-exposer.
* Proxies GET /vice/:host/url-ready to the new call in app-exposer.
* Proxies GET /vice/resources to the call in app-exposer that filters based on the logged in user. Changed from the old version, which didn't validate access.
* Moves old VICE calls to under /vice/admin.
* Rearranges the use of (context) in the VICE routes file.