### PR TITLE
Add instant launch endpoints that contain submission info

### DIFF
--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -176,6 +176,12 @@
       (client/get {:as :json})
       (:body)))
 
+(defn get-full-instant-launch
+  [id]
+  (-> (app-exposer-url ["instantlaunches" id "full"] {} :no-user true)
+      (client/get {:as :json})
+      (:body)))
+
 (defn add-instant-launch
   [username il]
   (-> (app-exposer-url ["instantlaunches/"] {} :no-user true)
@@ -209,6 +215,13 @@
       (client/get {:as           :json
                    :query-params (assoc query :user (:shortUsername current-user))})
       (:body)))
+
+(defn list-full-metadata
+  [query]
+  {:instant_launches (-> (app-exposer-url ["instantlaunches" "metadata" "full"] {} :no-user true)
+                         (client/get {:as           :json
+                                      :query-params (assoc query :user (:shortUsername current-user))})
+                         (:body))})
 
 (defn get-metadata
   [id]

--- a/src/terrain/routes/instantlaunches.clj
+++ b/src/terrain/routes/instantlaunches.clj
@@ -88,7 +88,8 @@
          :summary ListFullMetadataSummary
          :description ListFullMetadataDescription
          :query [query MetadataListingQueryMap]
-         :return FullInstantLaunchList))
+         :return FullInstantLaunchList
+         (ok (list-full-metadata query))))
 
      (context "/:id" []
        :path-params [id :- InstantLaunchIDParam]

--- a/src/terrain/routes/instantlaunches.clj
+++ b/src/terrain/routes/instantlaunches.clj
@@ -39,7 +39,13 @@
          :summary GetInstantLaunchSummary
          :description GetInstantLaunchDescription
          :return InstantLaunch
-         (ok (get-instant-launch id)))))))
+         (ok (get-instant-launch id)))
+
+       (GET "/full" []
+         :summary GetFullInstantLaunchSummary
+         :description GetFullInstantLaunchDescription
+         :return FullInstantLaunch
+         (ok (get-full-instant-launch id)))))))
 
 (defn admin-instant-launch-routes
   []
@@ -70,12 +76,19 @@
            :description DeleteLatestILMappingsDefaultsDescription
            (ok (delete-latest-instant-launch-mappings-defaults)))))
 
-     (GET "/metadata" []
-       :summary ListMetadataSummary
-       :description ListMetadataDescription
-       :query [query MetadataListingQueryMap]
-       :return AvuList
-       (ok (list-metadata query)))
+     (context "/metadata" []
+       (GET "/" []
+         :summary ListMetadataSummary
+         :description ListMetadataDescription
+         :query [query MetadataListingQueryMap]
+         :return AvuList
+         (ok (list-metadata query)))
+
+       (GET "/full" []
+         :summary ListFullMetadataSummary
+         :description ListFullMetadataDescription
+         :query [query MetadataListingQueryMap]
+         :return FullInstantLaunchList))
 
      (context "/:id" []
        :path-params [id :- InstantLaunchIDParam]

--- a/src/terrain/routes/schemas/instantlaunches.clj
+++ b/src/terrain/routes/schemas/instantlaunches.clj
@@ -39,6 +39,20 @@
    (optional-key :added_by)        (describe String "The username of the user who created the instant launch")
    (optional-key :added_on)        (describe String "The date and time when the instant launch was created")})
 
+(defschema FullInstantLaunch
+  (assoc InstantLaunch
+         :quick_launch_name        (describe String "The name of the quick launch")
+         :quick_launch_description (describe String "The description of the quick launch")
+         :quick_launch_creator     (describe String "The username of the person that created the quick launch")
+         :is_public                (describe Boolean "Whether or not the quick launch is public")
+         :submission               (describe Any "The submission associated with the instant launch/quick launch")
+         :app_id                   (describe String "The UUID of the app used in the instant launch/quick launch")
+         :app_name                 (describe String "The name of the app used in the instant launch/quick launch")
+         :app_description          (describe String "The description of the app used in the instant launch/quick launch")
+         :app_deleted              (describe Boolean "Whether or not the app is deleted")
+         :app_disabled             (describe Boolean "Whether or not the app is disabled")
+         :integrator               (describe String "The username of the person that integrated the app used in the instant launch/quick launch")))
+
 (defschema InstantLaunchList
   {:instant_launches (describe [InstantLaunch] "A list of instant launches")})
 

--- a/src/terrain/routes/schemas/instantlaunches.clj
+++ b/src/terrain/routes/schemas/instantlaunches.clj
@@ -32,6 +32,10 @@
 (def UpsertMetadataDescription "Adds or updates AVUs asssociated with a single instant launch")
 (def ResetMetadataSummary "Resets the AVUs associated with an instant launch")
 (def ResetMetadataDescription "Resets all of the AVUs associated with an instant launch to the AVUs passed into the API call")
+(def GetFullInstantLaunchSummary "Returns full description of an instant launch")
+(def GetFullInstantLaunchDescription "Returns full description of an instant launch, including more info about the quick launch, submission, and app")
+(def ListFullMetadataSummary "Returns a listing containing full descriptions of instant launches")
+(def ListFullMetadataDescription "Returns a listing containing full description of instant launches based on the metadata passed in")
 
 (defschema InstantLaunch
   {(optional-key :id)              (describe UUID "The UUID of the instant launch")
@@ -55,6 +59,9 @@
 
 (defschema InstantLaunchList
   {:instant_launches (describe [InstantLaunch] "A list of instant launches")})
+
+(defschema FullInstantLaunchList
+  {:instant_launches (describe [FullInstantLaunch] "A list of full instant launches")})
 
 (defschema InstantLaunchSelector
   {:pattern    (describe String "The pattern used to match against the file. Interpretation is defined by the 'kind' field")


### PR DESCRIPTION
Adds the `/admin/instant-launches/metadata/full` endpoint, which returns more information about the instant launch pulled from the quick launch and app information associated with it. Also includes the submission.

Adds the `/instant-launches/:id/full` endpoint, which returns the same information as the above endpoint, but just for a single instant launch.

These will allow us to get displayable, launchable instant launches in the UI without requiring multiple service calls to pull all of the necessary info together.