### PR TITLE
CORE-1983: add support for multiyear subscriptions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -66,7 +66,8 @@
             [jonase/eastwood "0.3.10"]
             [reifyhealth/lein-git-down "0.4.1"]]
   :profiles {:dev     {:dependencies [[clj-http-fake "1.0.3"]]
-                       :resource-paths ["conf/test" "test-resources"]}
+                       :resource-paths ["conf/test" "test-resources"]
+                       :jvm-opts ["-Dotel.javaagent.enabled=false"]}
              :uberjar {:aot :all}}
   :main ^:skip-aot terrain.core
   :ring {:handler terrain.core/dev-handler
@@ -79,4 +80,6 @@
                  ["sonatype-releases"
                   {:url "https://oss.sonatype.org/content/repositories/releases/"}]
                  ["public-github" {:url "git://github.com" :protocol :https}]]
-  :jvm-opts ["-Dlogback.configurationFile=/etc/iplant/de/logging/terrain-logging.xml" "-javaagent:./opentelemetry-javaagent.jar" "-Dotel.resource.attributes=service.name=terrain"])
+  :jvm-opts ["-Dlogback.configurationFile=/etc/iplant/de/logging/terrain-logging.xml"
+             "-javaagent:./opentelemetry-javaagent.jar"
+             "-Dotel.resource.attributes=service.name=terrain"])

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
       (string/trim (:out (sh "git" "rev-parse" "HEAD")))
       ""))
 
