### PR TITLE
Admin endpoints for the subscription add-on functionality.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -54,7 +54,7 @@
                  [io.nats/jnats "2.4.0"]
                  [less-awful-ssl "1.0.6"]
                  [clojure.java-time "1.2.0"]
-                 [org.cyverse.de/cyverse-de-protobufs "0b5a5c7fab36702627ad7956ae1bb9cdeff1f133"]]
+                 [org.cyverse.de/cyverse-de-protobufs "5648b3a0afc6cdd006c453b5784c28d00b63ef62"]]
   :eastwood {:exclude-namespaces [terrain.util.jwt :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
   :plugins [[lein-ancient "0.6.15"]

--- a/src/terrain/routes/qms.clj
+++ b/src/terrain/routes/qms.clj
@@ -90,7 +90,50 @@
          :query [params schema/BulkSubscriptionParams]
          :body [body schema/SubscriptionRequests]
          :return schema/BulkSubscriptionResponse
-         (ok (handlers/add-subscriptions params body))))
+         (ok (handlers/add-subscriptions params body)))
+       
+       (context "/:subscription-uuid" []
+         :path-params [subscription-uuid :- schema/SubscriptionID]
+         
+         (context "/addons" []
+           (GET "/" []
+             :middleware [require-authentication]
+             :summary schema/ListSubscriptionAddonsSummary
+             :description schema/ListSubscriptionAddonsDescription
+             :return schema/SubscriptionAddonListResponse
+             (ok (handlers/list-subscription-addons subscription-uuid)))
+           
+           (POST "/" []
+             :middleware [require-authentication]
+             :summary schema/AddSubscriptionAddonSummary
+             :description schema/AddSubscriptionAddonDescription
+             :body [body schema/AddonIDBody]
+             :return schema/SubscriptionAddonResponse
+             (ok (handlers/add-subscription-addon subscription-uuid (:uuid body))))
+           
+           (context "/:uuid" []
+             :path-params [uuid :- schema/SubscriptionAddonID]
+             
+             (GET "/" []
+               :middleware [require-authentication]
+               :summary schema/GetSubscriptionAddonSummary
+               :description schema/GetSubscriptionAddonDescription
+               :return schema/SubscriptionAddon
+               (ok (handlers/get-subscription-addon uuid)))
+           
+             (PUT "/" []
+               :middleware [require-authentication]
+               :summary schema/UpdateSubscriptionAddonSummary
+               :description schema/UpdateSubscriptionAddonDescription
+               :body [body schema/UpdateSubscriptionAddon]
+               (ok (handlers/update-subscription-addon (assoc body :uuid uuid))))
+             
+             (DELETE "/" []
+               :middleware [require-authentication]
+               :summary schema/DeleteSubscriptionAddonSummary
+               :description schema/DeleteSubscriptionAddonDescription
+               :return schema/SubscriptionAddon
+               (ok (handlers/delete-subscription-addon uuid)))))))
 
      (context "/addons" []
        (POST "/" []

--- a/src/terrain/routes/qms.clj
+++ b/src/terrain/routes/qms.clj
@@ -118,7 +118,7 @@
                :middleware [require-authentication]
                :summary schema/GetSubscriptionAddonSummary
                :description schema/GetSubscriptionAddonDescription
-               :return schema/SubscriptionAddon
+               :return schema/SubscriptionAddonResponse
                (ok (handlers/get-subscription-addon uuid)))
            
              (PUT "/" []
@@ -132,7 +132,7 @@
                :middleware [require-authentication]
                :summary schema/DeleteSubscriptionAddonSummary
                :description schema/DeleteSubscriptionAddonDescription
-               :return schema/SubscriptionAddon
+               :return schema/SubscriptionAddonResponse
                (ok (handlers/delete-subscription-addon uuid)))))))
 
      (context "/addons" []

--- a/src/terrain/routes/schemas/qms.clj
+++ b/src/terrain/routes/schemas/qms.clj
@@ -31,6 +31,16 @@
 (def UpdateAddonDescription "Updates an available add-on that can be applied to a user's subscription")
 (def DeleteAddonSummary "Deletes an add-on")
 (def DeleteAddonDescription "Deletes an add-on that was available to be applied to a user's subscription")
+(def GetSubscriptionAddonSummary "Returns a single subscription add-on")
+(def GetSubscriptionAddonDescription "Returns a subscription add-on by its UUID. This has already been applied to the subscription")
+(def AddSubscriptionAddonSummary "Adds an add-on to a subscription")
+(def AddSubscriptionAddonDescription "Adds an add-on to a subscription, increasing the quota for the resource type in the add-on")
+(def ListSubscriptionAddonsSummary "Returns the add-ons applied to a subscription")
+(def ListSubscriptionAddonsDescription "Returns descriptions of all of the add-ons that have been applied to the indicated subscription")
+(def UpdateSubscriptionAddonSummary "Updates a subscription add-on")
+(def UpdateSubscriptionAddonDescription "Updates a subscription add-on with the values contained within")
+(def DeleteSubscriptionAddonSummary "Delete a subscription add-on")
+(def DeleteSubscriptionAddonDescription "Delete a subscription add-on, decreasing the quota for the resource type in the add-on by the amount provided by the add-on")
 
 (def PlanID (describe (maybe UUID) "The UUID assigned to a plan in QMS"))
 (def PlanName (describe String "The name of the plan"))
@@ -42,6 +52,8 @@
 (def Username (describe String "A user's username"))
 (def ResourceTypeName (describe String "The name of the resource type"))
 (def AddonID (describe UUID "The UUID assigned to an add-on"))
+(def SubscriptionID (describe UUID "The UUID assigned to a subscription"))
+(def SubscriptionAddonID (describe UUID "The UUID assigned to a subscription add-on"))
 
 (defschema SuccessResponse
   {(optional-key :result) (describe (maybe Any) "The result of the response")
@@ -216,3 +228,23 @@
 
 (defschema AddonListResponse
   {:addons (describe [AddOn] "The returned list of add-ons")})
+
+(defschema SubscriptionAddon
+  {(optional-key :uuid) (describe UUID "The UUID for the subscribed add-on")
+   :addon               (describe AddOn "The add-on applied to the subscription")
+   :subscription        (describe Subscription "The subscription the add-on was applied to")
+   :amount              (describe Double "The amount of the resource type provided by the add-on that was actually applied to the subscription")
+   :paid                (describe Boolean "Whether the add-on needs/needed to be paid for")})
+
+(defschema AddonIDBody
+  {:uuid AddonID})
+
+(defschema SubscriptionAddonResponse
+  {:subscription_addon (describe SubscriptionAddon "The returned subscription add-on")})
+
+(defschema UpdateSubscriptionAddon
+  {(optional-key :amount) (describe Double "The new amount of the resource provided by the subscription add-on")
+   (optional-key :paid)   (describe Boolean "Sets whether the subscription add-on needs to be charged for")})
+
+(defschema SubscriptionAddonListResponse
+  {:subscription_addons (describe [SubscriptionAddon] "The returned list of subscription add-ons")})

--- a/src/terrain/routes/schemas/qms.clj
+++ b/src/terrain/routes/schemas/qms.clj
@@ -87,7 +87,8 @@
    :update_type   (describe String "The update type")})
 
 (defschema QMSUser
-  {(optional-key :id)       QMSUserID
+  {(optional-key :uuid)      QMSUserID
+   (optional-key :id)        QMSUserID
    (optional-key :username) (describe String "The user's username in QMS")})
 
 (defschema PlanQuotaDefault
@@ -97,6 +98,7 @@
 
 (defschema Plan
   {(optional-key :id)                  PlanID
+   (optional-key :uuid)                PlanID
    (optional-key :name)                (describe String "The name of the plan in QMS")
    (optional-key :description)         (describe String "The description of the plan")
    (optional-key :plan_quota_defaults) (describe [PlanQuotaDefault] "The list of default values for the quotas")})
@@ -121,7 +123,8 @@
   {:quota (describe Double "The resource usage limit")})
 
 (defschema Subscription
-  {(optional-key :id)                   (describe (maybe UUID) "The UUID assigned to a user's plan")
+  {(optional-key :uuid)                   (describe (maybe UUID) "The UUID assigned to a user's plan")
+   (optional-key :id)                   (describe (maybe UUID) "The UUID assigned to a user's plan")
    (optional-key :effective_start_date) (describe (maybe String) "The date the user's plan takes effect")
    (optional-key :effective_end_date)   (describe (maybe String) "The date the user's plan ends")
    (optional-key :user)                 QMSUser

--- a/src/terrain/services/qms.clj
+++ b/src/terrain/services/qms.clj
@@ -99,6 +99,11 @@
                                                :child_uuid (str child-uuid)})]
     (select-keys (nats/request-json (cfg/add-subscription-addon-subject) req) [:subscription_addon])))
 
