### PR TITLE
CORE-1603 Allow null folder values in DOI Request listing responses

### DIFF
--- a/src/terrain/routes/schemas/permanent_id_requests.clj
+++ b/src/terrain/routes/schemas/permanent_id_requests.clj
@@ -20,7 +20,7 @@
 
 (s/defschema PermanentIDRequestBase
   (st/merge schema/PermanentIDRequestBase
-            {:folder (describe stats-schema/DirStatInfo "The target folder's details")}))
+            {:folder (describe (s/maybe stats-schema/DirStatInfo) "The target folder's details")}))
 
 (s/defschema PermanentIDRequestStatusUpdate
   (st/dissoc schema/PermanentIDRequestStatusUpdate :permanent_id))


### PR DESCRIPTION
This PR will update the `PermanentIDRequestBase` schema to allow `null` folder values in (/admin)/permanent-id-requests listing responses.