### PR TITLE
CORE-316 Update endpoint schemas for app versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/common-cfg "2.8.2"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.2.3"]
+                 [org.cyverse/common-swagger-api "3.3.0"]
                  [org.cyverse/kameleon "3.0.6"
                   :exclusion [com.impossibl.pgjdbc-ng/pgjdbc-ng]]
                  [com.impossibl.pgjdbc-ng/pgjdbc-ng "0.8.9"]

--- a/src/terrain/routes/schemas/instantlaunches.clj
+++ b/src/terrain/routes/schemas/instantlaunches.clj
@@ -55,6 +55,7 @@
          :is_public                (describe Boolean "Whether or not the quick launch is public")
          :submission               (describe Any "The submission associated with the instant launch/quick launch")
          :app_id                   (describe String "The UUID of the app used in the instant launch/quick launch")
+         :app_version_id           (describe String "The UUID of the app version used in the instant launch/quick launch")
          :app_name                 (describe String "The name of the app used in the instant launch/quick launch")
          :app_description          (describe String "The description of the app used in the instant launch/quick launch")
          :app_deleted              (describe Boolean "Whether or not the app is deleted")


### PR DESCRIPTION
This PR updates terrain with the latest schema changes for app versions from cyverse-de/common-swagger-api#75, and also updates the `FullInstantLaunch` schema with an `app_version_id` field, required due to changes in cyverse-de/app-exposer#44.