### PR TITLE
CORE-1484 Add non-admin instant launch metadata search endpoint

### DIFF
--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -224,10 +224,10 @@
       (:body)))
 
 (defn list-full-metadata
-  [query]
+  [query username]
   {:instant_launches (-> (app-exposer-url ["instantlaunches" "metadata" "full"] {} :no-user true)
                          (client/get {:as           :json
-                                      :query-params (assoc query :user (:shortUsername current-user))})
+                                      :query-params (assoc query :user username)})
                          (:body))})
 
 (defn get-metadata

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -80,6 +80,7 @@
    (dashboard-aggregator-routes)
    (filesystem-stat-routes)
    (quicklaunch-routes)
+   (instant-launch-routes)
    (secured-data-routes)
    (secured-filesystem-routes)
    (secured-search-routes)
@@ -114,7 +115,6 @@
    (oauth-routes)
    (request-routes)
    (bag-routes)
-   (instant-launch-routes)
    (vice-routes)
    (route/not-found (service/unrecognized-path-response))))
 

--- a/src/terrain/routes/instantlaunches.clj
+++ b/src/terrain/routes/instantlaunches.clj
@@ -42,13 +42,12 @@
        :return FullInstantLaunchList
        (ok (get-full-instant-launch-list)))
 
-     (context "/metadata" []
-       (GET "/full" []
-         :summary ListFullMetadataSummary
-         :description ListFullMetadataDescription
-         :query [query MetadataListingQueryMap]
-         :return FullInstantLaunchList
-         (ok (list-full-metadata query (or (:username current-user) "anonymous")))))
+     (GET "/metadata/full" []
+       :summary ListFullMetadataSummary
+       :description ListFullMetadataDescription
+       :query [query MetadataListingQueryMap]
+       :return FullInstantLaunchList
+       (ok (list-full-metadata query (or (:username current-user) "anonymous"))))
 
      (context "/quicklaunches" []
        (context "/public" []

--- a/src/terrain/routes/instantlaunches.clj
+++ b/src/terrain/routes/instantlaunches.clj
@@ -4,7 +4,7 @@
         [common-swagger-api.schema.quicklaunches :only [QuickLaunch]]
         [terrain.routes.schemas.instantlaunches]
         [common-swagger-api.schema.metadata :only [AvuList AvuListRequest SetAvuRequest]]
-        [terrain.auth.user-attributes :only [current-user]]
+        [terrain.auth.user-attributes :only [current-user require-authentication]]
         [terrain.clients.app-exposer]
         [terrain.util :only [optional-routes]])
   (:require [terrain.util.config :as config]
@@ -22,18 +22,21 @@
        (context "/defaults" []
 
          (GET "/latest" []
+           :middleware  [require-authentication]
            :summary LatestILMappingsDefaultsSummary
            :description LatestILMappingsDefaultsDescription
            :return DefaultInstantLaunchMapping
            (ok (latest-instant-launch-mappings-defaults)))))
 
      (GET "/" []
+       :middleware  [require-authentication]
        :summary ListInstantLaunchesSummary
        :description ListInstantLaunchesDescription
        :return InstantLaunchList
        (ok (get-instant-launch-list)))
 
      (GET "/full" []
+       :middleware  [require-authentication]
        :summary ListFullInstantLaunchesSummary
        :description ListFullInstantLaunchesDescription
        :return FullInstantLaunchList
@@ -45,11 +48,12 @@
          :description ListFullMetadataDescription
          :query [query MetadataListingQueryMap]
          :return FullInstantLaunchList
-         (ok (list-full-metadata query))))
+         (ok (list-full-metadata query (or (:username current-user) "anonymous")))))
 
      (context "/quicklaunches" []
        (context "/public" []
          (GET "/" []
+           :middleware  [require-authentication]
            :summary ListQuickLaunchesForPublicAppsSummary
            :description ListQuickLaunchesForPublicAppsDescription
            :return [QuickLaunch]
@@ -59,12 +63,14 @@
        :path-params [id :- InstantLaunchIDParam]
 
        (GET "/" []
+         :middleware  [require-authentication]
          :summary GetInstantLaunchSummary
          :description GetInstantLaunchDescription
          :return InstantLaunch
          (ok (get-instant-launch id)))
 
        (GET "/full" []
+         :middleware  [require-authentication]
          :summary GetFullInstantLaunchSummary
          :description GetFullInstantLaunchDescription
          :return FullInstantLaunch
@@ -112,7 +118,7 @@
          :description ListFullMetadataDescription
          :query [query MetadataListingQueryMap]
          :return FullInstantLaunchList
-         (ok (list-full-metadata query))))
+         (ok (list-full-metadata query (:username current-user)))))
 
      (context "/:id" []
        :path-params [id :- InstantLaunchIDParam]

--- a/src/terrain/routes/instantlaunches.clj
+++ b/src/terrain/routes/instantlaunches.clj
@@ -39,6 +39,14 @@
        :return FullInstantLaunchList
        (ok (get-full-instant-launch-list)))
 
+     (context "/metadata" []
+       (GET "/full" []
+         :summary ListFullMetadataSummary
+         :description ListFullMetadataDescription
+         :query [query MetadataListingQueryMap]
+         :return FullInstantLaunchList
+         (ok (list-full-metadata query))))
+
      (context "/quicklaunches" []
        (context "/public" []
          (GET "/" []


### PR DESCRIPTION
This endpoint is needed for [CORE-1484](https://cyverse.atlassian.net/browse/CORE-1484). It's a duplicate of the admin version of the endpoint except this one is for non-admins and is accessible to users who aren't logged in. This will allow the DE to query for the list of instant launches which have been added to the navigation drawer as a "first class" resource, specifically the `cli` instant launch.