### PR TITLE
CORE-316 Add app version endpoints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/common-cfg "2.8.2"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.3.4-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "3.4.0"]
                  [org.cyverse/kameleon "3.0.6"
                   :exclusion [com.impossibl.pgjdbc-ng/pgjdbc-ng]]
                  [com.impossibl.pgjdbc-ng/pgjdbc-ng "0.8.9"]

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.8"]
                  [org.cyverse/common-cfg "2.8.2"]
                  [org.cyverse/common-cli "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.3.3"]
+                 [org.cyverse/common-swagger-api "3.3.4-SNAPSHOT"]
                  [org.cyverse/kameleon "3.0.6"
                   :exclusion [com.impossibl.pgjdbc-ng/pgjdbc-ng]]
                  [com.impossibl.pgjdbc-ng/pgjdbc-ng "0.8.9"]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -527,10 +527,30 @@
                   :content-type :json
                   :as           :json}))))
 
+(defn add-pipeline-version
+  [app-id pipeline]
+  (:body
+   (client/post (apps-url "apps" "pipelines" app-id "versions")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  pipeline
+                  :content-type :json
+                  :as           :json}))))
+
 (defn update-pipeline
   [app-id pipeline]
   (:body
    (client/put (apps-url "apps" "pipelines" app-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :form-params  pipeline
+                 :content-type :json
+                 :as           :json}))))
+
+(defn update-pipeline-version
+  [app-id version-id pipeline]
+  (:body
+   (client/put (apps-url "apps" "pipelines" app-id "versions" version-id)
                (disable-redirects
                 {:query-params (secured-params)
                  :form-params  pipeline
@@ -545,10 +565,26 @@
                  {:query-params (secured-params)
                   :as           :json}))))
 
+(defn copy-pipeline-version
+  [app-id version-id]
+  (:body
+   (client/post (apps-url "apps" "pipelines" app-id "versions" version-id "copy")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :as           :json}))))
+
 (defn edit-pipeline
   [app-id]
   (:body
    (client/get (apps-url "apps" "pipelines" app-id "ui")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
+
+(defn edit-pipeline-version
+  [app-id version-id]
+  (:body
+   (client/get (apps-url "apps" "pipelines" app-id "versions" version-id "ui")
                (disable-redirects
                 {:query-params (secured-params)
                  :as           :json}))))

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -160,6 +160,16 @@
                   :content-type :json
                   :as           :json}))))
 
+(defn create-app-version
+  [system-id app-id app]
+  (:body
+   (client/post (apps-url "apps" system-id app-id "versions")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  app
+                  :content-type :json
+                  :as           :json}))))
+
 (defn preview-args
   [system-id app]
   (:body
@@ -218,10 +228,26 @@
                 {:query-params (secured-params)
                  :as           :json}))))
 
+(defn get-app-version
+  [system-id app-id version-id]
+  (:body
+   (client/get (apps-url "apps" system-id app-id "versions" version-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
+
 (defn delete-app
   [system-id app-id]
   (:body
    (client/delete (apps-url "apps" system-id app-id)
+                  (disable-redirects
+                   {:query-params (secured-params)
+                    :as           :json}))))
+
+(defn delete-app-version
+  [system-id app-id version-id]
+  (:body
+   (client/delete (apps-url "apps" system-id app-id "versions" version-id)
                   (disable-redirects
                    {:query-params (secured-params)
                     :as           :json}))))
@@ -236,10 +262,30 @@
                    :content-type :json
                    :as           :json}))))
 
