### PR TITLE
CORE-2016: support for scheduled quota default and subscription rate changes.

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,6 +1,7 @@
 {:lint-as {common-swagger-api.schema/defapi clojure.core/def
            slingshot.slingshot/try+         clojure.core/try
-           pronto.core/defmapper            clojure.core/def}
+           pronto.core/defmapper            clojure.core/def
+           terrain.qms-model/deftestcases   clojure.core/def}
  :linters {:clojure-lsp/unused-public-var {:exclude [terrain.routes/app-wrapper]}
            :unresolved-var                {:exclude [clojure-commons.error-codes
                                                      ring.util.http-response]}

--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
                  [less-awful-ssl "1.0.6"]
                  [clojure.java-time "1.4.2"]
                  [com.appsflyer/pronto "3.0.0"]
-                 [org.cyverse/cyverse-de-protobufs "0.0.2"]]
+                 [org.cyverse/cyverse-de-protobufs "0.0.3-SNAPSHOT"]]
   :eastwood {:exclude-namespaces [terrain.util.jwt :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
   :plugins [[lein-ancient "0.7.0"]

--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
                  [less-awful-ssl "1.0.6"]
                  [clojure.java-time "1.4.2"]
                  [com.appsflyer/pronto "3.0.0"]
-                 [org.cyverse/cyverse-de-protobufs "0.0.3-SNAPSHOT"]]
+                 [org.cyverse/cyverse-de-protobufs "0.0.3"]]
   :eastwood {:exclude-namespaces [terrain.util.jwt :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
   :plugins [[lein-ancient "0.7.0"]

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -1277,8 +1277,8 @@
                    :content-type :json}))))
 
 (defn record-login
-  [ip-address user-agent]
-  (let [params (remove-nil-values {:ip-address ip-address :user-agent user-agent})]
+  [ip-address session-id login-time]
+  (let [params (remove-nil-values {:ip-address ip-address :session-id session-id :login-time login-time})]
     (:body
      (client/post (apps-url "users" "login")
                   (disable-redirects

--- a/src/terrain/clients/apps/raw.clj
+++ b/src/terrain/clients/apps/raw.clj
@@ -1285,14 +1285,6 @@
                    {:query-params (secured-params params)
                     :as           :json})))))
 
-(defn record-logout
-  [params]
-  (:body
-   (client/post (apps-url "users" "logout")
-                (disable-redirects
-                 {:query-params (secured-params params)
-                  :as           :json}))))
-
 (defn list-integration-data
   [params]
   (client/get (apps-url "admin" "integration-data")

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -20,7 +20,8 @@
   (log/error "getting token from " (keycloak-admin-token-url "protocol" "openid-connect" "token"))
   (log/error "id/secret " (config/keycloak-admin-client-id) " " (config/keycloak-admin-client-secret))
   (:body (http/post (keycloak-admin-token-url "protocol" "openid-connect" "token")
-                    {:form-params {:grant_type    "client_credentials"
+                    {:insecure?   true
+                     :form-params {:grant_type    "client_credentials"
                                    :client_id     (config/keycloak-admin-client-id)
                                    :client_secret (config/keycloak-admin-client-secret)}
                      :as          :json})))
@@ -35,7 +36,8 @@
    (get-user username (:access_token (get-token))))
   ([username token]
    (let [user-data (http/get (keycloak-admin-url "users")
-                             {:query-params {:username username
+                             {:insecure?    true
+                              :query-params {:username username
                                              :exact true}
                               :headers {:authorization (str "Bearer " token)}
                               :as :json})]
@@ -53,7 +55,8 @@
    (get-user-session user-id (:access_token (get-token))))
   ([user-id token]
    (:body (http/get (keycloak-admin-url "users" user-id "sessions")
-                    {:headers {:authorization (str "Bearer " token)}
+                    {:insecure? true
+                     :headers {:authorization (str "Bearer " token)}
                      :as :json}))))
 
 (defn get-user-session-by-username

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -1,6 +1,7 @@
 (ns terrain.clients.keycloak.admin
   (:require [cemerick.url :as curl]
             [clj-http.client :as http]
+            [clojure.tools.logging :as log]
             [terrain.util.config :as config]))
 
 (defn- keycloak-admin-url
@@ -16,6 +17,8 @@
 (defn get-token
   "Obtains authorization token data for the admin service account. You'll probably want the access_token field in the return value."
   []
+  (log/error "getting token from " (keycloak-admin-token-url "protocol" "openid-connect" "token"))
+  (log/error "id/secret " (config/keycloak-admin-client-id) " " (config/keycloak-admin-client-secret))
   (:body (http/post (keycloak-admin-token-url "protocol" "openid-connect" "token")
                     {:form-params {:grant_type    "client_credentials"
                                    :client_id     (config/keycloak-admin-client-id)

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -7,12 +7,12 @@
 (defn- keycloak-admin-url
   "Builds a Keycloak admin API URL with the given path components."
   [& components]
-  (str (apply curl/url (config/keycloak-admin-base-uri) "realms" (config/keycloak-realm) components)))
+  (str (apply curl/url (config/keycloak-admin-base-uri) "admin" "realms" (config/keycloak-realm) components)))
 
 (defn- keycloak-admin-token-url
   "Like keycloak-admin-url but for the 'master' realm to get a token to use with the API"
   [& components]
-  (str (apply curl/url (config/keycloak-base-uri) "realms" "master" components)))
+  (str (apply curl/url (config/keycloak-admin-base-uri) "realms" "master" components)))
 
 (defn get-token
   "Obtains authorization token data for the admin service account. You'll probably want the access_token field in the return value."

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -1,0 +1,40 @@
+(ns terrain.clients.keycloak.admin
+  (:require [cemerick.url :as curl]
+            [clj-http.client :as http]
+            [terrain.util.config :as config]))
+
+(defn- keycloak-admin-url
+  "Builds a Keycloak admin API URL with the given path components."
+  [& components]
+  (str (apply curl/url (config/keycloak-admin-base-uri) "realms" (config/keycloak-realm) components)))
+
+(defn- keycloak-admin-token-url
+  "Like keycloak-admin-url but for the 'master' realm to get a token to use with the API"
+  [& components]
+  (str (apply curl/url (config/keycloak-admin-base-uri) "realms" "master" components)))
+
+(defn get-token
+  "Obtains authorization token data for the admin service account."
+  []
+  (:body (http/post (keycloak-admin-token-url "protocol" "openid-connect" "token")
+                    {:form-params {:grant_type    "client_credentials"
+                                   :client_id     (config/keycloak-client-id)
+                                   :client_secret (config/keycloak-client-secret)}
+                     :as          :json})))
+
+; https://www.keycloak.org/docs-api/26.0.5/rest-api/#_get_adminrealmsrealmusers
+(defn get-user
+  "Obtains user information from keycloak
+  
+  This will be a map including keys at least :username and :id, which should be
+  what we need to make further requests"
+  [username]
+  (let [user-data (http/get (keycloak-admin-url "users")
+                            {:query-params {:username username
+                                            :exact true}
+                             :headers {:authorization "Bearer " (get-token)}
+                             :as :json})]
+    ; the 'exact' query parameter doesn't seem to work on all keycloak versions, so we filter it
+    (->> user-data
+         (filter (fn [user] (= (:username obj) username)))
+         first)))

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -2,6 +2,7 @@
   (:require [cemerick.url :as curl]
             [clj-http.client :as http]
             [clojure.tools.logging :as log]
+            [clojure.string :as string]
             [terrain.util.config :as config]))
 
 (defn- keycloak-admin-url
@@ -64,5 +65,5 @@
   ([username]
    (get-user-session-by-username username (:access_token (get-token))))
   ([username token]
-   (log/error "Getting user sessions for username " username)
-   (get-user-session (:id (get-user username token)) token)))
+   (log/error "Getting user sessions for username " (string/replace username #"@.*$" ""))
+   (get-user-session (:id (get-user (string/replace username #"@.*$" "") token)) token)))

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -32,11 +32,11 @@
   (let [user-data (http/get (keycloak-admin-url "users")
                             {:query-params {:username username
                                             :exact true}
-                             :headers {:authorization "Bearer " (get-token)}
+                             :headers {:authorization (str "Bearer " (get-token))}
                              :as :json})]
     ; the 'exact' query parameter doesn't seem to work on all keycloak versions, so we filter it
     (->> user-data
-         (filter (fn [user] (= (:username obj) username)))
+         (filter (fn [user] (= (:username user) username)))
          first)))
 
 ; https://www.keycloak.org/docs-api/26.0.5/rest-api/#_get_adminrealmsrealmusersuser_idsessions
@@ -46,5 +46,5 @@
   This will be a list of maps, which will include user ID, ip address, session ID, and clients at least."
   [user-id]
   (:body (http/get (keycloak-admin-url "users" user-id "sessions")
-                   {:headers {:authorization "Bearer " (get-token)}
+                   {:headers {:authorization (str "Bearer " (get-token))}
                     :as :json})))

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -17,8 +17,6 @@
 (defn get-token
   "Obtains authorization token data for the admin service account. You'll probably want the access_token field in the return value."
   []
-  (log/error "getting token from " (keycloak-admin-token-url "protocol" "openid-connect" "token"))
-  (log/error "id/secret " (config/keycloak-admin-client-id) " " (config/keycloak-admin-client-secret))
   (:body (http/post (keycloak-admin-token-url "protocol" "openid-connect" "token")
                     {:insecure?   true
                      :form-params {:grant_type    "client_credentials"
@@ -42,6 +40,7 @@
                               :headers {:authorization (str "Bearer " token)}
                               :as :json})]
      ; the 'exact' query parameter doesn't seem to work on all keycloak versions, so we filter it
+     (log/error "Got user data" user-data)
      (->> user-data
           (filter (fn [user] (= (:username user) username)))
           first))))
@@ -54,6 +53,7 @@
   ([user-id]
    (get-user-session user-id (:access_token (get-token))))
   ([user-id token]
+   (log/error "Getting user sessions for ID " user-id)
    (:body (http/get (keycloak-admin-url "users" user-id "sessions")
                     {:insecure? true
                      :headers {:authorization (str "Bearer " token)}
@@ -64,4 +64,5 @@
   ([username]
    (get-user-session-by-username username (:access_token (get-token))))
   ([username token]
+   (log/error "Getting user sessions for username " username)
    (get-user-session (:id (get-user username token)) token)))

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -11,7 +11,7 @@
 (defn- keycloak-admin-token-url
   "Like keycloak-admin-url but for the 'master' realm to get a token to use with the API"
   [& components]
-  (str (apply curl/url (config/keycloak-admin-base-uri) "realms" "master" components)))
+  (str (apply curl/url (config/keycloak-base-uri) "realms" "master" components)))
 
 (defn get-token
   "Obtains authorization token data for the admin service account. You'll probably want the access_token field in the return value."

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -38,3 +38,13 @@
     (->> user-data
          (filter (fn [user] (= (:username obj) username)))
          first)))
+
+; https://www.keycloak.org/docs-api/26.0.5/rest-api/#_get_adminrealmsrealmusersuser_idsessions
+(defn get-user-session
+  "Obtains information about the user's current session from keycloak.
+  
+  This will be a list of maps, which will include user ID, ip address, session ID, and clients at least."
+  [user-id]
+  (:body (http/get (keycloak-admin-url "users" user-id "sessions")
+                   {:headers {:authorization "Bearer " (get-token)}
+                    :as :json})))

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -18,8 +18,8 @@
   []
   (:body (http/post (keycloak-admin-token-url "protocol" "openid-connect" "token")
                     {:form-params {:grant_type    "client_credentials"
-                                   :client_id     (config/keycloak-client-id)
-                                   :client_secret (config/keycloak-client-secret)}
+                                   :client_id     (config/keycloak-admin-client-id)
+                                   :client_secret (config/keycloak-admin-client-secret)}
                      :as          :json})))
 
 ; https://www.keycloak.org/docs-api/26.0.5/rest-api/#_get_adminrealmsrealmusers

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -41,7 +41,6 @@
                               :headers {:authorization (str "Bearer " token)}
                               :as :json})]
      ; the 'exact' query parameter doesn't seem to work on all keycloak versions, so we filter it
-     (log/error "Got user data" user-data)
      (->> user-data
           :body
           (filter (fn [user] (= (:username user) username)))
@@ -55,7 +54,6 @@
   ([user-id]
    (get-user-session user-id (:access_token (get-token))))
   ([user-id token]
-   (log/error "Getting user sessions for ID" user-id)
    (:body (http/get (keycloak-admin-url "users" user-id "sessions")
                     {:insecure? true
                      :headers {:authorization (str "Bearer " token)}
@@ -66,7 +64,5 @@
   ([username]
    (get-user-session-by-username username (:access_token (get-token))))
   ([username token]
-   (log/error "Getting user sessions for username" (string/replace username #"@.*$" ""))
    (let [user (get-user (string/replace username #"@.*$" "") token)]
-     (log/error "Got single-user data:" user)
      (get-user-session (:id user) token))))

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -14,7 +14,7 @@
   (str (apply curl/url (config/keycloak-admin-base-uri) "realms" "master" components)))
 
 (defn get-token
-  "Obtains authorization token data for the admin service account."
+  "Obtains authorization token data for the admin service account. You'll probably want the access_token field in the return value."
   []
   (:body (http/post (keycloak-admin-token-url "protocol" "openid-connect" "token")
                     {:form-params {:grant_type    "client_credentials"
@@ -29,7 +29,7 @@
   This will be a map including keys at least :username and :id, which should be
   what we need to make further requests"
   ([username]
-   (get-user username (get-token)))
+   (get-user username (:access_token (get-token))))
   ([username token]
    (let [user-data (http/get (keycloak-admin-url "users")
                              {:query-params {:username username
@@ -47,7 +47,7 @@
   
   This will be a list of maps, which will include user ID, ip address, session ID, and clients at least."
   ([user-id]
-   (get-user-session user-id (get-token)))
+   (get-user-session user-id (:access_token (get-token))))
   ([user-id token]
    (:body (http/get (keycloak-admin-url "users" user-id "sessions")
                     {:headers {:authorization (str "Bearer " token)}
@@ -56,6 +56,6 @@
 (defn get-user-session-by-username
   "Same as `get-user-session`, but by username by way of a request to `get-user` first."
   ([username]
-   (get-user-session-by-username username (get-token)))
+   (get-user-session-by-username username (:access_token (get-token))))
   ([username token]
    (get-user-session (:id (get-user username token)) token)))

--- a/src/terrain/clients/keycloak/admin.clj
+++ b/src/terrain/clients/keycloak/admin.clj
@@ -43,6 +43,7 @@
      ; the 'exact' query parameter doesn't seem to work on all keycloak versions, so we filter it
      (log/error "Got user data" user-data)
      (->> user-data
+          :body
           (filter (fn [user] (= (:username user) username)))
           first))))
 
@@ -54,7 +55,7 @@
   ([user-id]
    (get-user-session user-id (:access_token (get-token))))
   ([user-id token]
-   (log/error "Getting user sessions for ID " user-id)
+   (log/error "Getting user sessions for ID" user-id)
    (:body (http/get (keycloak-admin-url "users" user-id "sessions")
                     {:insecure? true
                      :headers {:authorization (str "Bearer " token)}
@@ -65,5 +66,7 @@
   ([username]
    (get-user-session-by-username username (:access_token (get-token))))
   ([username token]
-   (log/error "Getting user sessions for username " (string/replace username #"@.*$" ""))
-   (get-user-session (:id (get-user (string/replace username #"@.*$" "") token)) token)))
+   (log/error "Getting user sessions for username" (string/replace username #"@.*$" ""))
+   (let [user (get-user (string/replace username #"@.*$" "") token)]
+     (log/error "Got single-user data:" user)
+     (get-user-session (:id user) token))))

--- a/src/terrain/clients/qms/model.clj
+++ b/src/terrain/clients/qms/model.clj
@@ -62,7 +62,7 @@
     (when (contains? m :default_paid)
       (.setDefaultPaid builder (:default_paid m)))
     (when (contains? m :addon_rates)
-      (.addAllAddonRates builder (addon-rates-from-maps (:addon-rates m))))
+      (.addAllAddonRates builder (addon-rates-from-maps (:addon_rates m))))
     (.build builder)))
 
 (defn add-addon-request-from-map

--- a/src/terrain/clients/qms/model.clj
+++ b/src/terrain/clients/qms/model.clj
@@ -1,0 +1,118 @@
+(ns terrain.clients.qms.model
+  (:require [terrain.util.time :as time])
+  (:import [org.cyverse.de.protobufs
+            AddAddonRequest
+            Addon
+            AddonRate
+            AssociateByUuids
+            ByUuid
+            NoParamsRequest
+            ResourceType
+            SubscriptionAddon
+            UpdateAddonRequest
+            UpdateSubscriptionAddonRequest]))
+
+(defn resource-type-from-map
+  [m]
+  (let [builder (ResourceType/newBuilder)]
+    (when (contains? m :uuid)
+      (.setUuid builder (:uuid m)))
+    (when (contains? m :name)
+      (.setName builder (:name m)))
+    (when (contains? m :unit)
+      (.setUnit builder (:unit m)))
+    (when (contains? m :consumable)
+      (.setConsumable builder (:consumable m)))
+    (.build builder)))
+
+(defn addon-rate-from-map
+  [m]
+  (let [builder (AddonRate/newBuilder)]
+    (when (contains? m :uuid)
+      (.setUuid builder (:uuid m)))
+    (when (contains? m :rate)
+      (.setUuid builder (:rate m)))
+    (when (contains? m :effective_date)
+      (.setEffectiveDate builder (time/protobuf-timestamp (:effective_date m))))
+    (.build builder)))
+
+(defn addon-from-map
+  [m]
+  (let [builder (Addon/newBuilder)]
+    (when (contains? m :uuid)
+      (.setUuid builder (:uuid m)))
+    (when (contains? m :name)
+      (.setName builder (:name m)))
+    (when (contains? m :description)
+      (.setDescription builder (:description m)))
+    (when (contains? m :resource_type)
+      (.setResourceType builder (resource-type-from-map (:resource_type m))))
+    (when (contains? m :default_amount)
+      (.setDefaultAmount builder (:default_amount m)))
+    (when (contains? m :default_paid)
+      (.setDefaultPaaid builder (:default_paid m)))
+    (when (contains? m :addon_rates)
+      (.setAddonRates builder (into-array AddonRate (map addon-rate-from-map (:addon-rates m)))))
+    (.build builder)))
+
+(defn add-addon-request-from-map
+  [m]
+  (let [builder (AddAddonRequest/newBuilder)]
+    (when (contains? m :addon)
+      (.setAddon builder (addon-from-map (:addon m))))
+    (.build builder)))
+
+(defn new-no-params-request
+  []
+  (.build (NoParamsRequest/newBuilder)))
+
+(defn update-addon-request-from-map
+  [m]
+  (let [builder (UpdateAddonRequest/newBuilder)]
+    (when (contains? m :addon)
+      (.setAddon builder (addon-from-map (:addon m))))
+    (when (contains? m :update_name)
+      (.setUpdateName builder (:update_name m)))
+    (when (contains? m :update_description)
+      (.setUpdateDescription builder (:update_description m)))
+    (when (contains? m :update_resource_type)
+      (.setUpdateResourceType builder (:update_resource_type m)))
+    (when (contains? m :update_default_amount)
+      (.setUpdateDefaultAmount builder (:update_default_amount m)))
+    (when (contains? m :update_default_paid)
+      (.setUpdateDefaultPaid builder (:update_default_paid m)))
+    (when (contains? m :update_addon_rates)
+      (.setUpdateAddonRates builder (:update_addon_rates m)))
+    (.build builder)))
+
+(defn by-uuid-request-from-map
+  [m]
+  (let [builder (ByUuid/newBuilder)]
+    (when (contains? m :uuid)
+      (.setUuid builder (:uuid m)))))
+
+(defn associate-by-uuids-from-map
+  [m]
+  (let [builder (AssociateByUuids/newBuilder)]
+    (when (contains? m :parent_uuid)
+      (.setParentUuid builder (:parent_uuid m)))
+    (when (contains? m :child_uuid)
+      (.setChildUuid builder (:child_uuid m)))))
+
+(defn subscription-addon-from-map
+  [m]
+  (let [builder (SubscriptionAddon/newBuilder)]
+    (when (contains? m :uuid)
+      (.setUuid builder (:uuid m)))
+    (when (contains? m :addon)
+      (.setAddon builder (addon-from-map (:addon m))))
+    ;; TODO: finish implementing this function.
+    ))
+
+(defn update-subscription-addon-request-from-map
+  [m]
+  (let [builder (UpdateSubscriptionAddonRequest/newBuilder)]
+    (when (contains? m :subscription_addon)
+      (.setSubscriptionAddon builder (subscription-addon-from-map (:subscription_addon m))))
+    ;; TODO: finish implementing this function
+    ))

--- a/src/terrain/clients/qms/model.clj
+++ b/src/terrain/clients/qms/model.clj
@@ -22,7 +22,7 @@
   [m]
   (let [builder (ResourceType/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))
+      (.setUuid builder (str (:uuid m))))
     (when (contains? m :name)
       (.setName builder (:name m)))
     (when (contains? m :unit)
@@ -35,7 +35,7 @@
   [m]
   (let [builder (AddonRate/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))
+      (.setUuid builder (str (:uuid m))))
     (when (contains? m :rate)
       (.setRate builder (:rate m)))
     (when (contains? m :effective_date)
@@ -50,7 +50,7 @@
   [m]
   (let [builder (Addon/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))
+      (.setUuid builder (str (:uuid m))))
     (when (contains? m :name)
       (.setName builder (:name m)))
     (when (contains? m :description)
@@ -99,7 +99,7 @@
   [m]
   (let [builder (ByUUID/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))
+      (.setUuid builder (str (:uuid m))))
     (.build builder)))
 
 (defn associate-by-uuids-from-map
@@ -115,7 +115,7 @@
   [m]
   (let [builder (QMSUser/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))
+      (.setUuid builder (str (:uuid m))))
     (when (contains? m :username)
       (.setUsername builder (:username m)))
     (.build builder)))
@@ -124,7 +124,7 @@
   [m]
   (let [builder (QuotaDefault/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))
+      (.setUuid builder (str (:uuid m))))
     (when (contains? m :quota_value)
       (.setQuotaValue builder (:quota_value m)))
     (when (contains? m :resource_type)
@@ -141,7 +141,7 @@
   [m]
   (let [builder (PlanRate/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))
+      (.setUuid builder (str (:uuid m))))
     (when (contains? m :rate)
       (.setRate builder (:rate m)))
     (when (contains? m :effective_date)
@@ -156,7 +156,7 @@
   [m]
   (let [builder (Plan/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))
+      (.setUuid builder (str (:uuid m))))
     (when (contains? m :name)
       (.setName builder (:name m)))
     (when (contains? m :description)
@@ -171,7 +171,7 @@
   [m]
   (let [builder (Usage/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))
+      (.setUuid builder (str (:uuid m))))
     (when (contains? m :usage)
       (.setUsage builder (:usage m)))
     (when (contains? m :subscription_id)
@@ -196,7 +196,7 @@
   [m]
   (let [builder (Subscription/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))
+      (.setUuid builder (str (:uuid m))))
     (when (contains? m :effective_start_date)
       (.setEffectiveStartDate builder (time/protobuf-timestamp (:effective_start_date m))))
     (when (contains? m :effective_end_date)
@@ -217,7 +217,7 @@
   [m]
   (let [builder (SubscriptionAddon/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))
+      (.setUuid builder (str (:uuid m))))
     (when (contains? m :addon)
       (.setAddon builder (addon-from-map (:addon m))))
     (when (contains? m :subscription)

--- a/src/terrain/clients/qms/model.clj
+++ b/src/terrain/clients/qms/model.clj
@@ -42,6 +42,10 @@
       (.setEffectiveDate builder (time/protobuf-timestamp (:effective_date m))))
     (.build builder)))
 
+(defn addon-rates-from-maps
+  [ms]
+  (map addon-rate-from-map ms))
+
 (defn addon-from-map
   [m]
   (let [builder (Addon/newBuilder)]
@@ -56,9 +60,9 @@
     (when (contains? m :default_amount)
       (.setDefaultAmount builder (:default_amount m)))
     (when (contains? m :default_paid)
-      (.setDefaultPaaid builder (:default_paid m)))
+      (.setDefaultPaid builder (:default_paid m)))
     (when (contains? m :addon_rates)
-      (.setAddonRates builder (into-array AddonRate (map addon-rate-from-map (:addon-rates m)))))
+      (.addAllAddonRates builder (addon-rates-from-maps (:addon-rates m))))
     (.build builder)))
 
 (defn add-addon-request-from-map

--- a/src/terrain/clients/qms/model.clj
+++ b/src/terrain/clients/qms/model.clj
@@ -133,6 +133,10 @@
       (.setEffectiveDate builder (time/protobuf-timestamp (:effective_date m))))
     (.build builder)))
 
+(defn quota-defaults-from-maps
+  [ms]
+  (map quota-default-from-map ms))
+
 (defn plan-rate-from-map
   [m]
   (let [builder (PlanRate/newBuilder)]
@@ -144,6 +148,10 @@
       (.setEffectiveDate builder (time/protobuf-timestamp (:effective_date m))))
     (.build builder)))
 
+(defn plan-rates-from-maps
+  [ms]
+  (map plan-rate-from-map ms))
+
 (defn plan-from-map
   [m]
   (let [builder (Plan/newBuilder)]
@@ -154,9 +162,9 @@
     (when (contains? m :description)
       (.setDescription builder (:description m)))
     (when (contains? m  :plan_quota_defaults)
-      (.setPlanQuotaDefaults (into-array QuotaDefault (map quota-default-from-map (:plan_quota_defaults m)))))
+      (.addAllPlanQuotaDefaults builder (quota-defaults-from-maps (:plan_quota_defaults m))))
     (when (contains? m :plan_rates)
-      (.setPlanRates builder (into-array PlanRate (map plan-rate-from-map (:plan_rates m)))))
+      (.addAllPlanRates builder (plan-rates-from-maps (:plan_rates m))))
     (.build builder)))
 
 (defn usage-from-map
@@ -171,14 +179,18 @@
     (when (contains? m :resource_type)
       (.setResourceType builder (resource-type-from-map (:resource_type m))))
     (when (contains? m :created_by)
-      (.setCreatedby builder (:created_by m)))
-    (when (contains? m :crated_at)
+      (.setCreatedBy builder (:created_by m)))
+    (when (contains? m :created_at)
       (.setCreatedAt builder (time/protobuf-timestamp (:created_at m))))
     (when (contains? m :last_modified_by)
       (.setLastModifiedBy builder (:last_modified_by m)))
     (when (contains? m :last_modified_at)
       (.setLastModifiedAt builder (time/protobuf-timestamp (:last_modified_at m))))
     (.build builder)))
+
+(defn usages-from-maps
+  [m]
+  (map usage-from-map (:usages m)))
 
 (defn subscription-from-map
   [m]
@@ -194,7 +206,7 @@
     (when (contains? m :plan)
       (.setPlan builder (plan-from-map (:plan m))))
     (when (contains? m :usages)
-      (.setUsages builder (into-array Usage (map usage-from-map (:usages m)))))
+      (.addAllUsages builder (usages-from-maps (:usages m))))
     (when (contains? m :paid)
       (.setPaid builder (:paid m)))
     (when (contains? m :plan_rate)

--- a/src/terrain/clients/qms/model.clj
+++ b/src/terrain/clients/qms/model.clj
@@ -4,13 +4,19 @@
             AddAddonRequest
             Addon
             AddonRate
-            AssociateByUuids
-            ByUuid
+            AssociateByUUIDs
+            ByUUID
             NoParamsRequest
             ResourceType
+            Plan
+            PlanRate
+            QMSUser
+            QuotaDefault
+            Subscription
             SubscriptionAddon
             UpdateAddonRequest
-            UpdateSubscriptionAddonRequest]))
+            UpdateSubscriptionAddonRequest
+            Usage]))
 
 (defn resource-type-from-map
   [m]
@@ -31,7 +37,7 @@
     (when (contains? m :uuid)
       (.setUuid builder (:uuid m)))
     (when (contains? m :rate)
-      (.setUuid builder (:rate m)))
+      (.setRate builder (:rate m)))
     (when (contains? m :effective_date)
       (.setEffectiveDate builder (time/protobuf-timestamp (:effective_date m))))
     (.build builder)))
@@ -87,17 +93,109 @@
 
 (defn by-uuid-request-from-map
   [m]
-  (let [builder (ByUuid/newBuilder)]
+  (let [builder (ByUUID/newBuilder)]
     (when (contains? m :uuid)
-      (.setUuid builder (:uuid m)))))
+      (.setUuid builder (:uuid m)))
+    (.build builder)))
 
 (defn associate-by-uuids-from-map
   [m]
-  (let [builder (AssociateByUuids/newBuilder)]
+  (let [builder (AssociateByUUIDs/newBuilder)]
     (when (contains? m :parent_uuid)
       (.setParentUuid builder (:parent_uuid m)))
     (when (contains? m :child_uuid)
-      (.setChildUuid builder (:child_uuid m)))))
+      (.setChildUuid builder (:child_uuid m)))
+    (.build builder)))
+
+(defn user-from-map
+  [m]
+  (let [builder (QMSUser/newBuilder)]
+    (when (contains? m :uuid)
+      (.setUuid builder (:uuid m)))
+    (when (contains? m :username)
+      (.setUsername builder (:username m)))
+    (.build builder)))
+
+(defn quota-default-from-map
+  [m]
+  (let [builder (QuotaDefault/newBuilder)]
+    (when (contains? m :uuid)
+      (.setUuid builder (:uuid m)))
+    (when (contains? m :quota_value)
+      (.setQuotaValue builder (:quota_value m)))
+    (when (contains? m :resource_type)
+      (.setResourceType builder (resource-type-from-map (:resource_type m))))
+    (when (contains? m :effective_date)
+      (.setEffectiveDate builder (time/protobuf-timestamp (:effective_date m))))
+    (.build builder)))
+
+(defn plan-rate-from-map
+  [m]
+  (let [builder (PlanRate/newBuilder)]
+    (when (contains? m :uuid)
+      (.setUuid builder (:uuid m)))
+    (when (contains? m :rate)
+      (.setRate builder (:rate m)))
+    (when (contains? m :effective_date)
+      (.setEffectiveDate builder (time/protobuf-timestamp (:effective_date m))))
+    (.build builder)))
+
+(defn plan-from-map
+  [m]
+  (let [builder (Plan/newBuilder)]
+    (when (contains? m :uuid)
+      (.setUuid builder (:uuid m)))
+    (when (contains? m :name)
+      (.setName builder (:name m)))
+    (when (contains? m :description)
+      (.setDescription builder (:description m)))
+    (when (contains? m  :plan_quota_defaults)
+      (.setPlanQuotaDefaults (into-array QuotaDefault (map quota-default-from-map (:plan_quota_defaults m)))))
+    (when (contains? m :plan_rates)
+      (.setPlanRates builder (into-array PlanRate (map plan-rate-from-map (:plan_rates m)))))
+    (.build builder)))
+
+(defn usage-from-map
+  [m]
+  (let [builder (Usage/newBuilder)]
+    (when (contains? m :uuid)
+      (.setUuid builder (:uuid m)))
+    (when (contains? m :usage)
+      (.setUsage builder (:usage m)))
+    (when (contains? m :subscription_id)
+      (.setSubscriptionId builder (:subscription_id m)))
+    (when (contains? m :resource_type)
+      (.setResourceType builder (resource-type-from-map (:resource_type m))))
+    (when (contains? m :created_by)
+      (.setCreatedby builder (:created_by m)))
+    (when (contains? m :crated_at)
+      (.setCreatedAt builder (time/protobuf-timestamp (:created_at m))))
+    (when (contains? m :last_modified_by)
+      (.setLastModifiedBy builder (:last_modified_by m)))
+    (when (contains? m :last_modified_at)
+      (.setLastModifiedAt builder (time/protobuf-timestamp (:last_modified_at m))))
+    (.build builder)))
+
+(defn subscription-from-map
+  [m]
+  (let [builder (Subscription/newBuilder)]
+    (when (contains? m :uuid)
+      (.setUuid builder (:uuid m)))
+    (when (contains? m :effective_start_date)
+      (.setEffectiveStartDate builder (time/protobuf-timestamp (:effective_start_date m))))
+    (when (contains? m :effective_end_date)
+      (.setEffectiveEndDate builder (time/protobuf-timestamp (:effective_end_date m))))
+    (when (contains? m :user)
+      (.setUser builder (user-from-map (:user m))))
+    (when (contains? m :plan)
+      (.setPlan builder (plan-from-map (:plan m))))
+    (when (contains? m :usages)
+      (.setUsages builder (into-array Usage (map usage-from-map (:usages m)))))
+    (when (contains? m :paid)
+      (.setPaid builder (:paid m)))
+    (when (contains? m :plan_rate)
+      (.setPlanRate builder (plan-rate-from-map (:plan_rate m))))
+    (.build builder)))
 
 (defn subscription-addon-from-map
   [m]
@@ -106,13 +204,27 @@
       (.setUuid builder (:uuid m)))
     (when (contains? m :addon)
       (.setAddon builder (addon-from-map (:addon m))))
-    ;; TODO: finish implementing this function.
-    ))
+    (when (contains? m :subscription)
+      (.setSubscription builder (subscription-from-map (:subscription m))))
+    (when (contains? m :amount)
+      (.setAmount builder (:amount m)))
+    (when (contains? m :paid)
+      (.setPaid builder (:paid m)))
+    (when (contains? m :addon_rate)
+      (.setAddonRate builder (addon-rate-from-map (:addon_rate m))))
+    (.build builder)))
 
 (defn update-subscription-addon-request-from-map
   [m]
   (let [builder (UpdateSubscriptionAddonRequest/newBuilder)]
     (when (contains? m :subscription_addon)
       (.setSubscriptionAddon builder (subscription-addon-from-map (:subscription_addon m))))
-    ;; TODO: finish implementing this function
-    ))
+    (when (contains? m :update_addon_id)
+      (.setUpdateAddonId builder (:update_addon_id m)))
+    (when (contains? m :update_subscription_id)
+      (.setUpdateSubscriptionId builder (:update_subscription_id m)))
+    (when (contains? m :update_amount)
+      (.setUpdateAmount builder (:update_amount m)))
+    (when (contains? m :update_paid)
+      (.setUpdatePaid builder (:update_paid m)))
+    (.build builder)))

--- a/src/terrain/clients/qms_nats.clj
+++ b/src/terrain/clients/qms_nats.clj
@@ -100,7 +100,3 @@
   (as-> {:uuid (str uuid)} r
     (nats/request-json (cfg/get-subscription-addon-subject) (model/by-uuid-request-from-map r))
     (return-keys r [:subscription_addon])))
-
-(let [printer (JsonFormat/printer)
-      npr     (model/new-no-params-request)]
-  (.print printer npr))

--- a/src/terrain/clients/qms_nats.clj
+++ b/src/terrain/clients/qms_nats.clj
@@ -3,10 +3,7 @@
             [terrain.clients.qms.model :as model]
             [terrain.util.nats :as nats]
             [terrain.util.config :as cfg])
-  (:import [org.cyverse.de.protobufs
-            ByUUID
-            AssociateByUUIDs
-            UpdateSubscriptionAddonRequest]))
+  (:import [com.google.protobuf.util JsonFormat]))
 
 (def not-nil? (complement nil?))
 
@@ -103,3 +100,7 @@
   (as-> {:uuid (str uuid)} r
     (nats/request-json (cfg/get-subscription-addon-subject) (model/by-uuid-request-from-map r))
     (return-keys r [:subscription_addon])))
+
+(let [printer (JsonFormat/printer)
+      npr     (model/new-no-params-request)]
+  (.print printer npr))

--- a/src/terrain/routes/bootstrap.clj
+++ b/src/terrain/routes/bootstrap.clj
@@ -8,9 +8,6 @@
             [terrain.util :refer [optional-routes]]
             [terrain.util.config :as config]))
 
-;; Declarations to eliminate lint warnings for path and query parameter bindings.
-(declare user-agent ip-address params)
-
 (defn secured-bootstrap-routes
   []
   (optional-routes
@@ -19,10 +16,9 @@
     (context "/bootstrap" []
       :tags ["bootstrap"]
 
-      (GET "/" [:as {{user-agent "user-agent"} :headers}]
-           :query [{:keys [ip-address]} sessions-schema/IPAddrParam]
+      (GET "/" []
            :return schema/TerrainBootstrapResponse
            :summary "Bootstrap Service"
            :description "This service obtains information about and initializes the workspace for the authenticated user.
            It also records the fact that the user logged in."
-           (ok (bootstrap user-agent))))))
+           (ok (bootstrap))))))

--- a/src/terrain/routes/bootstrap.clj
+++ b/src/terrain/routes/bootstrap.clj
@@ -25,13 +25,4 @@
            :summary "Bootstrap Service"
            :description "This service obtains information about and initializes the workspace for the authenticated user.
            It also records the fact that the user logged in."
-           (ok (bootstrap ip-address user-agent))))
-
-    (context "/logout" []
-      :tags ["bootstrap"]
-
-      (GET "/" []
-           :query [params sessions-schema/LogoutParams]
-           :summary sessions-schema/LogoutSummary
-           :description sessions-schema/LogoutDocs
-           (ok (apps-client/record-logout params))))))
+           (ok (bootstrap user-agent))))))

