### PR TITLE
CORE-1946: only use JWKs whose intended use is for signing when valid…

### DIFF
--- a/src/terrain/util/keycloak_oidc.clj
+++ b/src/terrain/util/keycloak_oidc.clj
@@ -56,7 +56,7 @@
 (defn- update-cert-cache
   []
   (otel/with-span [s ["update-cert-cache"]]
-    (let [new-certs (kc/get-oidc-certs)]
+    (let [new-certs (filterv (comp (partial = "sig") :use) (kc/get-oidc-certs))]
       (reset! cached-certs-time (System/currentTimeMillis))
       (reset! cached-certs new-certs))))
 


### PR DESCRIPTION
…ating JWT signatures

Keycloak sometimes includes encryption keys in the list of keys from its certs endpoint. According to the [JWK specification](https://www.rfc-editor.org/rfc/rfc7517#section-4.2), the `use` field indicates whether a key is used for signing or encryption. The solution is to filter the list of keys returned by the certs endpoint so that we only attempt to validate JWT signatures using JWKs that are used for signing.