### PR TITLE
CORE-1967 Allow anonymous access in /filesystem/metadata endpoints

### DIFF
--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -88,6 +88,7 @@
    (instant-launch-routes)
    (secured-data-routes)
    (secured-filesystem-routes)
+   (secured-filesystem-metadata-routes)
    (secured-search-routes)
    (app-category-routes)
    (app-avu-routes)

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -126,6 +126,7 @@
           (config/metadata-routes-enabled))]
 
     (POST "/filesystem/metadata/csv-parser" [:as {:keys [user-info params] :as req}]
+      :middleware [require-authentication]
       (meta/parse-metadata-csv-file user-info params))
 
     (GET "/filesystem/metadata/templates" [:as req]
@@ -135,12 +136,15 @@
       (controller req mt/do-metadata-template-view template-id))
 
     (GET "/filesystem/metadata/template/:template-id/blank-csv" [template-id :as req]
+      :middleware [require-authentication]
       (controller req meta-raw/get-template-csv template-id))
 
     (GET "/filesystem/metadata/template/:template-id/guide-csv" [template-id :as req]
+      :middleware [require-authentication]
       (controller req meta-raw/get-template-guide template-id))
 
     (GET "/filesystem/metadata/template/:template-id/zip-csv" [template-id :as req]
+      :middleware [require-authentication]
       (controller req meta-raw/get-template-zip template-id))
 
     (GET "/filesystem/metadata/template/attr/:attr-id" [attr-id :as req]
@@ -150,15 +154,19 @@
       (controller req meta/do-metadata-get :params data-id))
 
     (POST "/filesystem/:data-id/metadata" [data-id :as req]
+      :middleware [require-authentication]
       (controller req meta/do-metadata-set data-id :params :body))
 
     (POST "/filesystem/:data-id/metadata/copy" [data-id :as req]
+      :middleware [require-authentication]
       (controller req meta/do-metadata-copy :params data-id :body))
 
     (POST "/filesystem/:data-id/metadata/save" [data-id :as req]
+      :middleware [require-authentication]
       (controller req meta/do-metadata-save data-id :params :body))
 
     (POST "/filesystem/:data-id/ore/save" [data-id :as req]
+      :middleware [require-authentication]
       (controller req meta/do-ore-save data-id :params))))
 
 (defn admin-filesystem-metadata-routes

--- a/src/terrain/util/transformers.clj
+++ b/src/terrain/util/transformers.clj
@@ -40,8 +40,10 @@
   "Generates a set of query parameters to pass to a remote service that requires
    the username of the authenticated user."
   ([]
-     (user-params {}))
+   (user-params {}))
   ([existing-params]
-     (assoc existing-params :user (:shortUsername current-user)))
+   (as-> (add-current-user-to-map {}) m
+         (select-keys m [:user])
+         (merge existing-params m)))
   ([existing-params param-keys]
-     (user-params (select-keys existing-params param-keys))))
+   (user-params (select-keys existing-params param-keys))))


### PR DESCRIPTION
This PR will add the `secured-filesystem-metadata-routes` to the `optionally-authenticated-routes`, allowing them to be accessed without the `/secured` prefix, and allowing `anonymous` access for the GET endpoints.

POST and CSV download endpoints still require authentication.

This is required in order for Local Contexts Labels and Notices to be viewed by logged out users for public data under Community Data folders.