### PR TITLE
Make the reason field optional in the waiting state object

### DIFF
--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -46,7 +46,7 @@
     :command (describe [String] "The command used to start the analysis")}))
 
 (defschema ContainerStateWaiting
-  {:reason                 (describe (maybe String) "The reason the container is in the waiting state")
+  {(optional-key :reason)  (describe (maybe String) "The reason the container is in the waiting state")
    (optional-key :message) (describe (maybe String) "The message associated with the waiting state")})
 
 (defschema ContainerStateRunning


### PR DESCRIPTION
I can't find a good way to test this in QA, but this appears to be the field that is causing issues in production. Apparently there is a way for it to be missing.