### PR TITLE
Update the version of common-swagger-api to 3.2.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/common-cfg "2.8.2"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.2.2"]
+                 [org.cyverse/common-swagger-api "3.2.3"]
                  [org.cyverse/kameleon "3.0.6"
                   :exclusion [com.impossibl.pgjdbc-ng/pgjdbc-ng]]
                  [com.impossibl.pgjdbc-ng/pgjdbc-ng "0.8.9"]


### PR DESCRIPTION
Updates the version of common-swagger-api listed in project.clj to 3.2.3, which should allow analysis submissions to include the :max_cpu_cores field.