### PR TITLE
CORE-1930: Add initial data-usage-api route

### DIFF
--- a/src/terrain/clients/data_usage_api.clj
+++ b/src/terrain/clients/data_usage_api.clj
@@ -1,0 +1,18 @@
+(ns terrain.clients.data-usage-api
+  (:require [cemerick.url :as curl]
+            [clj-http.client :as http]
+            [terrain.util.config :as config]))
+
+(defn- data-usage-api
+  ([components]
+   (data-usage-api components {}))
+  ([components query]
+   (-> (apply curl/url (config/data-usage-api-uri) components)
+       (assoc :query query)
+       str)))
+
+(defn user-current-usage
+  [username]
+  (-> (data-usage-api [username "data" "current"])
+      (http/get {:as :json})
+      (:body)))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -38,6 +38,7 @@
         [terrain.routes.permanent-id-requests]
         [terrain.routes.pref]
         [terrain.routes.resource-usage-api]
+        [terrain.routes.data-usage-api]
         [terrain.routes.session]
         [terrain.routes.user-info]
         [terrain.routes.collaborator]
@@ -118,6 +119,7 @@
    (bag-routes)
    (vice-routes)
    (resource-usage-api-routes)
+   (data-usage-api-routes)
    (route/not-found (service/unrecognized-path-response))))
 
 ; The old way of adding secured routes. Prepends /secured to the URL

--- a/src/terrain/routes/data_usage_api.clj
+++ b/src/terrain/routes/data_usage_api.clj
@@ -1,0 +1,26 @@
+(ns terrain.routes.data-usage-api
+  (:require [terrain.util.config :as config]
+            [terrain.clients.data-usage-api :as dua]
+            [terrain.auth.user-attributes :refer [current-user require-authentication]]
+            [terrain.util :refer [optional-routes]]
+            [common-swagger-api.schema  :refer [context GET]]
+            [terrain.routes.schemas.data-usage-api :as schema]
+            [ring.util.http-response :refer [ok]]))
+
+(defn data-usage-api-routes
+  []
+  (optional-routes
+    [config/data-usage-api-routes-enabled]
+
+    (context "/resource-usage" []
+      :tags ["resource-usage"]
+
+      (context "/data" []
+        (GET "/current" []
+          :middleware [require-authentication]
+          :summary schema/UserCurrentDataSummary
+          :description schema/UserCurrentDataDescription
+          :return schema/UserCurrentDataTotal
+          (ok (dua/user-current-usage (:username current-user))))))))
+
+

--- a/src/terrain/routes/schemas/data_usage_api.clj
+++ b/src/terrain/routes/schemas/data_usage_api.clj
@@ -1,0 +1,16 @@
+(ns terrain.routes.schemas.data-usage-api
+  (:require [common-swagger-api.schema :refer [describe]]
+            [schema.core :refer [defschema optional-key maybe]])
+  (:import [java.util UUID]))
+
+(def UserCurrentDataSummary "Get the most recent summary of a user's data usage")
+
+(def UserCurrentDataDescription "Uses the current date to get the most recent record of data usage for the currently logged-in user")
+
+(defschema UserCurrentDataTotal
+  {:id            (describe UUID "The UUID assigned to the current reading")
+   :user_id       (describe UUID "The UUID assigned to the user the reading applies to")
+   :username      (describe String "The username of the user the reading applies to")
+   :total         (describe Integer "The total number of bytes the user is consuming in the Data Store")
+   :time          (describe String "The date of the reading")
+   :last_modified (describe String "The date the reading in the database was last modified")})

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -131,6 +131,11 @@
   [props config-valid configs]
   "terrain.routes.resource-usage-api" true)
 
+(cc/defprop-optboolean data-usage-api-routes-enabled
+  "Enables or disables data-usage-api endpoints."
+  [props config-valid configs]
+  "terrain.routes.data-usage-api" true)
+
 (cc/defprop-optstr iplant-email-base-url
   "The base URL to use when connnecting to the iPlant email service."
   [props config-valid configs app-routes-enabled]
@@ -552,6 +557,11 @@
   "The base URI for the resource-usage-api service."
   [props config-valid configs]
   "terrain.resource-usage-api.base-uri" "http://resource-usage-api")
+
+(cc/defprop-optstr data-usage-api-uri
+  "The base URI for the data-usage-api service."
+  [props config-valid configs]
+  "terrain.data-usage-api.base-uri" "http://data-usage-api")
 
 (cc/defprop-optstr keycloak-base-uri
   "The base URI for the Keycloak server."


### PR DESCRIPTION
For now this is the only one, but I wanted to get it pushed up now so it's easier to be integrating in the UI.