### PR TITLE
CORE-1554 Send HTML DOI Completion email to requesting user

### DIFF
--- a/src/terrain/services/permanent_id_requests.clj
+++ b/src/terrain/services/permanent_id_requests.clj
@@ -464,9 +464,9 @@ If this dataset accompanies a paper, please contact us with the DOI for that pap
           publish-avus    (format-publish-avus avus identifier type)
           publish-path    (publish-data-item current-user folder)]
       (email/send-permanent-id-request-complete type
+                                                identifier
                                                 publish-path
-                                                (json/encode doi-response {:pretty true})
-                                                identifier)
+                                                (json/encode doi-response {:pretty true}))
       (email/send-permanent-id-request-complete-for-user type identifier publish-path requested_by)
       (publish-metadata folder publish-avus)
       [identifier publish-path])

--- a/src/terrain/services/permanent_id_requests.clj
+++ b/src/terrain/services/permanent_id_requests.clj
@@ -450,7 +450,7 @@ If this dataset accompanies a paper, please contact us with the DOI for that pap
     response))
 
 (defn- complete-permanent-id-request
-  [user {request-id :id :keys [folder type] :as request}]
+  [user {request-id :id :keys [folder type requested_by] :as request}]
   (validate-request-for-completion request)
   (try+
     (let [folder          (validate-publish-dest folder)
@@ -467,6 +467,7 @@ If this dataset accompanies a paper, please contact us with the DOI for that pap
                                                 publish-path
                                                 (json/encode doi-response {:pretty true})
                                                 identifier)
+      (email/send-permanent-id-request-complete-for-user type identifier publish-path requested_by)
       (publish-metadata folder publish-avus)
       [identifier publish-path])
     (catch Object e

--- a/src/terrain/util/email.clj
+++ b/src/terrain/util/email.clj
@@ -79,6 +79,20 @@
       "permanent_id_request_complete"
       template-values)))
 
+(defn send-permanent-id-request-complete-for-user
+  "Sends an email message informing the requesting user of a Permanent ID Request completion."
+  [request-type doi path {:keys [name email]}]
+  (let [template-values {:user name
+                         :path path
+                         :doi  doi}
+        subject         (str request-type " Permanent ID Request Complete")]
+    (send-email
+      :to        email
+      :from-addr (config/permanent-id-request-src-addr)
+      :subject   subject
+      :template  "permanent_id_request_completion_user"
+      :values    template-values)))
+
 (defn send-permanent-id-request-submitted
   "Sends an email message to the user requesting a new Permanent ID Request."
   [request-type path {:keys [commonName email]}]

--- a/src/terrain/util/email.clj
+++ b/src/terrain/util/email.clj
@@ -43,8 +43,8 @@
 
 (defn send-permanent-id-request-new
   "Sends an email message informing data curators of a new Permanent ID Request."
-  [request-type path {:keys [commonName email]}]
-  (let [template-values {:username     commonName
+  [request-type path {:keys [commonName]}]
+  (let [template-values {:user         commonName
                          :environment  (config/environment-name)
                          :request_type request-type
                          :path         path}]
@@ -56,11 +56,11 @@
 (defn send-permanent-id-request-data-move-error
   "Sends an email message informing data curators that a Permanent ID Request data folder could not be moved to the
    commons repo folder."
-  [path dest-path {:keys [commonName]} error-msg]
+  [path dest-path requesting-user error-msg]
   (send-permanent-id-request
     "Could not move Permanent ID Request data folder"
     "permanent_id_request_move_error"
-    {:username      commonName
+    {:user          requesting-user
      :environment   (config/environment-name)
      :path          path
      :dest          dest-path
@@ -82,7 +82,7 @@
 (defn send-permanent-id-request-submitted
   "Sends an email message to the user requesting a new Permanent ID Request."
   [request-type path {:keys [commonName email]}]
-  (let [template-values {:username     commonName
+  (let [template-values {:user         commonName
                          :environment  (config/environment-name)
                          :request_type request-type
                          :path         path}

--- a/src/terrain/util/email.clj
+++ b/src/terrain/util/email.clj
@@ -68,12 +68,12 @@
 
 (defn send-permanent-id-request-complete
   "Sends an email message informing data curators of a Permanent ID Request completion."
-  [request-type path identifiers doi]
+  [request-type doi path api-response]
   (let [template-values {:environment  (config/environment-name)
                          :request_type request-type
+                         :doi          doi
                          :path         path
-                         :identifiers  identifiers
-                         :doi          doi}]
+                         :api_response api-response}]
     (send-permanent-id-request
       "Permanent ID Request Complete"
       "permanent_id_request_complete"


### PR DESCRIPTION
This PR will update the `permanent-id-requests` completion endpoint to send an HTML DOI Completion email to the requesting user, using the new template added by cyverse-de/de-mailer#10.

This PR will also add the following fixes and updates:
* Rename the permanent-id-request completion email template key `identifiers` to `api_response`, since it's now a JSON response from the DataCite API and not just `DOI` and `ARK` IDs.
* Fix for including the name of the requesting user in data-move error emails.
* Rename the email template keys `username` to `user`, since that's what the de-mailer service is now using in its templates, but it also makes more sense since the value is the user's full name, and not their account username.