+(defn get-subscription-addon
+  [addon-uuid]
+  (let [req (protobuf/create ByUUID {:uuid (str addon-uuid)})]
+    (select-keys (nats/request-json (cfg/get-subscription-addon-subject) req) [:subscription_addons])))
+
 (defn list-subscription-addons
   [uuid]
   (let [req (protobuf/create ByUUID {:uuid (str uuid)})]

--- a/src/terrain/services/qms.clj
+++ b/src/terrain/services/qms.clj
@@ -119,7 +119,7 @@
 
 (defn update-subscription-addon
   [sub-addon]
-  (let [req (protobuf/create (update-sub-addon-request sub-addon))]
+  (let [req (protobuf/create UpdateSubscriptionAddonRequest (update-sub-addon-request sub-addon))]
     (select-keys (nats/request-json (cfg/update-subscription-addon-subject) req) [:subscription_addon])))
 
 (defn delete-subscription-addon

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -653,6 +653,32 @@
   [props config-valid configs]
   "terrain.nats.subjects.addons.delete" "cyverse.qms.addon.delete")
 
+(cc/defprop-optstr add-subscription-addon-subject
+  "The NATS subject for adding a subscription addon"
+  [props config-valid configs]
+  "terrain.nats.subjects.subscription.addons.add" "cyverse.qms.user.plan.addons.add")
+
+(cc/defprop-optstr list-subscription-addons-subject
+  "The NATS subject for listing a subscription's addons"
+  [props config-valid configs]
+  "terrain.nats.subjects.subscription.addons.list" "cyverse.qms.user.plan.addons.list")
+
+(cc/defprop-optstr update-subscription-addon-subject
+  "The NATS subject for updating a subscription addon"
+  [props config-valid configs]
+  "terrain.nats.subjects.subscription.addons.update" "cyverse.qms.user.plan.addons.update")
+
+(cc/defprop-optstr delete-subscription-addon-subject
+  "The NATS subject for deleting a subscription addon"
+  [props config-valid configs]
+  "terrain.nats.subjects.subscription.addons.delete" "cyverse.qms.user.plan.addons.delete")
+
+(cc/defprop-optstr get-subscription-addon-subject
+  "The NATS subject for getting a subscription addon"
+  [props config-valid configs]
+  "terrain.nats.subjects.subscription.addons.get" "cyverse.qms.user.plan.addons.get")
+
+
 (def async-tasks-client
   (memoize #(async-tasks-client/new-async-tasks-client (async-tasks-base-url))))
 


### PR DESCRIPTION
This PR adds the ability to do the following to subscription add-ons as an administrator:
* Apply add-ons to a subscription.
* Modify subscription add-ons.
* Get information about a subscription add-on.
* List subscription add-ons.
* Delete subscription add-ons.

The add, delete, and update operations will change the quota for the resource type mentioned in the add-on. That logic lives in the `subscriptions` service.

JIRAs affected:
* https://cyverse.atlassian.net/browse/CORE-1845
* https://cyverse.atlassian.net/browse/CORE-1846
* https://cyverse.atlassian.net/browse/CORE-1847
* https://cyverse.atlassian.net/browse/CORE-1848

