### PR TITLE
CORE-1834: standardize error responses from QMS endpoints

### DIFF
--- a/src/terrain/clients/coge.clj
+++ b/src/terrain/clients/coge.clj
@@ -1,6 +1,7 @@
 (ns terrain.clients.coge
   (:use [clojure-commons.core :only [remove-nil-values]]
         [terrain.auth.user-attributes :only [current-user]]
+        [terrain.clients.util :only [with-trap]]
         [slingshot.slingshot :only [throw+ try+]])
   (:require [cemerick.url :as curl]
             [cheshire.core :as cheshire]
@@ -19,17 +20,6 @@
   (log/warn "CoGe request failed:" response)
   (throw+ {:error_code error-code
            :reason     (if (string? body) body (slurp body))}))
-
-(defmacro ^:private with-trap
-  [[handle-error] & body]
-  `(try+
-    (do ~@body)
-    (catch [:status 400] bad-request#
-      (~handle-error ce/ERR_BAD_REQUEST bad-request#))
-    (catch [:status 404] not-found#
-      (~handle-error ce/ERR_NOT_FOUND not-found#))
-    (catch (comp number? :status) server-error#
-      (~handle-error ce/ERR_REQUEST_FAILED server-error#))))
 
 (defn search-genomes
   "Searches for genomes in CoGe."

--- a/src/terrain/clients/util.clj
+++ b/src/terrain/clients/util.clj
@@ -1,0 +1,14 @@
+(ns terrain.clients.util
+  (:use [slingshot.slingshot :only [throw+ try+]])
+  (:require [clojure-commons.error-codes :as ce]))
+
+(defmacro with-trap
+  [[handle-error] & body]
+  `(try+
+    (do ~@body)
+    (catch [:status 400] bad-request#
+      (~handle-error ce/ERR_BAD_REQUEST bad-request#))
+    (catch [:status 404] not-found#
+      (~handle-error ce/ERR_NOT_FOUND not-found#))
+    (catch (comp number? :status) server-error#
+      (~handle-error ce/ERR_REQUEST_FAILED server-error#))))


### PR DESCRIPTION
This change standardizes the error response bodies from all QMS endpoints in Terrain so that they more closely resemble error response bodies from other endpoints in Terrain, for example:

Before:
```
$ curl -sH "$AUTH_HEADER" "https://qa.cyverse.org/terrain/admin/qms/users/sarahr/plan/does.not.exist/quota" -H 'Content-Type: application/json' -d '{"quota":10000}' | jq
{
  "error": "resource type 'does.not.exist' not found",
  "status": "Bad Request"
}
```

After:
```
$ curl -sH "$AUTH_HEADER" "http://localhost:8000/terrain/admin/qms/users/sarahr/plan/does.not.exist/quota" -H 'Content-Type: application/json' -d '{"quota":10000}' | jq
{
  "error_code": "ERR_BAD_REQUEST",
  "reason": "resource type 'does.not.exist' not found"
}
```
