### PR TITLE
CORE-2013: fixed an import error

### DIFF
--- a/src/terrain/util/keycloak_oidc.clj
+++ b/src/terrain/util/keycloak_oidc.clj
@@ -2,7 +2,7 @@
   (:require [clojure.string :as string]
             [clojure-commons.jwt :as jwt]
             [clojure-commons.response :as resp]
-            [slingshot.slingshot :only [try+ throw+]]
+            [slingshot.slingshot :refer [try+ throw+]]
             [terrain.clients.keycloak :as kc]
             [terrain.util.config :as config]))
 


### PR DESCRIPTION
I did a rebase and failed to do another lint check before merging the last PR. This PR fixes a lint error that was reintroduced by the rebase.