### PR TITLE
CORE-1542: updated the location of the signing keys for JWTs

### DIFF
--- a/k8s/terrain.yml
+++ b/k8s/terrain.yml
@@ -36,38 +36,9 @@ spec:
         - name: signing-keys
           secret:
             secretName: signing-keys
-            items:
-              - key: private-key.pem
-                path: private-key.pem
-                mode: 0644
-
-              - key: public-key.pem
-                path: public-key.pem
-                mode: 0644
-
-              - key: QApubkey.pem
-                path: accepted_keys/QApubkey.pem
-                mode: 0644
-
-              - key: apim_staging.pub
-                path: accepted_keys/apim_staging.pub
-                mode: 0644
-
-              - key: legfed-pubkey.pem
-                path: accepted_keys/legfed-pubkey.pem
-                mode: 0644
-
-              - key: mirrors.pem
-                path: accepted_keys/mirrors.pem
-                mode: 0644
-
-              - key: peanutbase-pubkey.pem
-                path: accepted_keys/peanutbase-pubkey.pem
-                mode: 0644
-
-              - key: projects-pubkey.pem
-                path: accepted_keys/project-pubkey.pem
-                mode: 0644
+        - name: accepted-keys
+          secret:
+            secretName: accepted-keys
         - name: service-configs
           secret:
             secretName: service-configs
@@ -89,7 +60,10 @@ spec:
           - /etc/iplant/de/terrain.properties
         volumeMounts:
           - name: signing-keys
-            mountPath: /etc/iplant/crypto
+            mountPath: /etc/iplant/crypto/signing_key
+            readOnly: true
+          - name: accepted-keys
+            mountPath: /etc/iplant/crypto/accepted_keys
             readOnly: true
           - name: localtime
             mountPath: /etc/localtime

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -374,7 +374,7 @@
 (cc/defprop-optstr jwt-private-signing-key
   "The path to the private key used for signing JWT assertions."
   [props config-valid configs]
-  "terrain.jwt.signing-key.private" "/etc/iplant/crypto/private-key.pem")
+  "terrain.jwt.signing-key.private" "/etc/iplant/crypto/signing_key/private-key.pem")
 
 (cc/defprop-optstr jwt-private-signing-key-password
   "The password used to access the private key used for signing JWT assertions."
@@ -384,7 +384,7 @@
 (cc/defprop-optstr jwt-public-signing-key
   "The path to the public key used to validate JWT assertions."
   [props config-valid configs]
-  "terrain.jwt.signing-key.public" "/etc/iplant/crypto/public-key.pem")
+  "terrain.jwt.signing-key.public" "/etc/iplant/crypto/signing_key/public-key.pem")
 
 (cc/defprop-optstr jwt-accepted-keys-dir
   "The path to the directory containing public signing keys for JWT assertions."

--- a/src/terrain/util/jwt.clj
+++ b/src/terrain/util/jwt.clj
@@ -2,6 +2,7 @@
   (:use [slingshot.slingshot :only [try+ throw+]])
   (:require [clj-time.core :as time]
             [clojure.string :as string]
+            [clojure.tools.logging :as log]
             [clojure-commons.error-codes :as ce]
             [clojure-commons.jwt :as jwt]
             [clojure-commons.response :as resp]
@@ -90,6 +91,7 @@
         (if-let [assertion (assertion-fn request)]
           (let [claims ((jwt-validator) assertion)]
             (validate-claims claims user-extraction-fn)
+            (log/info "user authenticated using a legacy JWT assertion")
             (handler (assoc request :jwt-claims claims)))
           (resp/unauthorized "Custom JWT header not found."))
         (catch [:type :validation] _


### PR DESCRIPTION
This PR makes the following changes:

1. Removes the explicit item names from the volume for the `signing-keys` secret.
2. Changes the mount point for the `signing-keys` secret.
3. Adds a volume and mount point for the new `accepted-keys` secret.
4. Updates the authentication code to log a message every time a legacy JWT token is used for authentication. This will allow us to determine whether or not this feature is being used and possibly remove support altogether at some point in the future.

The goal of this change is to make external deployments easier. External DE deployments currently must have custom deployment definitions for Terrain because they don't have the same set of accepted JWT signing keys. This change removes this requirement. Please see [CORE-1542][1] for details.

[1]: https://cyverse.atlassian.net/browse/CORE-1542

[CORE-1542]: https://cyverse.atlassian.net/browse/CORE-1542