--- a/src/terrain/routes/schemas/qms.clj
+++ b/src/terrain/routes/schemas/qms.clj
@@ -100,6 +100,7 @@
 
 (defschema PlanRate
   {(optional-key :id)             (describe String "The plan rate ID")
+   (optional-key :uuid)           (describe String "The plan rate ID")
    (optional-key :effective_date) (describe String "The date and time the plan rate becomes effective")
    (optional-key :rate)           (describe Double "The rate associated with the plan")})
 
@@ -231,7 +232,7 @@
    :default_amount      (describe Double "The amount of the resource provided by the add-on")
    :default_paid        (describe Boolean "Whether the add-on needs to be paid for")
    :resource_type       (describe NATSResourceType "The resource type the add-on provides more of")
-   :addon_rate          (describe [AddonRate] "The rates associated with the addon")})
+   :addon_rates         (describe [AddonRate] "The rates associated with the addon")})
 
 (defschema UpdateAddon
   {:uuid                          (describe UUID "The UUID of the add-on being updated")
@@ -266,7 +267,7 @@
    :subscription        (describe Subscription "The subscription the add-on was applied to")
    :amount              (describe Double "The amount of the resource type provided by the add-on that was actually applied to the subscription")
    :paid                (describe Boolean "Whether the add-on needs/needed to be paid for")
-   :addon_rates         (describe AddonRate "The active rate for the addon when it was added to the subscription")})
+   :addon_rate          (describe AddonRate "The active rate for the addon when it was added to the subscription")})
 
 (defschema AddonIDBody
   {:uuid AddonID})