-(defproject org.cyverse/terrain "2.12.0-SNAPSHOT"
+(defproject org.cyverse/terrain "3.0.0-SNAPSHOT"
   :description "Discovery Environment API gateway/API services catch-all project"
   :url "https://github.com/cyverse-de/terrain"
   :license {:name "BSD Standard License"

--- a/src/terrain/routes/qms.clj
+++ b/src/terrain/routes/qms.clj
@@ -92,10 +92,10 @@
          :body [body schema/SubscriptionRequests]
          :return schema/BulkSubscriptionResponse
          (ok (handlers/add-subscriptions params body)))
-       
+
        (context "/:subscription-uuid" []
          :path-params [subscription-uuid :- schema/SubscriptionID]
-         
+
          (context "/addons" []
            (GET "/" []
              :middleware [require-authentication]
@@ -103,7 +103,7 @@
              :description schema/ListSubscriptionAddonsDescription
              :return schema/SubscriptionAddonListResponse
              (ok (n/list-subscription-addons subscription-uuid)))
-           
+
            (POST "/" []
              :middleware [require-authentication]
              :summary schema/AddSubscriptionAddonSummary
@@ -111,24 +111,24 @@
              :body [body schema/AddonIDBody]
              :return schema/SubscriptionAddonResponse
              (ok (n/add-subscription-addon subscription-uuid (:uuid body))))
-           
+
            (context "/:uuid" []
              :path-params [uuid :- schema/SubscriptionAddonID]
-             
+
              (GET "/" []
                :middleware [require-authentication]
                :summary schema/GetSubscriptionAddonSummary
                :description schema/GetSubscriptionAddonDescription
                :return schema/SubscriptionAddonResponse
                (ok (n/get-subscription-addon uuid)))
-           
+
              (PUT "/" []
                :middleware [require-authentication]
                :summary schema/UpdateSubscriptionAddonSummary
                :description schema/UpdateSubscriptionAddonDescription
                :body [body schema/UpdateSubscriptionAddon]
                (ok (n/update-subscription-addon (assoc body :uuid uuid))))
-             
+
              (DELETE "/" []
                :middleware [require-authentication]
                :summary schema/DeleteSubscriptionAddonSummary
@@ -151,7 +151,7 @@
          :description schema/ListAddonsDescription
          :return schema/AddonListResponse
          (ok (n/list-addons)))
-       
+
        (PUT "/" []
          :middleware [require-authentication]
          :summary schema/UpdateAddonSummary
@@ -159,7 +159,7 @@
          :body [body schema/UpdateAddon]
          :return schema/AddonResponse
          (ok (n/update-addon body)))
-       
+
        (DELETE "/:uuid" []
          :middleware [require-authentication]
          :summary schema/DeleteAddonSummary
@@ -216,7 +216,7 @@
      (context "/users" []
        (context "/:username" []
          :path-params [username :- schema/Username]
-         
+
          (context "/plan" []
            (GET "/" []
              :middleware [[require-service-account ["cyverse-subscription-updater"]]]
@@ -224,7 +224,7 @@
              :description schema/GetSubscriptionDescription
              :return schema/SubscriptionPlanResponse
              (ok (qms/subscription username)))
-           
+
            (PUT "/:plan-name" []
              :middleware [[require-service-account ["cyverse-subscription-updater"]]]
              :summary schema/UpdateSubscriptionSummary
@@ -232,7 +232,7 @@
              :path-params [plan-name :- schema/PlanName]
              :return schema/SuccessResponse
              (ok (qms/update-subscription username plan-name {:paid true}))))))
-     
+
      (context "/addons" []
        (GET "/" []
          :middleware [[require-service-account ["cyverse-subscription-updater"]]]
@@ -240,11 +240,11 @@
          :description schema/ListAddonsDescription
          :return schema/AddonListResponse
          (ok (n/list-addons))))
-     
+
      (context "/subscriptions" []
        (context "/:subscription-uuid" []
          :path-params [subscription-uuid :- schema/SubscriptionID]
-         
+
          (context "/addons" []
            (GET "/" []
              :middleware [[require-service-account ["cyverse-subscription-updater"]]]
@@ -252,7 +252,7 @@
              :description schema/ListSubscriptionAddonsDescription
              :return schema/SubscriptionAddonListResponse
              (ok (n/list-subscription-addons subscription-uuid)))
-           
+
            (POST "/" []
              :middleware [[require-service-account ["cyverse-subscription-updater"]]]
              :summary schema/AddSubscriptionAddonSummary
@@ -260,24 +260,24 @@
              :body [body schema/AddonIDBody]
              :return schema/SubscriptionAddonResponse
              (ok (n/add-subscription-addon subscription-uuid (:uuid body))))
-           
+
            (context "/:uuid" []
              :path-params [uuid :- schema/SubscriptionAddonID]
-             
+
              (GET "/" []
                :middleware [[require-service-account ["cyverse-subscription-updater"]]]
                :summary schema/GetSubscriptionAddonSummary
                :description schema/GetSubscriptionAddonDescription
                :return schema/SubscriptionAddonResponse
                (ok (n/get-subscription-addon uuid)))
-           
+
              (PUT "/" []
                :middleware [[require-service-account ["cyverse-subscription-updater"]]]
                :summary schema/UpdateSubscriptionAddonSummary
                :description schema/UpdateSubscriptionAddonDescription
                :body [body schema/UpdateSubscriptionAddon]
                (ok (n/update-subscription-addon (assoc body :uuid uuid))))
-             
+
              (DELETE "/" []
                :middleware [[require-service-account ["cyverse-subscription-updater"]]]
                :summary schema/DeleteSubscriptionAddonSummary

--- a/src/terrain/routes/schemas/qms.clj
+++ b/src/terrain/routes/schemas/qms.clj
@@ -1,6 +1,6 @@
 (ns terrain.routes.schemas.qms
   (:require [common-swagger-api.schema :refer [PagingParams describe]]
-            [schema.core :refer [defschema Any optional-key maybe enum]])
+            [schema.core :as s :refer [defschema Any optional-key maybe enum]])
   (:import [java.util UUID]))
 
 (def GetAllPlansSummary "Returns a list of all plans registered in QMS")
@@ -61,9 +61,10 @@
    :status                (describe String "The status of the response")})
 
 (defschema ResourceType
-  {:id   ResourceID
-   :name ResourceTypeName
-   :unit (describe String "The unit of the resource type")})
+  {:id         ResourceID
+   :name       ResourceTypeName
+   :unit       (describe String "The unit of the resource type")
+   :consumable (describe Boolean "True if using the resource consumes it permanently")})
 
 (defschema ResourceTypesResponse
   {:result (describe [ResourceType] "The list of resource types")
@@ -160,7 +161,9 @@
 (defschema SubscriptionRequest
   {(optional-key :username)  (describe String "The username to associate with the subscription")
    (optional-key :plan_name) (describe String "The name of the plan to associate with the subscription")
-   :paid                     (describe Boolean "True if the user paid for the subscription")})
+   :paid                     (describe Boolean "True if the user paid for the subscription")
+   (optional-key :periods)   (describe Integer "The number of subscription periods")
+   (optional-key :end_date)  (describe String "The end date of the subscription.")})
 
 (defschema SubscriptionRequests
   {(optional-key :subscriptions) (describe (maybe [SubscriptionRequest]) "The list of subscription requests")})
@@ -169,8 +172,11 @@
   {(optional-key :force)
    (describe String "True if the subscription should be created even if the user already has a higher level plan")})
 
+;; The :periods parameter uses s/Int so that we can get automatic coercion.
 (defschema AddSubscriptionParams
-  {:paid (describe Boolean "True if the user paid for the subscription")})
+  {:paid                    (describe Boolean "True if the user paid for the subscription")
+   (optional-key :periods)  (describe s/Int "The number of subscription periods")
+   (optional-key :end_date) (describe String "The end date of the subscription")})
 
 (defschema ListSubscriptionsParams
   (merge PagingParams


### PR DESCRIPTION
This change introduces a couple of new concepts: Subscription Periods, and consumable resource types.

A subscription period refers to the period of time during which the subscription is active. All of our subscriptions are active for one year by default, so a single subscription period is equivalent to one year. With this change, a user may purchase a subscription for multiple subscription periods. For example, if a user chooses to purchase a three year subscription, the user would be given access to the allocations associated with their subscription for three years.

A consumable resource type is a type of resource is not reclaimable. For example, CPU hours can't be reclaimed because once a unit of compute time has been used, it can never be used again. Conversely, storage space can be reclaimed because deleting a file makes the space used to store the file available to be used again. Whether a resource type can be consumed or not is important when creating a new multiyear subscription. In general, we will want to multiply the default allocation associated with a consumable resource, but not a non-consumable resource, by the number of subscription periods when we're computing the quotas for a multiyear subscription.