+(defn relabel-app-version
+  [system-id app-id version-id relabel-request]
+  (:body
+   (client/patch (apps-url "apps" system-id app-id "versions" version-id)
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :form-params  relabel-request
+                   :content-type :json
+                   :as           :json}))))
+
 (defn update-app
   [system-id app-id update-request]
   (:body
    (client/put (apps-url "apps" system-id app-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :form-params  update-request
+                 :content-type :json
+                 :as           :json}))))
+
+(defn update-app-version
+  [system-id app-id version-id update-request]
+  (:body
+   (client/put (apps-url "apps" system-id app-id "versions" version-id)
                (disable-redirects
                 {:query-params (secured-params)
                  :form-params  update-request
@@ -264,6 +310,14 @@
                  {:query-params (secured-params)
                   :as           :json}))))
 
+(defn copy-app-version
+  [system-id app-id version-id]
+  (:body
+   (client/post (apps-url "apps" system-id app-id "versions" version-id "copy")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :as           :json}))))
+
 (defn list-single-app
   [system-id app-id]
   (:body
@@ -284,6 +338,14 @@
   [system-id app-id]
   (:body
    (client/get (apps-url "apps" system-id app-id "details")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
+
+(defn get-app-version-details
+  [system-id app-id version-id]
+  (:body
+   (client/get (apps-url "apps" system-id app-id "versions" version-id "details")
                (disable-redirects
                 {:query-params (secured-params)
                  :as           :json}))))
@@ -431,10 +493,26 @@
                 {:query-params (secured-params)
                  :as           :json}))))
 
+(defn list-app-version-tasks
+  [system-id app-id version-id]
+  (:body
+   (client/get (apps-url "apps" system-id app-id "versions" version-id "tasks")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
+
 (defn get-app-ui
   [system-id app-id]
   (:body
    (client/get (apps-url "apps" system-id app-id "ui")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
+
+(defn get-app-version-ui
+  [system-id app-id version-id]
+  (:body
+   (client/get (apps-url "apps" system-id app-id "versions" version-id "ui")
                (disable-redirects
                 {:query-params (secured-params)
                  :as           :json}))))
@@ -710,10 +788,28 @@
                 {:query-params (secured-params)
                  :as           :json}))))
 
+(defn get-app-version-docs
+  [system-id app-id version-id]
+  (:body
+   (client/get (apps-url "apps" system-id app-id "versions" version-id "documentation")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
+
 (defn edit-app-docs
   [system-id app-id docs]
   (:body
    (client/patch (apps-url "apps" system-id app-id "documentation")
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :form-params  docs
+                   :content-type :json
+                   :as           :json}))))
+
+(defn edit-app-version-docs
+  [system-id app-id version-id docs]
+  (:body
+   (client/patch (apps-url "apps" system-id app-id "versions" version-id "documentation")
                  (disable-redirects
                   {:query-params (secured-params)
                    :form-params  docs
@@ -730,6 +826,16 @@
                   :content-type :json
                   :as           :json}))))
 
+(defn add-app-version-docs
+  [system-id app-id version-id docs]
+  (:body
+   (client/post (apps-url "apps" system-id app-id "versions" version-id "documentation")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  docs
+                  :content-type :json
+                  :as           :json}))))
+
 (defn admin-edit-app-docs
   [system-id app-id docs]
   (:body
@@ -740,10 +846,30 @@
                    :content-type :json
                    :as           :json}))))
 
