### PR TITLE
CORE-1442: limit the number of VICE requests that a user may submit t…

### DIFF
--- a/src/terrain/services/requests.clj
+++ b/src/terrain/services/requests.clj
@@ -10,6 +10,7 @@
 
 ;; Request type constants
 (def vice-request-type "vice")
+(def vice-maximum-requests-per-user 1)
 
 (defn list-requests
   "Lists requests for administrative endpoints."
@@ -31,7 +32,11 @@
 (defn submit-vice-request
   "Submits a VICE request. Details about the currently authenticated user are automatically added to the request."
   [{username :shortUsername :as user} details]
-  (rc/submit-request vice-request-type username (add-user-to-request-details user details)))
+  (rc/submit-request
+   vice-request-type
+   vice-maximum-requests-per-user
+   username
+   (add-user-to-request-details user details)))
 
 (defn- validate-request-type
   "Verifies that a request has the expected type. This is useful for endpoints where the request type is included


### PR DESCRIPTION
…o one

The following error will be returned if a user has already submitted a VICE request:

```
$ curl -sH "$AUTH_HEADER" -H "Content-Type: application/json" "http://localhost:8000/terrain/requests/vice" -d '{"intended_use":"you know, do stuff","concurrent_jobs":64}' | jq .
{
  "message": "no more requests of type 'vice' may be submitted",
  "error_code": "ERR_LIMIT_REACHED",
  "details": {
    "maximumRequests": 1,
    "requestType": "vice",
    "submittedRequests": 1
  }
}
```