### PR TITLE
CORE-1951: added middleware to ensure that a workspace is created for…

### DIFF
--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -1393,13 +1393,19 @@
                 :body         body
                 :content-type :json})))
 
+(def workspace-for-user
+  (memoize (fn [params]
+             (-> (apps-url "workspaces")
+                 (client/get (disable-redirects {:query-params params
+                                                 :as           :json}))
+                 :body))))
+
 (defn bootstrap
   []
-  (:body
-   (client/get (apps-url "bootstrap")
-               (disable-redirects
-                {:query-params (secured-params)
-                 :as           :json}))))
+  (-> (apps-url "bootstrap")
+      (client/get (disable-redirects {:query-params (secured-params)
+                                      :as           :json}))
+      :body))
 
 (defn save-webhooks
   [webhooks]

--- a/src/terrain/middleware.clj
+++ b/src/terrain/middleware.clj
@@ -2,7 +2,9 @@
   (:require [clojure.string :as string]
             [terrain.auth.user-attributes :as user-attributes]
             [clojure-commons.response :as resp]
-            [terrain.clients.data-usage-api :as dua]))
+            [terrain.clients.apps.raw :as apps]
+            [terrain.clients.data-usage-api :as dua]
+            [terrain.util.transformers :refer [secured-params]]))
 
 (defn- add-context-path
   "Adds a context path to the start of a URI path if it's not present."
@@ -45,3 +47,10 @@
     (if (dua/user-data-overage? (:user (:user-info req)))
       (resp/forbidden "The account has data overages")
       (handler req))))
+
+(defn wrap-create-workspace
+  [handler]
+  (fn [request]
+    (when (:user-info request)
+      (apps/workspace-for-user (secured-params)))
+    (handler request)))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -7,7 +7,7 @@
         [ring.middleware.keyword-params :only [wrap-keyword-params]]
         [service-logging.middleware :only [wrap-logging clean-context]]
         [terrain.auth.user-attributes]
-        [terrain.middleware :only [wrap-context-path-adder wrap-query-param-remover]]
+        [terrain.middleware :only [wrap-context-path-adder wrap-create-workspace wrap-query-param-remover]]
         [terrain.routes.admin]
         [terrain.routes.analyses]
         [terrain.routes.apps.admin.apps]
@@ -206,7 +206,8 @@
     require-authentication
     wrap-user-info
     validate-current-user
-    wrap-logging]
+    wrap-logging
+    wrap-create-workspace]
    (admin-routes)))
 
 (def service-account-handler
@@ -221,14 +222,16 @@
    [authenticate-current-user
     require-authentication
     wrap-user-info
-    wrap-logging]
+    wrap-logging
+    wrap-create-workspace]
    (secured-routes)))
 
 (def optionally-authenticated-routes-handler
   (middleware
    [authenticate-current-user
     wrap-user-info
-    wrap-logging]
+    wrap-logging
+    wrap-create-workspace]
    (optionally-authenticated-routes)))
 
 (def secured-routes-no-context-handler
@@ -236,7 +239,8 @@
    [authenticate-current-user
     require-authentication
     wrap-user-info
-    wrap-logging]
+    wrap-logging
+    wrap-create-workspace]
    (secured-routes-no-context)))
 
 (def unsecured-routes-handler


### PR DESCRIPTION
… all authenticated users

The result of the HTTP call is memoized in order to eliminate unnecessary HTTP requests. Once we know that the workspace exists, there's no need to make another request to ensure that it still exists.
