### PR TITLE
CORE-1893 Update clj-jargon to v3.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
                  [slingshot "0.12.2"]
                  [org.cyverse/async-tasks-client "0.0.3"]
                  [org.cyverse/clj-icat-direct "2.9.0"]
-                 [org.cyverse/clj-jargon "3.0.3"
+                 [org.cyverse/clj-jargon "3.1.0-SNAPSHOT"
                   :exclusions [org.bouncycastle/bcprov-jdk16]]
                  [org.cyverse/clojure-commons "3.0.6"]
                  [org.cyverse/cyverse-groups-client "0.1.8"]

--- a/src/terrain/services/filesystem/common_paths.clj
+++ b/src/terrain/services/filesystem/common_paths.clj
@@ -41,14 +41,9 @@
 
 (defn valid-path? [path-to-check] (valid/good-string? path-to-check))
 
-(defn base-trash-path
-  []
-  (item/trash-base-dir (cfg/irods-zone) (cfg/irods-user)))
-
-
 (defn user-trash-path
   [user]
-  (ft/path-join (base-trash-path) user))
+  (item/trash-base-dir (cfg/irods-zone) user))
 
 (defn in-trash?
   [user ^String fpath]

--- a/src/terrain/services/filesystem/sharing.clj
+++ b/src/terrain/services/filesystem/sharing.clj
@@ -8,8 +8,6 @@
   (:require [clojure.tools.logging :as log]
             [clojure.string :as string]
             [clojure-commons.file-utils :as ft]
-            [cemerick.url :as url]
-            [dire.core :refer [with-pre-hook! with-post-hook!]]
             [otel.otel :as otel]
             [terrain.services.filesystem.common-paths :as paths]
             [terrain.util.config :as cfg]
@@ -50,7 +48,7 @@
   [cm user share-with perm fpath]
   (otel/with-span [s ["terrain.services.filesystem.sharing/share-path"]]
     (let [hdir      (share-path-home fpath)
-          trash-dir (trash-base-dir (:zone cm) user)
+          trash-dir (trash-base-dir (:zone cm))
           base-dirs #{hdir trash-dir}]
       (log/warn fpath "is being shared with" share-with "by" user)
       (process-parent-dirs (partial set-readable cm share-with true) #(not (base-dirs %)) fpath)
@@ -121,7 +119,7 @@
           access to any other files or subdirectories."
   [cm user unshare-with fpath]
   (otel/with-span [s ["terrain.services.filesystem.sharing/unshare-path"]]
-    (let [base-dirs #{(ft/rm-last-slash (paths/user-home-dir user)) (trash-base-dir (:zone cm) user)}]
+    (let [base-dirs #{(ft/rm-last-slash (paths/user-home-dir user)) (trash-base-dir (:zone cm))}]
       (log/warn "Removing permissions on" fpath "from" unshare-with "by" user)
       (remove-permissions cm unshare-with fpath)
 


### PR DESCRIPTION
This PR will also update calls to `clj-jargon.item-info/trash-base-dir`, which no longer requires a user param, so that items can be put into the same trash paths as used by `irm`.