### PR TITLE
update the Skaffold schema version to v3

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,14 +1,17 @@
-apiVersion: skaffold/v1
+apiVersion: skaffold/v3
 kind: Config
 metadata:
   name: terrain
-deploy:
-  kubectl:
-    manifests:
-    - k8s/terrain.yml
 build:
+  artifacts:
+    - image: harbor.cyverse.org/de/terrain
   tagPolicy:
     gitCommit: {}
-  artifacts:
-  - image: harbor.cyverse.org/de/terrain
   local: {}
+  platforms:
+    - "linux/amd64"
+manifests:
+  rawYaml:
+    - k8s/terrain.yml
+deploy:
+  kubectl: {}


### PR DESCRIPTION
The primary purpose of this is to allow the platform to be specified for cross-compilation.