### PR TITLE
CORE-2016: removed the unnecessary `consumable` flag from addon updates

### DIFF
--- a/src/terrain/routes/schemas/qms.clj
+++ b/src/terrain/routes/schemas/qms.clj
@@ -211,8 +211,7 @@
    :consumable          (describe Boolean "True if using the resource consumes it permanently")})
 
 (defschema ResourceTypeForAddonUpdate
-  {:uuid       (describe UUID "The UUID of the new resource type associated with the add-on")
-   :consumable (describe Boolean "True if using the resource consumes it permanently")})
+  {:uuid (describe UUID "The UUID of the new resource type associated with the add-on")})
 
 (defschema ResourceTypeForAddonDeletion
   {(optional-key :uuid)       (describe (maybe String) "The UUID of the resource type associated with the add-on being deleted. Probably blank")


### PR DESCRIPTION
The `consumable` flag shouldn't have been added to the resource type for an addon update.