--- a/src/terrain/services/bootstrap.clj
+++ b/src/terrain/services/bootstrap.clj
@@ -68,8 +68,7 @@
 (defn bootstrap
   "This service obtains information about and initializes the workspace for the authenticated user.
    It also records the fact that the user logged in."
-  [user-agent]
-  (assertions/assert-valid user-agent "Missing or empty request parameter: user-agent")
+  []
   (let [{user :shortUsername :keys [email firstName lastName username]} current-user
         login-session (future (get-login-session username))
         apps-info     (future (get-apps-info))

--- a/src/terrain/services/bootstrap.clj
+++ b/src/terrain/services/bootstrap.clj
@@ -68,7 +68,7 @@
 (defn bootstrap
   "This service obtains information about and initializes the workspace for the authenticated user.
    It also records the fact that the user logged in."
-  [ip-address user-agent]
+  [user-agent]
   (assertions/assert-valid user-agent "Missing or empty request parameter: user-agent")
   (let [{user :shortUsername :keys [email firstName lastName username]} current-user
         login-session (future (get-login-session username))

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -700,7 +700,7 @@
 (cc/defprop-optstr keycloak-admin-base-uri
   "The base URI to use for administrative requests to Keycloak."
   [props config-valid configs]
-  "terrain.keycloak.admin-base-uri" "https://keycloaktest2.cyverse.org/auth/admin")
+  "terrain.keycloak.admin-base-uri" "https://keycloaktest2.cyverse.org/auth")
 
 (declare keycloak-admin-client-id)
 (cc/defprop-str keycloak-admin-client-id

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -696,6 +696,24 @@
   [props config-valid configs]
   "terrain.keycloak.client-secret")
 
+(declare keycloak-admin-base-uri)
+(cc/defprop-optstr keycloak-admin-base-uri
+  "The base URI to use for administrative requests to Keycloak."
+  [props config-valid configs]
+  "terrain.keycloak.admin-base-uri" "https://keycloaktest2.cyverse.org/auth/admin")
+
+(declare keycloak-admin-client-id)
+(cc/defprop-str keycloak-admin-client-id
+  "The Keycloak admin client ID to use."
+  [props config-valid configs]
+  "terrain.keycloak.admin-client-id")
+
+(declare keycloak-admin-client-secret)
+(cc/defprop-str keycloak-admin-client-secret
+  "The keycloak admin client secret to use."
+  [props config-valid configs]
+  "terrain.keycloak.admin-client-secret")
+
 (declare dashboard-aggregator-url)
 (cc/defprop-optstr dashboard-aggregator-url
   "The URL to the dashboard-aggregator service."

--- a/src/terrain/util/nats.clj
+++ b/src/terrain/util/nats.clj
@@ -2,16 +2,8 @@
   (:require [less.awful.ssl :as ssl]
             [java-time.api :as jt]
             [cheshire.core :as json]
-            [clojure.string :as string]
-            [pronto.core :as p])
-  (:import [io.nats.client Nats Options$Builder]
-           [org.cyverse.de.protobufs
-            AddAddonRequest
-            NoParamsRequest
-            UpdateAddonRequest
-            ByUUID
-            AssociateByUUIDs
-            UpdateSubscriptionAddonRequest]))
+            [clojure.string :as string])
+  (:import [io.nats.client Nats Options$Builder]))
 
 (defn- get-options [servers-str tls? crt-fpath key-fpath ca-fpath max-reconns reconn-wait]
   (let [ssl-ctx     (when tls? (ssl/ssl-context key-fpath crt-fpath ca-fpath))
@@ -52,10 +44,6 @@
   [b]
   (json/parse-string (String. b) true))
 
-(defn publish-json [subject out]
-  (let [o (json-encode out)]
-    (.publish @nats-conn subject o)))
-
 (defn request-json
   ([subject out timeout]
    (let [msg-bytes (-> (json-encode out) (.getBytes))]
@@ -64,22 +52,3 @@
          (json-decode-bytes))))
   ([subject out]
    (request-json subject out (jt/duration 20 :seconds))))
-
-(p/defmapper default-mapper [AddAddonRequest
-                             NoParamsRequest
-                             UpdateAddonRequest
-                             ByUUID
-                             AssociateByUUIDs
-                             UpdateSubscriptionAddonRequest])
-
-(defn create
-  ([mapper cl m]
-   (p/clj-map->proto-map mapper cl m))
-  ([cl m]
-   (create default-mapper cl m)))
-
-(defn request
-  ([subject cl m timeout]
-   (request-json subject (create cl m) timeout))
-  ([subject cl m]
-   (request-json subject (create cl m))))

--- a/src/terrain/util/nats.clj
+++ b/src/terrain/util/nats.clj
@@ -3,7 +3,8 @@
             [java-time.api :as jt]
             [cheshire.core :as json]
             [clojure.string :as string])
-  (:import [io.nats.client Nats Options$Builder]))
+  (:import [com.google.protobuf.util JsonFormat]
+           [io.nats.client Nats Options$Builder]))
 
 (defn- get-options [servers-str tls? crt-fpath key-fpath ca-fpath max-reconns reconn-wait]
   (let [ssl-ctx     (when tls? (ssl/ssl-context key-fpath crt-fpath ca-fpath))
@@ -38,7 +39,7 @@
 
 (defn- json-encode
   [o]
-  (json/generate-string o {:key-fn encode-key}))
+  (.print (JsonFormat/printer) o))
 
 (defn- json-decode-bytes
   [b]

--- a/test/terrain/qms_model.clj
+++ b/test/terrain/qms_model.clj
@@ -50,7 +50,8 @@
 
 (defn addon-rates-equal-maps
   [ms ars]
-  (every? true? (map addon-rate-equals-map ms ars)))
+  (and (= (count ms) (.size ars))
+       (every? true? (map addon-rate-equals-map ms ars))))
 
 (deftest test-addon-rate-from-map
   (doseq [{:keys [m desc]} addon-rate-test-cases]
@@ -171,7 +172,8 @@
 
 (defn quota-defaults-equal-maps
   [ms qds]
-  (every? true? (map quota-default-equals-map ms qds)))
+  (and (= (count ms) (.size qds))
+       (every? true? (map quota-default-equals-map ms qds))))
 
 (deftest test-quota-default-from-map
   (doseq [{:keys [m desc]} quota-default-test-cases]
@@ -243,7 +245,8 @@
 
 (defn usages-equal-maps
   [ms us]
-  (every? true? (map usage-equals-map ms us)))
+  (and (= (count ms) (.size us))
+       (every? true? (map usage-equals-map ms us))))
 
 (deftest test-usage-from-map
   (doseq [{:keys [m desc]} usage-test-cases]

--- a/test/terrain/qms_model.clj
+++ b/test/terrain/qms_model.clj
@@ -58,3 +58,70 @@
    :default_amount 123.45
    :default_paid   true
    :addon_rates    (mapv :m addon-rate-test-cases)})
+
+(defn addon-equals-map
+  [m a]
+  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid a)))
+        (and (contains? m :name) (not= (:name m) (.getName a)))
+        (and (contains? m :description)  (not= (:description m) (.getDescription a)))
+        (and (contains? m :resource_type) (not= (model/resource-type-from-map (:resource_type m)) (.getResourceType a)))
+        (and (contains? m :default_amount) (not= (:default_amount m) (.getDefaultAmount a)))
+        (and (contains? m :default_paid) (not= (:default_paid m) (.getDefaultPaid a)))
+        (and (contains? m :addon_rates) (some false? (map addon-rate-equals-map (:addon_rates m) (.getAddonRatesList a))))]
+       (some true?)
+       not))
+
+(deftest test-addon-from-map
+  (doseq [{:keys [m desc]} addon-test-cases]
+    (testing desc (is (addon-equals-map m (model/addon-from-map m))))))
+
+(deftestcases add-addon-request-test-cases
+  {:addon (:m (first addon-test-cases))})
+
+(defn add-addon-request-equals-map
+  [m ar]
+  (->> [(and (contains? m :addon) (not (addon-equals-map (:addon m) (.getAddon ar))))]
+       (some true?)
+       not))
+
+(deftest test-add-addon-request-from-map
+  (doseq [{:keys [m desc]} add-addon-request-test-cases]
+    (testing desc (is (add-addon-request-equals-map m (model/add-addon-request-from-map m))))))
+
+(deftestcases update-addon-request-test-cases
+  {:addon                 (:m (first addon-test-cases))
+   :update_name           true
+   :update_description    true
+   :update_resource_type  true
+   :update_default_amount true
+   :update_default_paid   true
+   :update_addon_rates    true})
+
+(defn update-addon-request-equals-map
+  [m uar]
+  (->> [(and (contains? m :addon) (not (addon-equals-map (:addon m) (.getAddon uar))))
+        (and (contains? m :update_name) (not= (:update_name m) (.getUpdateName uar)))
+        (and (contains? m :update_description) (not= (:update_description m) (.getUpdateDescription uar)))
+        (and (contains? m :update_resource_type) (not= (:update_resource_type m) (.getUpdateResourceType uar)))
+        (and (contains? m :update_default_amount) (not= (:update_default_amount m) (.getUpdateDefaultAmount uar)))
+        (and (contains? m :update_default_paid) (not= (:update_default_paid m) (.getUpdateDefaultPaid uar)))
+        (and (contains? m :update_addon_rates) (not= (:update_addon_rates m) (.getUpdateAddonRates uar)))]
+       (some true?)
+       not))
+
+(deftest test-update-addon-request-from-map
+  (doseq [{:keys [m desc]} update-addon-request-test-cases]
+    (testing desc (is (update-addon-request-equals-map m (model/update-addon-request-from-map m))))))
+
+(deftestcases by-uuid-request-test-cases
+  {:uuid "262EF59B-08DF-4794-B81C-6F8602C54392"})
+
+(defn by-uuid-request-equals-map
+  [m bur]
+  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid bur)))]
+       (some true?)
+       not))
+
+(deftest test-by-uuid-request-from-map
+  (doseq [{:keys [m desc]} by-uuid-request-test-cases]
+    (testing desc (is (by-uuid-request-equals-map m (model/by-uuid-request-from-map m))))))