+(defn admin-edit-app-version-docs
+  [system-id app-id version-id docs]
+  (:body
+   (client/patch (apps-url "admin" "apps" system-id app-id "versions" version-id "documentation")
+                 (disable-redirects
+                  {:query-params (secured-params)
+                   :form-params  docs
+                   :content-type :json
+                   :as           :json}))))
+
 (defn admin-add-app-docs
   [system-id app-id docs]
   (:body
    (client/post (apps-url "admin" "apps" system-id app-id "documentation")
+                (disable-redirects
+                 {:query-params (secured-params)
+                  :form-params  docs
+                  :content-type :json
+                  :as           :json}))))
+
+(defn admin-add-app-version-docs
+  [system-id app-id version-id docs]
+  (:body
+   (client/post (apps-url "admin" "apps" system-id app-id "versions" version-id "documentation")
                 (disable-redirects
                  {:query-params (secured-params)
                   :form-params  docs
@@ -866,6 +992,14 @@
   [system-id app-id]
   (:body
    (client/get (apps-url "apps" system-id app-id "tools")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
+
+(defn get-tools-in-app-version
+  [system-id app-id version-id]
+  (:body
+   (client/get (apps-url "apps" system-id app-id "versions" version-id "tools")
                (disable-redirects
                 {:query-params (secured-params)
                  :as           :json}))))
@@ -1122,6 +1256,14 @@
                 {:query-params (secured-params)
                  :as           :json}))))
 
+(defn get-app-version-integration-data
+  [system-id app-id version-id]
+  (:body
+   (client/get (apps-url "apps" system-id app-id "versions" version-id "integration-data")
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
+
 (defn get-tool-integration-data
   [tool-id]
   (:body
@@ -1134,6 +1276,14 @@
   [system-id app-id integration-data-id]
   (:body
    (client/put (apps-url "admin" "apps" system-id app-id "integration-data" integration-data-id)
+               (disable-redirects
+                {:query-params (secured-params)
+                 :as           :json}))))
+
+(defn update-app-version-integration-data
+  [system-id app-id version-id integration-data-id]
+  (:body
+   (client/put (apps-url "admin" "apps" system-id app-id "versions" version-id "integration-data" integration-data-id)
                (disable-redirects
                 {:query-params (secured-params)
                  :as           :json}))))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -20,6 +20,7 @@
         [terrain.routes.apps.pipelines]
         [terrain.routes.apps.reference-genomes]
         [terrain.routes.apps.tools]
+        [terrain.routes.apps.versions]
         [terrain.routes.bags]
         [terrain.routes.bootstrap]
         [terrain.routes.callbacks]
@@ -97,6 +98,7 @@
    (app-elements-routes)
    (app-pipeline-routes)
    (apps-routes)
+   (app-version-routes)
    (misc-metadata-routes)))
 
 ; Add new secured routes to this function, not to (secured-routes).
@@ -303,6 +305,7 @@
                                      {:name "app-element-types", :description, "App Element Endpoints"}
                                      {:name "app-metadata", :description "App Metadata Endpoints"}
                                      {:name "app-pipelines", :description "App Pipeline Endpoints"}
+                                     {:name "app-versions", :description, "App Version Endpoints"}
                                      {:name "bags", :description "Item Bag Endpoints"}
                                      {:name "bootstrap", :description "Bootstrap Endpoints"}
                                      {:name "callbacks", :description "Callback Endpoints"}

--- a/src/terrain/routes/apps/admin/apps.clj
+++ b/src/terrain/routes/apps/admin/apps.clj
@@ -110,4 +110,31 @@
          :body [body apps-schema/PublishAppRequest]
          :summary apps-schema/PublishAppSummary
          :description apps-schema/PublishAppDocs
-         (ok (apps/admin-publish-app system-id app-id body)))))))
+         (ok (apps/admin-publish-app system-id app-id body)))
+
+       (context "/versions/:version-id" []
+                :path-params [version-id :- apps-schema/AppVersionIdParam]
+
+                (PATCH "/documentation" []
+                       :body [body apps-schema/AppDocumentationRequest]
+                       :return apps-schema/AppDocumentation
+                       :summary schema/AppVersionDocumentationUpdateSummary
+                       :description schema/AppVersionDocumentationUpdateDocs
+                       (ok (apps/admin-edit-app-version-docs system-id app-id version-id body)))
+
+                (POST "/documentation" []
+                      :body [body apps-schema/AppDocumentationRequest]
+                      :return apps-schema/AppDocumentation
+                      :summary schema/AppVersionDocumentationAddSummary
+                      :description schema/AppVersionDocumentationAddDocs
+                      (ok (apps/admin-add-app-version-docs system-id app-id version-id body)))
+
+                (PUT "/integration-data/:integration-data-id" []
+                     :path-params [integration-data-id :- IntegrationDataIdPathParam]
+                     :return IntegrationData
+                     :summary schema/AppVersionIntegrationDataUpdateSummary
+                     :description schema/AppVersionIntegrationDataUpdateDocs
+                     (ok (apps/update-app-version-integration-data system-id
+                                                                   app-id
+                                                                   version-id
+                                                                   integration-data-id))))))))

