### PR TITLE
CORE-1835: add an endpoint for listing resource types

### DIFF
--- a/src/terrain/clients/qms.clj
+++ b/src/terrain/clients/qms.clj
@@ -72,3 +72,9 @@
   (-> (qms-api ["v1" "plans" plan-id])
       (http/get {:as :json})
       (:body)))
+
+(defn list-resource-types
+  []
+  (-> (qms-api ["v1" "resource-types"])
+      (http/get {:as :json})
+      (:body)))

--- a/src/terrain/routes/qms.clj
+++ b/src/terrain/routes/qms.clj
@@ -32,6 +32,14 @@
          :return schema/PlanResponse
          (ok (qms/single-plan plan-id))))
 
+     (context "/resource-types" []
+       (GET "/" []
+         :middleware [require-authentication]
+         :summary schema/GetResourceTypesSummary
+         :description schema/GetResourceTypesDescription
+         :return schema/ResourceTypesResponse
+         (ok (qms/list-resource-types))))
+
      ;;; It's /user and not /users since this is for the logged-in user and not
      ;;; an admin-only lookup, which would require the username to be included
      ;;; in the path or query-parameters.

--- a/src/terrain/routes/schemas/qms.clj
+++ b/src/terrain/routes/schemas/qms.clj
@@ -7,6 +7,8 @@
 (def GetAllPlansDescription "Returns a list of all plans registered in QMS. New plans may be registered at run-time through QMS itself")
 (def GetPlanSummary "Returns details about a single plan in QMS")
 (def GetPlanDescription "Returns details about a single plan in QMS. Plan is referenced by its UUID")
+(def GetResourceTypesSummary "List Resource Types")
+(def GetResourceTypesDescription "Returns a list of all resource types registered in QMS")
 (def GetUserPlanSummary "Returns details about the user's current plan")
 (def GetUserPlanDescription "Returns details about the user's current plan, including quota and usage information")
 (def UpdateUserPlanQuotaSummary "Updates a quota in the user's current subscription")
@@ -41,6 +43,10 @@
   {:id   ResourceID
    :name ResourceTypeName
    :unit (describe String "The unit of the resource type")})
+
+(defschema ResourceTypesResponse
+  {:result (describe [ResourceType] "The list of resource types")
+   :status (describe String "The status of the response")})
 
 (defschema Usage
   {:id                              UsageID


### PR DESCRIPTION
The primary purpose of adding this endpoint is to add validation to the Terrain CLI. Here are the Swagger docs for the endpoint:

![image](https://user-images.githubusercontent.com/415143/210672489-7b86f45c-7545-4d71-924e-f5e4304c582a.png)

The usage of this endpoint is very simple:

```
$ curl -sH "$AUTH_HEADER" "http://localhost:8000/terrain/qms/resource-types" | jq
{
  "result": [
    {
      "id": "99e3bc7e-950a-11ec-84a4-406c8f3e9cbb",
      "name": "cpu.hours",
      "unit": "cpu hours"
    },
    {
      "id": "99e3f91e-950a-11ec-84a4-406c8f3e9cbb",
      "name": "data.size",
      "unit": "bytes"
    }
  ],
  "status": "OK"
}
```