--- a/test/terrain/qms_model.clj
+++ b/test/terrain/qms_model.clj
@@ -1,5 +1,6 @@
 (ns terrain.qms-model
   (:require [clojure.test :refer [deftest is testing]]
+            [kameleon.uuids :refer [uuidify]]
             [terrain.clients.qms.model :as model]
             [terrain.util.time :as time]))
 
@@ -19,14 +20,14 @@
   (= (time/protobuf-timestamp m-date) pb-date))
 
 (deftestcases resource-type-test-cases
-  {:uuid       "45DD6319-219B-4EB1-A792-024AE323588E"
+  {:uuid       (uuidify "45DD6319-219B-4EB1-A792-024AE323588E")
    :name       "some.resource.type"
    :unit       "some.unit"
    :consumable true})
 
 (defn resource-type-equals-map
   [m rt]
-  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid rt)))
+  (->> [(and (contains? m :uuid) (not= (str (:uuid m)) (.getUuid rt)))
         (and (contains? m :name) (not= (:name m) (.getName rt)))
         (and (contains? m :unit) (not= (:unit m) (.getUnit rt)))
         (and (contains? m :consumable) (not= (:consumable m) (.getConsumable rt)))]
@@ -37,13 +38,13 @@
     (testing desc (is (resource-type-equals-map m (model/resource-type-from-map m))))))
 
 (deftestcases addon-rate-test-cases
-  {:uuid           "2D331892-992A-4895-9FA3-A5F4638099B2"
+  {:uuid           (uuidify "2D331892-992A-4895-9FA3-A5F4638099B2")
    :rate           123.45
    :effective_date "2024-11-22T14:33:00-07:00"})
 
 (defn addon-rate-equals-map
   [m ar]
-  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid ar)))
+  (->> [(and (contains? m :uuid) (not= (str (:uuid m)) (.getUuid ar)))
         (and (contains? m :rate) (not= (:rate m) (.getRate ar)))
         (and (contains? m :effective_date) (not (dates-equal (:effective_date m) (.getEffectiveDate ar))))]
        (every? false?)))
