### PR TITLE
Trim the :error key in preferences when other keys are present

### DIFF
--- a/src/terrain/routes/schemas/bootstrap.clj
+++ b/src/terrain/routes/schemas/bootstrap.clj
@@ -35,8 +35,7 @@
 
 (defschema UserPreferencesResponse
   (doc-only (conditional :error BootstrapServiceError
-                         :else Any)
-                         ;; :else user-prefs-schema/UserPreferencesResponse) ;; wasn't working for some reason
+                         :else user-prefs-schema/UserPreferencesResponse)
             user-prefs-schema/UserPreferencesResponseDocs))
 
 (defschema UserSessionResponse
@@ -49,5 +48,4 @@
    :session     UserSessionResponse
    :apps_info   AppsBootstrapResponse
    :data_info   DataInfoResponse
-   :preferences (conditional :error BootstrapServiceError
-                             :else Any)}) ;; I don't know why but UserPreferencesResponse isn't working
+   :preferences UserPreferencesResponse})

--- a/src/terrain/services/bootstrap.clj
+++ b/src/terrain/services/bootstrap.clj
@@ -50,7 +50,10 @@
 (defn- get-user-prefs
   [username]
   (trap-bootstrap-request
-   #(prefs/user-prefs username)))
+   #(let [prefs (prefs/user-prefs username)]
+      (if (and (:error prefs) (:default_output_folder prefs)) ;; if we've got both, there's an error stored in preferences. remove it so schema validation works right
+        (dissoc prefs :error)
+        prefs))))
 
 (defn bootstrap
   "This service obtains information about and initializes the workspace for the authenticated user.


### PR DESCRIPTION
(also, bring back the proper schemas for preferences, now that we know what was actually going on there, namely that the presence of an `:error` key in stored preferences was changing the schema to the error one, ironically, in error)