### PR TITLE
CORE-1840: add support for the paid subscription flag

### DIFF
--- a/src/terrain/clients/qms.clj
+++ b/src/terrain/clients/qms.clj
@@ -73,9 +73,9 @@
         (:body))))
 
 (defn update-subscription
-  [username plan-name]
+  [username plan-name params]
   (with-trap [default-error-handler]
-    (-> (qms-api ["v1" "users" username plan-name])
+    (-> (qms-api ["v1" "users" username plan-name] params)
         (http/put {:as :json})
         (:body))))
 

--- a/src/terrain/routes/qms.clj
+++ b/src/terrain/routes/qms.clj
@@ -124,9 +124,10 @@
              :middleware [require-authentication]
              :summary schema/UpdateSubscriptionSummary
              :description schema/UpdateSubscriptionDescription
+             :query [params schema/AddSubscriptionParams]
              :path-params [plan-name :- schema/PlanName]
              :return schema/SuccessResponse
-             (ok (qms/update-subscription username plan-name)))))))))
+             (ok (qms/update-subscription username plan-name params)))))))))
 
 (defn service-account-qms-api-routes
   []
@@ -146,4 +147,4 @@
            :description schema/UpdateSubscriptionDescription
            :path-params [plan-name :- schema/PlanName]
            :return schema/SuccessResponse
-           (ok (qms/update-subscription username plan-name))))))))
+           (ok (qms/update-subscription username plan-name {:paid true}))))))))

--- a/src/terrain/routes/schemas/qms.clj
+++ b/src/terrain/routes/schemas/qms.clj
@@ -106,7 +106,8 @@
    (optional-key :user)                 QMSUser
    (optional-key :plan)                 Plan
    (optional-key :quotas)               (describe (maybe [Quota]) "The list of quotas associated with the user's plan")
-   (optional-key :usages)               (describe (maybe [Usage]) "The list of usages associated with the user's plan")})
+   (optional-key :usages)               (describe (maybe [Usage]) "The list of usages associated with the user's plan")
+   (optional-key :paid)                 (describe (maybe Boolean) "True if the user paid for the subsciption")})
 
 (defschema SubscriptionPlanResponse
   {(optional-key :result) (describe (maybe Subscription) "The user's plan")
@@ -134,7 +135,8 @@
 
 (defschema SubscriptionRequest
   {(optional-key :username)  (describe String "The username to associate with the subscription")
-   (optional-key :plan_name) (describe String "The name of the plan to associate with the subscription")})
+   (optional-key :plan_name) (describe String "The name of the plan to associate with the subscription")
+   :paid                     (describe Boolean "True if the user paid for the subscription")})
 
 (defschema SubscriptionRequests
   {(optional-key :subscriptions) (describe (maybe [SubscriptionRequest]) "The list of subscription requests")})
@@ -142,6 +144,9 @@
 (defschema BulkSubscriptionParams
   {(optional-key :force)
    (describe String "True if the subscription should be created even if the user already has a higher level plan")})
+
+(defschema AddSubscriptionParams
+  {:paid (describe Boolean "True if the user paid for the subscription")})
 
 (defschema ListSubscriptionsParams
   (merge PagingParams


### PR DESCRIPTION
This change adds the paid subscription plans to the subscription creation and retrieval endpoints in `terrain`. For the subscription retrieval endpoints, the change consists of a new field in the response body. For the creation endpoints, the change includes new required fields.

For the `POST /terrain/admin/qms/subscriptions` endpoint, each subscription request must now contain a `paid` flag indicating whether or not the user paid for the subscription. Here's an example request body:

```
{
  "subscriptions": [
    {
      "username": "sarahr",
      "plan_name": "Commercial",
      "paid": false
    }
  ]
}
```

For the `PUT /terrain/admin/qms/users/{username}/plan/{plan-name}` endpoint, a new required query parameter was added.