@@ -58,7 +59,7 @@
     (testing desc (is (addon-rate-equals-map m (model/addon-rate-from-map m))))))
 
 (deftestcases addon-test-cases
-  {:uuid           "C8EDAB3A-454B-4337-AD82-3AB5EF47B3B5"
+  {:uuid           (uuidify "C8EDAB3A-454B-4337-AD82-3AB5EF47B3B5")
    :name           "some-addon"
    :description    "Some Addon"
    :resource_type  (:m (first resource-type-test-cases))
@@ -68,7 +69,7 @@
 
 (defn addon-equals-map
   [m a]
-  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid a)))
+  (->> [(and (contains? m :uuid) (not= (str (:uuid m)) (.getUuid a)))
         (and (contains? m :name) (not= (:name m) (.getName a)))
         (and (contains? m :description)  (not= (:description m) (.getDescription a)))
         (and (contains? m :resource_type) (not= (model/resource-type-from-map (:resource_type m)) (.getResourceType a)))
@@ -118,11 +119,11 @@
     (testing desc (is (update-addon-request-equals-map m (model/update-addon-request-from-map m))))))
 
 (deftestcases by-uuid-request-test-cases
-  {:uuid "262EF59B-08DF-4794-B81C-6F8602C54392"})
+  {:uuid (uuidify "262EF59B-08DF-4794-B81C-6F8602C54392")})
 
 (defn by-uuid-request-equals-map
   [m bur]
-  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid bur)))]
+  (->> [(and (contains? m :uuid) (not= (str (:uuid m)) (.getUuid bur)))]
        (every? false?)))
 
 (deftest test-by-uuid-request-from-map
@@ -144,12 +145,12 @@
     (testing desc (is (associate-by-uuids-request-equals-map m (model/associate-by-uuids-from-map m))))))
 
 (deftestcases user-test-cases
-  {:uuid     "E90FC296-EE37-406D-BB1A-BACEBAA71679"
+  {:uuid     (uuidify "E90FC296-EE37-406D-BB1A-BACEBAA71679")
    :username "someuser"})
 
 (defn user-equals-map
   [m u]
-  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid u)))
+  (->> [(and (contains? m :uuid) (not= (str (:uuid m)) (.getUuid u)))
         (and (contains? m :username) (not= (:username m) (.getUsername u)))]))
 
 (deftest test-user-from-map
@@ -157,14 +158,14 @@
     (testing desc (is (user-equals-map m (model/user-from-map m))))))
 
 (deftestcases quota-default-test-cases
-  {:uuid           "3E6004AA-6637-4D99-A069-145258D5A136"
+  {:uuid           (uuidify "3E6004AA-6637-4D99-A069-145258D5A136")
    :quota_value    123.45
    :resource_type  (:m (first resource-type-test-cases))
    :effective_date "2024-11-27T15:20:00-07:00"})
 
 (defn quota-default-equals-map
   [m qd]
-  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid qd)))
+  (->> [(and (contains? m :uuid) (not= (str (:uuid m)) (.getUuid qd)))
         (and (contains? m :quota_value) (not= (:quota_value m) (.getQuotaValue qd)))
         (and (contains? m :resource_type) (not (resource-type-equals-map (:resource_type m) (.getResourceType qd))))
         (and (contains? m :effective_date) (not (dates-equal (:effective_date m) (.getEffectiveDate qd))))]
@@ -180,13 +181,13 @@
     (testing desc (is (quota-default-equals-map m (model/quota-default-from-map m))))))
 
 (deftestcases plan-rate-test-cases
-  {:uuid           "36F7C33A-2175-4C3E-812E-3CA5AC984988"
+  {:uuid           (uuidify "36F7C33A-2175-4C3E-812E-3CA5AC984988")
    :rate           123.45
    :effective_date "2024-11-27T15:37:00-07:00"})
 
 (defn plan-rate-equals-map
   [m pr]
-  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid pr)))
+  (->> [(and (contains? m :uuid) (not= (str (:uuid m)) (.getUuid pr)))
         (and (contains? m :quota_value) (not= (:quota_value m) (.getQuotaValue pr)))
         (and (contains? m :resource_type) (not (resource-type-equals-map (:resource_type m) (.getResourceType pr))))
         (and (contains? m :effective_date) (not (dates-equal (:effective_date m) (.getEffectiveDate pr))))]
@@ -201,7 +202,7 @@
     (testing desc (is (plan-rate-equals-map m (model/plan-rate-from-map m))))))
 
 (deftestcases plan-test-cases
-  {:uuid                "60D18DE6-796E-4F7A-932D-017986D1DF25"
+  {:uuid                (uuidify "60D18DE6-796E-4F7A-932D-017986D1DF25")
    :name                "Plan"
    :description         "The most generic plan imaginable"
    :plan_quota_defaults (map :m quota-default-test-cases)
@@ -209,7 +210,7 @@
 
 (defn plan-equals-map
   [m p]
-  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid p)))
+  (->> [(and (contains? m :uuid) (not= (str (:uuid m)) (.getUuid p)))
         (and (contains? m :name) (not= (:name m) (.getName p)))
         (and (contains? m :description) (not= (:description m) (.getDescription p)))
         (and (contains? m :plan_quota_defaults)
@@ -222,7 +223,7 @@
     (testing desc (is (plan-equals-map m (model/plan-from-map m))))))
 
 (deftestcases usage-test-cases
-  {:uuid             "DCF04FA0-C615-4C26-99ED-65D98AA37CC7"
+  {:uuid             (uuidify "DCF04FA0-C615-4C26-99ED-65D98AA37CC7")
    :usage            123.45
    :subscription_id  "D693F7B6-E0B9-4444-AA36-E2B62699F9B2"
    :resource_type    (:m (first resource-type-test-cases))
@@ -233,7 +234,7 @@
 
 (defn usage-equals-map
   [m u]
-  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid u)))
+  (->> [(and (contains? m :uuid) (not= (str (:uuid m)) (.getUuid u)))
         (and (contains? m :usage) (not= (:usage m) (.getUsage u)))
         (and (contains? m :subscription_id) (not= (:subscription_id m) (.getSubscriptionId u)))
         (and (contains? m :resource_type) (not (resource-type-equals-map (:resource_type m) (.getResourceType u))))
@@ -253,7 +254,7 @@
     (testing desc (is (usage-equals-map m (model/usage-from-map m))))))
 
 (deftestcases subscription-test-cases
-  {:uuid                 "BC7CAE34-D955-486E-910F-339BD3FB6A42"
+  {:uuid                 (uuidify "BC7CAE34-D955-486E-910F-339BD3FB6A42")
    :effective_start_date "2024-11-27T17:08:00-07:00"
    :effective_end_date   "2025-11-27T17:08:00-07:00"
    :user                 (:m (first user-test-cases))
@@ -264,7 +265,7 @@
 
 (defn subscription-equals-map
   [m s]
-  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid s)))
+  (->> [(and (contains? m :uuid) (not= (str (:uuid m)) (.getUuid s)))
         (and (contains? m :effective_start_date) (not (dates-equal (:effective_start_date m) (.getEffectiveStartDate s))))
         (and (contains? m :effective_end_date) (not (dates-equal (:effective_end_date m) (.getEffectiveStartDate s))))
         (and (contains? m :user) (not (user-equals-map (:user m) (.getUser s))))
@@ -279,7 +280,7 @@
     (testing desc (is (subscription-equals-map m (model/subscription-from-map m))))))
 
 (deftestcases subscription-addon-test-cases
-  {:uuid         "6D8EAC2D-B6F8-4851-8AC8-6C24A6939381"
+  {:uuid         (uuidify "6D8EAC2D-B6F8-4851-8AC8-6C24A6939381")
    :addon        (:m (first addon-test-cases))
    :subscription (:m (first subscription-test-cases))
    :amount       123.45
@@ -288,7 +289,7 @@
 
 (defn subscription-addon-equals-map
   [m sa]
-  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid sa)))
+  (->> [(and (contains? m :uuid) (not= (str (:uuid m)) (.getUuid sa)))
         (and (contains? m :addon) (not (addon-equals-map (:addon m) (.getAddon sa))))
         (and (contains? m :subscription) (not (subscription-equals-map (:subscription m) (.getSubscription sa))))
         (and (contains? m :amount) (not= (:amount m) (.getAmount sa)))

--- a/test/terrain/qms_model.clj
+++ b/test/terrain/qms_model.clj
@@ -14,6 +14,10 @@
   [sym m]
   `(def ~sym (gen-testcases ~m)))
 
+(defn dates-equal
+  [m-date pb-date]
+  (= (time/protobuf-timestamp m-date) pb-date))
+
 (deftestcases resource-type-test-cases
   {:uuid       "45DD6319-219B-4EB1-A792-024AE323588E"
    :name       "some.resource.type"
@@ -26,8 +30,7 @@
         (and (contains? m :name) (not= (:name m) (.getName rt)))
         (and (contains? m :unit) (not= (:unit m) (.getUnit rt)))
         (and (contains? m :consumable) (not= (:consumable m) (.getConsumable rt)))]
-       (some true?)
-       not))
+       (every? false?)))
 
 (deftest test-resource-type-from-map
   (doseq [{:keys [m desc]} resource-type-test-cases]
@@ -42,9 +45,12 @@
   [m ar]
   (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid ar)))
         (and (contains? m :rate) (not= (:rate m) (.getRate ar)))
-        (and (contains? m :effective_date) (not= (time/protobuf-timestamp (:effective_date m)) (.getEffectiveDate ar)))]
-       (some true?)
-       not))
+        (and (contains? m :effective_date) (not (dates-equal (:effective_date m) (.getEffectiveDate ar))))]
+       (every? false?)))
+
+(defn addon-rates-equal-maps
+  [ms ars]
+  (every? true? (map addon-rate-equals-map ms ars)))
 
 (deftest test-addon-rate-from-map
   (doseq [{:keys [m desc]} addon-rate-test-cases]
@@ -67,9 +73,8 @@
         (and (contains? m :resource_type) (not= (model/resource-type-from-map (:resource_type m)) (.getResourceType a)))
         (and (contains? m :default_amount) (not= (:default_amount m) (.getDefaultAmount a)))
         (and (contains? m :default_paid) (not= (:default_paid m) (.getDefaultPaid a)))
-        (and (contains? m :addon_rates) (some false? (map addon-rate-equals-map (:addon_rates m) (.getAddonRatesList a))))]
-       (some true?)
-       not))
+        (and (contains? m :addon_rates) (not (addon-rates-equal-maps (:addon_rates m) (.getAddonRatesList a))))]
+       (every? false?)))
 
 (deftest test-addon-from-map
   (doseq [{:keys [m desc]} addon-test-cases]
@@ -81,8 +86,7 @@
 (defn add-addon-request-equals-map
   [m ar]
   (->> [(and (contains? m :addon) (not (addon-equals-map (:addon m) (.getAddon ar))))]
-       (some true?)
-       not))
+       (every? false?)))
 
 (deftest test-add-addon-request-from-map
   (doseq [{:keys [m desc]} add-addon-request-test-cases]
@@ -106,8 +110,7 @@
         (and (contains? m :update_default_amount) (not= (:update_default_amount m) (.getUpdateDefaultAmount uar)))
         (and (contains? m :update_default_paid) (not= (:update_default_paid m) (.getUpdateDefaultPaid uar)))
         (and (contains? m :update_addon_rates) (not= (:update_addon_rates m) (.getUpdateAddonRates uar)))]
-       (some true?)
-       not))
+       (every? false?)))
 
 (deftest test-update-addon-request-from-map
   (doseq [{:keys [m desc]} update-addon-request-test-cases]
@@ -119,9 +122,199 @@
 (defn by-uuid-request-equals-map
   [m bur]
   (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid bur)))]
-       (some true?)
-       not))
+       (every? false?)))
 
 (deftest test-by-uuid-request-from-map
   (doseq [{:keys [m desc]} by-uuid-request-test-cases]
     (testing desc (is (by-uuid-request-equals-map m (model/by-uuid-request-from-map m))))))
+
+(deftestcases associate-by-uuids-test-cases
+  {:parent_uuid "0C956469-70E3-4ECF-8B62-469FFC518A9E"
+   :child_uuid  "328B5F0B-C65B-4173-AE19-E31A7586A733"})
+
+(defn associate-by-uuids-request-equals-map
+  [m abur]
+  (->> [(and (contains? m :parent_uuid) (not= (:parent_uuid m) (.getParentUuid abur)))
+        (and (contains? m :child_uuid) (not= (:child_uuid m) (.getChildUuid abur)))]
+       (every? false?)))
+
+(deftest test-associate-by-uuids-request-from-map
+  (doseq [{:keys [m desc]} associate-by-uuids-test-cases]
+    (testing desc (is (associate-by-uuids-request-equals-map m (model/associate-by-uuids-from-map m))))))
+
+(deftestcases user-test-cases
+  {:uuid     "E90FC296-EE37-406D-BB1A-BACEBAA71679"
+   :username "someuser"})
+
+(defn user-equals-map
+  [m u]
+  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid u)))
+        (and (contains? m :username) (not= (:username m) (.getUsername u)))]))
+
+(deftest test-user-from-map
+  (doseq [{:keys [m desc]} user-test-cases]
+    (testing desc (is (user-equals-map m (model/user-from-map m))))))
+
+(deftestcases quota-default-test-cases
+  {:uuid           "3E6004AA-6637-4D99-A069-145258D5A136"
+   :quota_value    123.45
+   :resource_type  (:m (first resource-type-test-cases))
+   :effective_date "2024-11-27T15:20:00-07:00"})
+
+(defn quota-default-equals-map
+  [m qd]
+  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid qd)))
+        (and (contains? m :quota_value) (not= (:quota_value m) (.getQuotaValue qd)))
+        (and (contains? m :resource_type) (not (resource-type-equals-map (:resource_type m) (.getResourceType qd))))
+        (and (contains? m :effective_date) (not (dates-equal (:effective_date m) (.getEffectiveDate qd))))]
+       (every? false?)))
+
+(defn quota-defaults-equal-maps
+  [ms qds]
+  (every? true? (map quota-default-equals-map ms qds)))
+
+(deftest test-quota-default-from-map
+  (doseq [{:keys [m desc]} quota-default-test-cases]
+    (testing desc (is (quota-default-equals-map m (model/quota-default-from-map m))))))
+
+(deftestcases plan-rate-test-cases
+  {:uuid           "36F7C33A-2175-4C3E-812E-3CA5AC984988"
+   :rate           123.45
+   :effective_date "2024-11-27T15:37:00-07:00"})
+
+(defn plan-rate-equals-map
+  [m pr]
+  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid pr)))
+        (and (contains? m :quota_value) (not= (:quota_value m) (.getQuotaValue pr)))
+        (and (contains? m :resource_type) (not (resource-type-equals-map (:resource_type m) (.getResourceType pr))))
+        (and (contains? m :effective_date) (not (dates-equal (:effective_date m) (.getEffectiveDate pr))))]
+       (every? false?)))
+
+(defn plan-rates-equal-maps
+  [ms prs]
+  (every? true? (mapv plan-rate-equals-map ms prs)))
+
+(deftest test-plan-rate-from-map
+  (doseq [{:keys [m desc]} plan-rate-test-cases]
+    (testing desc (is (plan-rate-equals-map m (model/plan-rate-from-map m))))))
+
+(deftestcases plan-test-cases
+  {:uuid                "60D18DE6-796E-4F7A-932D-017986D1DF25"
+   :name                "Plan"
+   :description         "The most generic plan imaginable"
+   :plan_quota_defaults (map :m quota-default-test-cases)
+   :plan_rates          (map :m plan-rate-test-cases)})
+
+(defn plan-equals-map
+  [m p]
+  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid p)))
+        (and (contains? m :name) (not= (:name m) (.getName p)))
+        (and (contains? m :description) (not= (:description m) (.getDescription p)))
+        (and (contains? m :plan_quota_defaults)
+             (not (quota-defaults-equal-maps (:plan_quota_defaults m) (.getPlanQuotaDefaultsList p))))
+        (and (contains? m :plan_rates) (not (plan-rates-equal-maps (:plan_rates m) (.getPlanRatesList p))))]
+       (every? false?)))
+
+(deftest test-plan-from-map
+  (doseq [{:keys [m desc]} plan-test-cases]
+    (testing desc (is (plan-equals-map m (model/plan-from-map m))))))
+
+(deftestcases usage-test-cases
+  {:uuid             "DCF04FA0-C615-4C26-99ED-65D98AA37CC7"
+   :usage            123.45
+   :subscription_id  "D693F7B6-E0B9-4444-AA36-E2B62699F9B2"
+   :resource_type    (:m (first resource-type-test-cases))
+   :created_by       "someuser"
+   :created_at       "2024-11-27T16:46:00-07:00"
+   :last_modified_by "someuser"
+   :last_modified_at "2024-11-27T16:46:00-07:00"})
+
+(defn usage-equals-map
+  [m u]
+  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid u)))
+        (and (contains? m :usage) (not= (:usage m) (.getUsage u)))
+        (and (contains? m :subscription_id) (not= (:subscription_id m) (.getSubscriptionId u)))
+        (and (contains? m :resource_type) (not (resource-type-equals-map (:resource_type m) (.getResourceType u))))
+        (and (contains? m :created_by) (not= (:created_by m) (.getCreatedBy u)))
+        (and (contains? m :created_at) (not (dates-equal (:created_at m) (.getCreatedAt u))))
+        (and (contains? m :last_modified_by) (not= (:last_modified_by m) (.getLastModifiedBy u)))
+        (and (contains? m :last_modified_at) (not (dates-equal (:last_modified_at m) (.getLastModifiedAt u))))]
+       (every? false?)))
+
+(defn usages-equal-maps
+  [ms us]
+  (every? true? (map usage-equals-map ms us)))
+
+(deftest test-usage-from-map
+  (doseq [{:keys [m desc]} usage-test-cases]
+    (testing desc (is (usage-equals-map m (model/usage-from-map m))))))
+
+(deftestcases subscription-test-cases
+  {:uuid                 "BC7CAE34-D955-486E-910F-339BD3FB6A42"
+   :effective_start_date "2024-11-27T17:08:00-07:00"
+   :effective_end_date   "2025-11-27T17:08:00-07:00"
+   :user                 (:m (first user-test-cases))
+   :plan                 (:m (first plan-test-cases))
+   :usages               (map :m usage-test-cases)
+   :paid                 true
+   :plan_rate            (:m (first plan-rate-test-cases))})
+
+(defn subscription-equals-map
+  [m s]
+  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid s)))
+        (and (contains? m :effective_start_date) (not (dates-equal (:effective_start_date m) (.getEffectiveStartDate s))))
+        (and (contains? m :effective_end_date) (not (dates-equal (:effective_end_date m) (.getEffectiveStartDate s))))
+        (and (contains? m :user) (not (user-equals-map (:user m) (.getUser s))))
+        (and (contains? m :plan) (not (plan-equals-map (:plan m) (.getPlan s))))
+        (and (contains? m :usages) (not (usages-equal-maps (:usages m) (.getUsagesList s))))
+        (and (contains? m :paid) (not= (:paid m) (.getPaid s)))
+        (and (contains? m :plan_rate) (not (plan-rate-equals-map (:plan_rate m) (.getPlanRate s))))]
+       (some false?)))
+
+(deftest test-subscription-from-map
+  (doseq [{:keys [m desc]} subscription-test-cases]
+    (testing desc (is (subscription-equals-map m (model/subscription-from-map m))))))
+
+(deftestcases subscription-addon-test-cases
+  {:uuid         "6D8EAC2D-B6F8-4851-8AC8-6C24A6939381"
+   :addon        (:m (first addon-test-cases))
+   :subscription (:m (first subscription-test-cases))
+   :amount       123.45
+   :paid         true
+   :addon_rate   (:m (first addon-rate-test-cases))})
+
+(defn subscription-addon-equals-map
+  [m sa]
+  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid sa)))
+        (and (contains? m :addon) (not (addon-equals-map (:addon m) (.getAddon sa))))
+        (and (contains? m :subscription) (not (subscription-equals-map (:subscription m) (.getSubscription sa))))
+        (and (contains? m :amount) (not= (:amount m) (.getAmount sa)))
+        (and (contains? m :paid) (not= (:paid m) (.getPaid sa)))
+        (and (contains? m :addon_rate) (not (addon-rate-equals-map (:addon_rate m) (.getAddonRate sa))))]
+       (every? false?)))
+
+(deftest test-subscription-addon-from-map
+  (doseq [{:keys [m desc]} subscription-addon-test-cases]
+    (testing desc (is (subscription-addon-equals-map m (model/subscription-addon-from-map m))))))
+
+(deftestcases update-subscription-addon-update-request-test-cases
+  {:subscription_addon     (:m (first subscription-addon-test-cases))
+   :update_addon_id        true
+   :update_subscription_id true
+   :update_amount          true
+   :update_paid            true})
+
+(defn update-subscription-addon-update-request-equals-map
+  [m saur]
+  (->> [(and (contains? m :subscription_addon)
+             (not (subscription-addon-equals-map (:subscription_addon m) (.getSubscriptionAddon saur))))
+        (and (contains? m :update_addon_id) (not= (:update_addon_id m) (.getUpdateAddonId saur)))
+        (and (contains? m :update_subscription_id) (not= (:update_subscription_id m) (.getUpdateSubscriptionId saur)))
+        (and (contains? m :update_amount) (not= (:update_amount m) (.getUpdateAmount saur)))
+        (and (contains? m :update_paid) (not= (:update_paid m) (.getUpdatePaid saur)))]
+       (every? false?)))
+
+(deftest test-subscription-addon-update-request-from-map
+  (doseq [{:keys [m desc]} update-subscription-addon-update-request-test-cases]
+    (let [saur (model/update-subscription-addon-request-from-map m)]
+      (testing desc (is (update-subscription-addon-update-request-equals-map m saur))))))

--- a/test/terrain/qms_model.clj
+++ b/test/terrain/qms_model.clj
@@ -1,0 +1,60 @@
+(ns terrain.qms-model
+  (:require [clojure.test :refer [deftest is testing]]
+            [terrain.clients.qms.model :as model]
+            [terrain.util.time :as time]))
+
+(defn gen-testcases
+  [m]
+  (concat
+   [{:m m  :desc "fully specified"}
+    {:m {} :desc "empty"}]
+   (for [[f _] m] {:m (dissoc m f) :desc (str f " not specified")})))
+
+(defmacro deftestcases
+  [sym m]
+  `(def ~sym (gen-testcases ~m)))
+
+(deftestcases resource-type-test-cases
+  {:uuid       "45DD6319-219B-4EB1-A792-024AE323588E"
+   :name       "some.resource.type"
+   :unit       "some.unit"
+   :consumable true})
+
+(defn resource-type-equals-map
+  [m rt]
+  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid rt)))
+        (and (contains? m :name) (not= (:name m) (.getName rt)))
+        (and (contains? m :unit) (not= (:unit m) (.getUnit rt)))
+        (and (contains? m :consumable) (not= (:consumable m) (.getConsumable rt)))]
+       (some true?)
+       not))
+
+(deftest test-resource-type-from-map
+  (doseq [{:keys [m desc]} resource-type-test-cases]
+    (testing desc (is (resource-type-equals-map m (model/resource-type-from-map m))))))
+
+(deftestcases addon-rate-test-cases
+  {:uuid           "2D331892-992A-4895-9FA3-A5F4638099B2"
+   :rate           123.45
+   :effective_date "2024-11-22T14:33:00-07:00"})
+
+(defn addon-rate-equals-map
+  [m ar]
+  (->> [(and (contains? m :uuid) (not= (:uuid m) (.getUuid ar)))
+        (and (contains? m :rate) (not= (:rate m) (.getRate ar)))
+        (and (contains? m :effective_date) (not= (time/protobuf-timestamp (:effective_date m)) (.getEffectiveDate ar)))]
+       (some true?)
+       not))
+
+(deftest test-addon-rate-from-map
+  (doseq [{:keys [m desc]} addon-rate-test-cases]
+    (testing desc (is (addon-rate-equals-map m (model/addon-rate-from-map m))))))
+
+(deftestcases addon-test-cases
+  {:uuid           "C8EDAB3A-454B-4337-AD82-3AB5EF47B3B5"
+   :name           "some-addon"
+   :description    "Some Addon"
+   :resource_type  (:m (first resource-type-test-cases))
+   :default_amount 123.45
+   :default_paid   true
+   :addon_rates    (mapv :m addon-rate-test-cases)})


### PR DESCRIPTION
The primary reason for this change is to allow us to schedule rate and default quota limit changes for the future so that they automatically become active at a time that we specify. For example, we currently have some rate and default quota limit changes planned for January 1st, but we don't want to have to log in on New Years Day to make the changes. Having scheduled changes in the system means that we can set up the changes in advance and let them become effective later.