### PR TITLE
CORE-1983: service account support for multiyear subscriptions.

### DIFF
--- a/src/terrain/routes/qms.clj
+++ b/src/terrain/routes/qms.clj
@@ -229,9 +229,10 @@
              :middleware [[require-service-account ["cyverse-subscription-updater"]]]
              :summary schema/UpdateSubscriptionSummary
              :description schema/UpdateSubscriptionDescription
+             :query [params schema/ServiceAccountAddSubscriptionParams]
              :path-params [plan-name :- schema/PlanName]
              :return schema/SuccessResponse
-             (ok (qms/update-subscription username plan-name {:paid true}))))))
+             (ok (qms/update-subscription username plan-name (merge {:paid true} params)))))))
 
      (context "/addons" []
        (GET "/" []

--- a/src/terrain/routes/schemas/qms.clj
+++ b/src/terrain/routes/schemas/qms.clj
@@ -1,5 +1,5 @@
 (ns terrain.routes.schemas.qms
-  (:require [common-swagger-api.schema :refer [PagingParams describe]]
+  (:require [common-swagger-api.schema :refer [PagingParams describe ->optional-param]]
             [schema.core :as s :refer [defschema Any optional-key maybe enum]])
   (:import [java.util UUID]))
 
@@ -176,7 +176,10 @@
 (defschema AddSubscriptionParams
   {:paid                    (describe Boolean "True if the user paid for the subscription")
    (optional-key :periods)  (describe s/Int "The number of subscription periods")
-   (optional-key :end_date) (describe String "The end date of the subscription")})
+   (optional-key :end-date) (describe String "The end date of the subscription")})
+
+(defschema ServiceAccountAddSubscriptionParams
+  (->optional-param AddSubscriptionParams :paid))
 
 (defschema ListSubscriptionsParams
   (merge PagingParams


### PR DESCRIPTION
- Added support for the new query parameters to the service account endpoint for granting subscriptions.
- Also found and fixed a bug involving support for the `end-date` query parameter.
