### PR TITLE
CORE-2034 Search metadata by `target-ids`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
                  [org.cyverse/kameleon "3.0.10"
                   :exclusion [com.impossibl.pgjdbc-ng/pgjdbc-ng]]
                  [com.impossibl.pgjdbc-ng/pgjdbc-ng "0.8.9"]
-                 [org.cyverse/metadata-client "3.1.3-SNAPSHOT"]
+                 [org.cyverse/metadata-client "3.2.0"]
                  [org.cyverse/metadata-files "2.1.1"]
                  [org.cyverse/permissions-client "2.8.4"]
                  [org.cyverse/service-logging "2.8.4"]

--- a/project.clj
+++ b/project.clj
@@ -38,11 +38,11 @@
                  [org.cyverse/cyverse-groups-client "0.1.9"]
                  [org.cyverse/common-cfg "2.8.3"]
                  [org.cyverse/common-cli "2.8.2"]
-                 [org.cyverse/common-swagger-api "3.4.9"]
+                 [org.cyverse/common-swagger-api "3.4.10"]
                  [org.cyverse/kameleon "3.0.10"
                   :exclusion [com.impossibl.pgjdbc-ng/pgjdbc-ng]]
                  [com.impossibl.pgjdbc-ng/pgjdbc-ng "0.8.9"]
-                 [org.cyverse/metadata-client "3.1.2"]
+                 [org.cyverse/metadata-client "3.1.3-SNAPSHOT"]
                  [org.cyverse/metadata-files "2.1.1"]
                  [org.cyverse/permissions-client "2.8.4"]
                  [org.cyverse/service-logging "2.8.4"]

--- a/src/terrain/clients/metadata/raw.clj
+++ b/src/terrain/clients/metadata/raw.clj
@@ -16,6 +16,8 @@
   (str (apply curl/url (config/metadata-base-url) (map curl/url-encode components))))
 
 (def target-type-app "app")
+(def target-type-folder "folder")
+(def target-type-file "file")
 
 (defn resolve-data-type
   "Returns a type converted from the type field of a stat result to a type expected by the
@@ -69,12 +71,16 @@
 (def put-options post-options)
 
 (defn find-avus
-  [target-type attr value]
-  (metadata-client/find-avus (config/metadata-client)
-                             (:user (user-params))
-                             {:target-type target-type
-                              :attribute   attr
-                              :value       value}))
+  ([target-type attr value]
+   (find-avus target-type nil attr value nil))
+  ([target-type target-id attr value unit]
+   (metadata-client/find-avus (config/metadata-client)
+                              (:user (user-params))
+                              {:target-type target-type
+                               :target-id   target-id
+                               :attribute   attr
+                               :value       value
+                               :unit        unit})))
 
 (defn update-avus
   "Adds or updates Metadata AVUs on the given target item."

--- a/src/terrain/clients/metadata/raw.clj
+++ b/src/terrain/clients/metadata/raw.clj
@@ -82,6 +82,16 @@
                                :value       value
                                :unit        unit})))
 
+(defn search-avus
+  [target-type target-id attr value unit]
+  (metadata-client/search-avus (config/metadata-client)
+                               (:user (user-params))
+                               {:target-type target-type
+                                :target-id   target-id
+                                :attribute   attr
+                                :value       value
+                                :unit        unit}))
+
 (defn update-avus
   "Adds or updates Metadata AVUs on the given target item."
   [target-type target-id avus-req]

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -1,6 +1,7 @@
 (ns terrain.routes.filesystem
   (:require [clojure.string :as string]
             [common-swagger-api.schema :refer [context GET POST DELETE]]
+            [common-swagger-api.schema.metadata :as metadata-schema]
             [compojure.api.middleware :as mw]
             [medley.core :refer [update-existing-in]]
             [ring.util.http-response :refer [ok]]
@@ -33,7 +34,7 @@
       :else                v)))
 
 ;; Declarations to eliminate lint warnings for path and query parameter bindings.
-(declare req params user-info template-id attr-id data-id)
+(declare req params user-info template-id attr-id data-id attribute value unit target-id)
 
 (defn secured-filesystem-routes
   "The routes for file IO endpoints."
@@ -125,6 +126,17 @@
   (optional-routes
    [#(and (config/filesystem-routes-enabled)
           (config/metadata-routes-enabled))]
+
+   (GET "/filesystem/metadata" [:as {:keys [user-info params] :as req}]
+        :query [{:keys [attribute value unit target-id]} metadata-schema/AvuSearchQueryParams]
+        :return metadata-schema/AvuList
+        :summary "List Metadata AVUs."
+        :description "Lists Metadata AVUs matching parameters in the query string."
+        (ok (meta-raw/find-avus [meta-raw/target-type-folder meta-raw/target-type-file]
+                                target-id
+                                attribute
+                                value
+                                unit)))
 
     (POST "/filesystem/metadata/csv-parser" [:as {:keys [user-info params] :as req}]
       :middleware [require-authentication]

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -128,7 +128,7 @@
           (config/metadata-routes-enabled))]
 
    (GET "/filesystem/metadata" [:as {:keys [user-info params] :as req}]
-        :query [{:keys [attribute value unit target-id]} metadata-schema/AvuSearchQueryParams]
+        :query [{:keys [attribute value unit target-id]} metadata-schema/AvuSearchParams]
         :return metadata-schema/AvuList
         :summary "List Metadata AVUs."
         :description "Lists Metadata AVUs matching parameters in the query string."
@@ -141,6 +141,17 @@
     (POST "/filesystem/metadata/csv-parser" [:as {:keys [user-info params] :as req}]
       :middleware [require-authentication]
       (meta/parse-metadata-csv-file user-info params))
+
+   (POST "/filesystem/metadata/search" []
+         :body [{:keys [attribute value unit target-id]} metadata-schema/AvuSearchParams]
+         :return metadata-schema/AvuList
+         :summary "List AVUs."
+         :description "Lists AVUs matching parameters in the request body."
+         (ok (meta-raw/search-avus [meta-raw/target-type-folder meta-raw/target-type-file]
+                                   target-id
+                                   attribute
+                                   value
+                                   unit)))
 
     (GET "/filesystem/metadata/templates" [:as req]
       (controller req mt/do-metadata-template-list))


### PR DESCRIPTION
This PR will add a `GET /filesystem/metadata` endpoint, which allows a client to search file and folder metadata AVUs by a set of attributes, values, units, and target-ids.

It also will add a `POST /filesystem/metadata/search` endpoint, which does the same thing, only it accepts search params in the request body instead, calling the new `metadata-client.core/search-avus` method.

This is currently restricted to only searching the DE's metadata database, and not iRODS AVUs.

This PR depends on cyverse-de/metadata-client#7 and cyverse-de/common-swagger-api#90 which should be merged before this PR.