--- a/src/terrain/routes/apps/pipelines.clj
+++ b/src/terrain/routes/apps/pipelines.clj
@@ -1,6 +1,6 @@
 (ns terrain.routes.apps.pipelines
   (:use [common-swagger-api.schema]
-        [common-swagger-api.schema.apps :only [AppIdParam]]
+        [common-swagger-api.schema.apps :only [AppIdParam AppVersionIdParam]]
         [common-swagger-api.schema.apps.pipeline]
         [ring.util.http-response :only [ok]]
         [terrain.auth.user-attributes :only [require-authentication]]
@@ -47,4 +47,35 @@
              :return Pipeline
              :summary PipelineEditingViewSummary
              :description PipelineEditingViewDocs
-             (ok (apps/edit-pipeline app-id)))))))
+             (ok (apps/edit-pipeline app-id)))
+
+        (context "/versions" []
+
+                 (POST "/" []
+                       :body [body PipelineVersionRequest]
+                       :return Pipeline
+                       :summary PipelineVersionCreateSummary
+                       :description PipelineVersionCreateDocs
+                       (ok (apps/add-pipeline-version app-id body)))
+
+                 (context "/:version-id" []
+                          :path-params [version-id :- AppVersionIdParam]
+
+                          (PUT "/" []
+                               :body [body PipelineUpdateRequest]
+                               :return Pipeline
+                               :summary PipelineVersionUpdateSummary
+                               :description PipelineVersionUpdateDocs
+                               (ok (apps/update-pipeline-version app-id version-id body)))
+
+                          (POST "/copy" []
+                                :return Pipeline
+                                :summary PipelineVersionCopySummary
+                                :description PipelineVersionCopyDocs
+                                (ok (apps/copy-pipeline-version app-id version-id)))
+
+                          (GET "/ui" []
+                               :return Pipeline
+                               :summary PipelineVersionEditingViewSummary
+                               :description PipelineVersionEditingViewDocs
+                               (ok (apps/edit-pipeline-version app-id version-id)))))))))

--- a/src/terrain/routes/apps/versions.clj
+++ b/src/terrain/routes/apps/versions.clj
@@ -1,0 +1,123 @@
+(ns terrain.routes.apps.versions
+  (:require [common-swagger-api.schema :refer :all]
+            [common-swagger-api.schema.apps :as schema]
+            [common-swagger-api.schema.integration-data :as integration-schema]
+            [ring.util.http-response :refer [ok]]
+            [terrain.auth.user-attributes :refer [require-authentication]]
+            [terrain.clients.apps.raw :as apps]
+            [terrain.util :refer [optional-routes]]
+            [terrain.util.config :as config]))
+
+(defn app-version-routes
+  []
+
+  (optional-routes
+    [config/app-routes-enabled]
+
+    (context "/apps/:system-id/:app-id/versions" []
+             :tags ["app-versions"]
+             :path-params [system-id :- schema/SystemId
+                           app-id    :- schema/AppIdParam]
+
+             (POST "/" []
+                   :middleware [require-authentication]
+                   :body [body schema/AppVersionRequest]
+                   :return schema/App
+                   :summary schema/AppVersionCreateSummary
+                   :description schema/AppVersionCreateDocs
+                   (ok (apps/create-app-version system-id app-id body)))
+
+             (context "/:version-id" []
+                      :path-params [version-id :- schema/AppVersionIdParam]
+
+                      (DELETE "/" []
+                              :middleware [require-authentication]
+                              :summary schema/AppVersionDeleteSummary
+                              :description schema/AppVersionDeleteDocs
+                              (ok (apps/delete-app-version system-id app-id version-id)))
+
+                      (GET "/" []
+                           :middleware [require-authentication]
+                           :return schema/AppJobView
+                           :summary schema/AppJobViewSummary
+                           :description schema/AppJobViewDocs
+                           (ok (apps/get-app-version system-id app-id version-id)))
+
+                      (PATCH "/" []
+                             :middleware [require-authentication]
+                             :body [body schema/AppLabelUpdateRequest]
+                             :return schema/App
+                             :summary schema/AppLabelUpdateSummary
+                             :description-file "docs/apps/app-label-update.md"
+                             (ok (apps/relabel-app-version system-id app-id version-id body)))
+
+                      (PUT "/" []
+                           :middleware [require-authentication]
+                           :body [body schema/AppUpdateRequest]
+                           :return schema/App
+                           :summary schema/AppUpdateSummary
+                           :description schema/AppUpdateDocs
+                           (ok (apps/update-app-version system-id app-id version-id body)))
+
+                      (POST "/copy" []
+                            :middleware [require-authentication]
+                            :return schema/App
+                            :summary schema/AppCopySummary
+                            :description schema/AppCopyDocs
+                            (ok (apps/copy-app-version system-id app-id version-id)))
+
+                      (GET "/details" []
+                           :return schema/AppDetails
+                           :summary schema/AppDetailsSummary
+                           :description schema/AppDetailsDocs
+                           (ok (apps/get-app-version-details system-id app-id version-id)))
+
+                      (GET "/documentation" []
+                           :return schema/AppDocumentation
+                           :summary schema/AppDocumentationSummary
+                           :description schema/AppDocumentationDocs
+                           (ok (apps/get-app-version-docs system-id app-id version-id)))
+
+                      (PATCH "/documentation" []
+                             :middleware [require-authentication]
+                             :body [body schema/AppDocumentationRequest]
+                             :return schema/AppDocumentation
+                             :summary schema/AppDocumentationUpdateSummary
+                             :description schema/AppDocumentationUpdateDocs
+                             (ok (apps/edit-app-version-docs system-id app-id version-id body)))
+
+                      (POST "/documentation" []
+                            :middleware [require-authentication]
+                            :body [body schema/AppDocumentationRequest]
+                            :return schema/AppDocumentation
+                            :summary schema/AppDocumentationAddSummary
+                            :description schema/AppDocumentationAddDocs
+                            (ok (apps/add-app-version-docs system-id app-id version-id body)))
+
+                      (GET "/integration-data" []
+                           :middleware [require-authentication]
+                           :return integration-schema/IntegrationData
+                           :summary schema/AppIntegrationDataSummary
+                           :description schema/AppIntegrationDataDocs
+                           (ok (apps/get-app-version-integration-data system-id app-id version-id)))
+
+                      (GET "/tasks" []
+                           :middleware [require-authentication]
+                           :return schema/AppTaskListing
+                           :summary schema/AppTaskListingSummary
+                           :description schema/AppTaskListingDocs
+                           (ok (apps/list-app-version-tasks system-id app-id version-id)))
+
+                      (GET "/tools" []
+                           :middleware [require-authentication]
+                           :return schema/AppToolListing
+                           :summary schema/AppToolListingSummary
+                           :description schema/AppToolListingDocs
+                           (ok (apps/get-tools-in-app-version system-id app-id version-id)))
+
+                      (GET "/ui" []
+                           :middleware [require-authentication]
+                           :return schema/App
+                           :summary schema/AppEditingViewSummary
+                           :description schema/AppEditingViewDocs
+                           (ok (apps/get-app-version-ui system-id app-id version-id)))))))


### PR DESCRIPTION
This PR will add new CRUD endpoints for app versions:

* `POST /apps/:system-id/:app-id/versions`
* `DELETE /apps/:system-id/:app-id/versions/:version-id`
* `GET /apps/:system-id/:app-id/versions/:version-id`
* `PATCH /apps/:system-id/:app-id/versions/:version-id`
* `PUT /apps/:system-id/:app-id/versions/:version-id`
* `POST /apps/:system-id/:app-id/versions/:version-id/copy`
* `GET /apps/:system-id/:app-id/versions/:version-id/details`
* `GET /apps/:system-id/:app-id/versions/:version-id/documentation`
* `PATCH /apps/:system-id/:app-id/versions/:version-id/documentation`
* `POST /apps/:system-id/:app-id/versions/:version-id/documentation`
* `GET /apps/:system-id/:app-id/versions/:version-id/integration-data`
* `GET /apps/:system-id/:app-id/versions/:version-id/tasks`
* `GET /apps/:system-id/:app-id/versions/:version-id/tools`
* `GET /apps/:system-id/:app-id/versions/:version-id/ui`
* `PATCH /admin/apps/:system-id/:app-id/versions/:version-id/documentation`
* `POST /admin/apps/:system-id/:app-id/versions/:version-id/documentation`
* `PUT /admin/apps/:system-id/:app-id/versions/:version-id/integration-data/:integration-data-id`