### PR TITLE
CORE-2086: added a service-account endpoint for sending emails.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Terrain is the primary REST API gateway for the CyVerse Discovery Environment. It's a Clojure application that validates
 user authentication and coordinates calls to other web services.
 
+## Code Formatting
+
+- Please follow the [clojure community style guidelines][1] when generating new code.
+- Please try to avoid repeated code when possible.
+- Please try to keep line lenghts to 120 characters or fewer for readability.
+
 ## Common Development Commands
 
 ### Build and Run
@@ -109,3 +115,5 @@ Each integration typically follows the pattern:
 3. Service layer orchestrates calls to one or more clients
 4. Clients make HTTP requests to external services
 5. Responses are transformed and returned to caller
+
+[1]: https://guide.clojure.style/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Terrain is the primary REST API gateway for the CyVerse Discovery Environment. It's a Clojure application that validates
+user authentication and coordinates calls to other web services.
+
+## Common Development Commands
+
+### Build and Run
+- `lein uberjar` - Build the standalone JAR
+- `lein ring server` - Start development server on port 31325
+- `lein run` - Run the main application
+
+### Code Quality
+- `lein eastwood` - Run linter (configured to check for wrong-arity, wrong-ns-form, wrong-pre-post, wrong-tag,
+  misplaced-docstrings)
+- `lein cljfmt check` - Check code formatting
+- `lein cljfmt fix` - Fix code formatting
+- `lein ancient` - Check for outdated dependencies
+
+### Testing
+- `lein test` - Run all tests
+- `lein test :only terrain.test-namespace` - Run specific test namespace
+- `lein test2junit` - Run tests with JUnit XML output
+
+### REPL Development
+- `lein repl` - Start REPL
+- nREPL server runs on port 7888 when application starts
+
+## Architecture Overview
+
+### Core Structure
+The application follows a typical Clojure web service architecture with clear separation of concerns:
+
+1. **Entry Point** (`src/terrain/core.clj`)
+   - Main application initialization
+   - Configuration loading from `terrain.properties`
+   - nREPL server setup
+   - NATS message queue connection
+
+2. **Routing Layer** (`src/terrain/routes.clj` and `src/terrain/routes/`)
+   - Compojure-based routing
+   - Routes organized by domain (apps, filesystem, metadata, etc.)
+   - Authentication middleware wrapping
+   - Separate admin routes for privileged operations
+
+3. **Service Layer** (`src/terrain/services/`)
+   - Business logic implementation
+   - Key service modules:
+     - `admin.clj` - Miscellaneous administrative operations
+     - `bags.clj` - Bag management for bulk operations
+     - `bootstrap.clj` - Operations for preparing a user's workspace
+     - `coge.clj` - Integration for CoGe (Comparative Genomics)
+     - `collaborator_lists.clj` - Operations for managing lists of collaborators
+     - `communities.clj` - Operations for managing communities in the Discovery Environment
+     - `fileio/` - iRODS file I/O operations
+     - `filesystem/` - iRODS filesystem operations
+     - `metadata/` - App and data metadata management
+     - `oauth.clj` - OAuth integration
+     - `permanent_id_requests.clj` - Operations for managing permanent ID requests
+     - `qms.clj` - Quota Management System integration
+     - `requests.clj` - Operations for managing administrative requests
+     - `sharing.clj` - Operations for sharing data
+     - `subjects.clj` - Operations for searching for users and groups
+     - `teams.clj` - Operations for managing teams in the Discovery Environment
+     - `user_info.clj` - User profile management
+     - `user_prefs.clj` - User preference management
+     - `user_sessions.clj` - User session management
+
+4. **Client Layer** (`src/terrain/clients/`)
+   - External service integrations
+   - HTTP clients for microservices communication
+
+5. **Middleware** (`src/terrain/middleware.clj`)
+   - Request/response transformation
+   - User context injection
+   - Logging and monitoring
+   - Authentication
+
+### Key Dependencies
+- **Web Framework**: Compojure + Ring
+- **HTTP Client**: clj-http
+- **JSON**: Cheshire
+- **Database**: PostgreSQL via Kameleon library
+- **Message Queue**: NATS
+- **Storage**: iRODS (via clj-jargon)
+- **Authentication**: CyVerse custom auth + OAuth and Keycloak
+
+### Configuration
+The application expects configuration in `terrain.properties`, loaded from (in order):
+1. `$IPLANT_CONF_DIR/terrain.properties`
+2. Current working directory
+3. Classpath resources
+4. Fails if not found
+
+### Service Integration Pattern
+Terrain acts as an API gateway, delegating to specialized microservices:
+- Metadata service for app/data metadata
+- Permissions service for access control
+- Groups service for team management
+- Async tasks service for job management
+
+Each integration typically follows the pattern:
+1. Route handler validates request
+2. Request and response bodies are validated by `plumatic/schema`
+3. Service layer orchestrates calls to one or more clients
+4. Clients make HTTP requests to external services
+5. Responses are transformed and returned to caller

--- a/k8s/terrain.yml
+++ b/k8s/terrain.yml
@@ -2,6 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: terrain
+  labels:
+    app: cyverse-de
+    de-app: terrain
 spec:
   replicas: 2
   selector:
@@ -13,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        app: cyverse-de
         de-app: terrain
     spec:
       affinity:
@@ -136,6 +140,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: terrain
+  labels:
+    app: cyverse-de
+    de-app: terrain
 spec:
   selector:
     de-app: terrain

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -1,89 +1,98 @@
 (ns terrain.routes
-  (:require [cheshire.core :as cheshire]
-            [clojure-commons.lcase-params :refer [wrap-lcase-params]]
-            [clojure-commons.query-params :refer [wrap-query-params]]
-            [clojure.tools.logging :as log]
-            [clojure-commons.exception :as cx]
-            [common-swagger-api.schema :as schema]
-            [compojure.route :as route]
-            [compojure.api.core :refer [route-middleware]]
-            [ring.middleware.keyword-params :refer [wrap-keyword-params]]
-            [service-logging.thread-context :as tc]
-            [service-logging.middleware :refer [wrap-logging clean-context]]
-            [terrain.auth.user-attributes :as user-attributes]
-            [terrain.middleware :refer [wrap-context-path-adder wrap-create-workspace wrap-query-param-remover]]
-            [terrain.routes.admin :refer [secured-admin-routes]]
-            [terrain.routes.alerts :refer [alerts-routes admin-alerts-routes]]
-            [terrain.routes.analyses :refer [analysis-routes quicklaunch-routes]]
-            [terrain.routes.apps.admin.apps :refer [admin-apps-routes]]
-            [terrain.routes.apps.admin.reference-genomes :refer [admin-reference-genomes-routes]]
-            [terrain.routes.apps.admin.tools :refer [admin-tool-request-routes admin-tool-routes]]
-            [terrain.routes.apps.categories :refer [app-category-routes app-community-routes app-ontology-routes]]
-            [terrain.routes.apps.communities :refer [app-community-tag-routes]]
-            [terrain.routes.apps.elements :refer [app-elements-routes]]
-            [terrain.routes.apps.metadata :refer [app-avu-routes]]
-            [terrain.routes.apps.pipelines :refer [app-pipeline-routes]]
-            [terrain.routes.apps.reference-genomes :refer [reference-genomes-routes]]
-            [terrain.routes.apps.tools :refer [tool-request-routes tool-routes]]
-            [terrain.routes.apps.versions :refer [app-version-routes]]
-            [terrain.routes.bags :refer [bag-routes]]
-            [terrain.routes.bootstrap :refer [secured-bootstrap-routes]]
-            [terrain.routes.callbacks :refer [callback-routes]]
-            [terrain.routes.dashboard-aggregator :refer [dashboard-aggregator-routes]]
-            [terrain.routes.data :refer [secured-data-routes]]
-            [terrain.routes.fileio :refer [secured-fileio-routes]]
-            [terrain.routes.filesystem :refer [admin-filesystem-metadata-routes
-                                               secured-filesystem-metadata-routes
-                                               secured-filesystem-routes]]
-            [terrain.routes.filesystem.exists :refer [filesystem-existence-routes]]
-            [terrain.routes.filesystem.navigation :refer [filesystem-navigation-routes]]
-            [terrain.routes.filesystem.stats :refer [filesystem-stat-routes]]
-            [terrain.routes.filesystem.tickets :refer [filesystem-ticket-routes]]
-            [terrain.routes.groups :refer [admin-groups-routes]]
-            [terrain.routes.instantlaunches :refer [admin-instant-launch-routes instant-launch-routes]]
-            [terrain.routes.metadata :refer [admin-app-avu-routes
-                                             admin-app-community-routes
-                                             admin-category-routes
-                                             admin-integration-data-routes
-                                             admin-ontology-routes
-                                             admin-workspace-routes
-                                             apps-routes
-                                             misc-metadata-routes]]
-            [terrain.routes.misc :refer [unsecured-misc-routes]]
-            [terrain.routes.notification :refer [admin-notification-routes
-                                                 secured-notification-routes
-                                                 unsecured-notification-routes]]
-            [terrain.routes.permanent-id-requests :refer [admin-permanent-id-request-routes permanent-id-request-routes]]
-            [terrain.routes.pref :refer [secured-pref-routes]]
-            [terrain.routes.resource-usage-api :refer [resource-usage-api-routes]]
-            [terrain.routes.data-usage-api :refer [data-usage-api-routes]]
-            [terrain.routes.session :refer [secured-session-routes]]
-            [terrain.routes.user-info :refer [admin-user-info-routes secured-user-info-routes]]
-            [terrain.routes.collaborator :refer [admin-community-routes
-                                                 collaborator-list-routes
-                                                 community-routes
-                                                 subject-routes
-                                                 team-routes]]
-            [terrain.routes.search :refer [secured-search-routes]]
-            [terrain.routes.coge :refer [coge-routes]]
-            [terrain.routes.oauth :refer [oauth-admin-routes oauth-routes secured-oauth-routes]]
-            [terrain.routes.favorites :refer [secured-favorites-routes]]
-            [terrain.routes.tags :refer [secured-tag-routes]]
-            [terrain.routes.token :refer [admin-token-routes token-routes]]
-            [terrain.routes.webhooks :refer [webhook-routes]]
-            [terrain.routes.comments :refer [admin-app-comment-routes
-                                             admin-comment-routes
-                                             admin-data-comment-routes
-                                             app-comment-routes
-                                             data-comment-routes]]
-            [terrain.routes.qms :refer [admin-qms-api-routes qms-api-routes service-account-qms-api-routes]]
-            [terrain.routes.requests :refer [admin-request-routes admin-request-type-routes request-routes]]
-            [terrain.routes.settings :refer [admin-setting-routes]]
-            [terrain.routes.vice :refer [admin-vice-routes vice-routes]]
-            [terrain.util :as util]
-            [terrain.util.transformers :as transform]
-            [terrain.util.service :as service]
-            [terrain.util.config :as config]))
+  (:require
+   [cheshire.core :as cheshire]
+   [clojure-commons.exception :as cx]
+   [clojure-commons.lcase-params :refer [wrap-lcase-params]]
+   [clojure-commons.query-params :refer [wrap-query-params]]
+   [clojure.tools.logging :as log]
+   [common-swagger-api.schema :as schema]
+   [compojure.api.core :refer [route-middleware]]
+   [compojure.route :as route]
+   [ring.middleware.keyword-params :refer [wrap-keyword-params]]
+   [service-logging.middleware :refer [clean-context wrap-logging]]
+   [service-logging.thread-context :as tc]
+   [terrain.auth.user-attributes :as user-attributes]
+   [terrain.middleware :refer [wrap-context-path-adder wrap-create-workspace
+                               wrap-query-param-remover]]
+   [terrain.routes.admin :refer [secured-admin-routes]]
+   [terrain.routes.alerts :refer [admin-alerts-routes alerts-routes]]
+   [terrain.routes.analyses :refer [analysis-routes quicklaunch-routes]]
+   [terrain.routes.apps.admin.apps :refer [admin-apps-routes]]
+   [terrain.routes.apps.admin.reference-genomes :refer [admin-reference-genomes-routes]]
+   [terrain.routes.apps.admin.tools :refer [admin-tool-request-routes
+                                            admin-tool-routes]]
+   [terrain.routes.apps.categories :refer [app-category-routes
+                                           app-community-routes
+                                           app-ontology-routes]]
+   [terrain.routes.apps.communities :refer [app-community-tag-routes]]
+   [terrain.routes.apps.elements :refer [app-elements-routes]]
+   [terrain.routes.apps.metadata :refer [app-avu-routes]]
+   [terrain.routes.apps.pipelines :refer [app-pipeline-routes]]
+   [terrain.routes.apps.reference-genomes :refer [reference-genomes-routes]]
+   [terrain.routes.apps.tools :refer [tool-request-routes tool-routes]]
+   [terrain.routes.apps.versions :refer [app-version-routes]]
+   [terrain.routes.bags :refer [bag-routes]]
+   [terrain.routes.bootstrap :refer [secured-bootstrap-routes]]
+   [terrain.routes.callbacks :refer [callback-routes]]
+   [terrain.routes.coge :refer [coge-routes]]
+   [terrain.routes.collaborator :refer [admin-community-routes
+                                        collaborator-list-routes
+                                        community-routes subject-routes
+                                        team-routes]]
+   [terrain.routes.comments :refer [admin-app-comment-routes
+                                    admin-comment-routes
+                                    admin-data-comment-routes
+                                    app-comment-routes data-comment-routes]]
+   [terrain.routes.dashboard-aggregator :refer [dashboard-aggregator-routes]]
+   [terrain.routes.data :refer [secured-data-routes]]
+   [terrain.routes.data-usage-api :refer [data-usage-api-routes]]
+   [terrain.routes.email :refer [service-account-email-routes]]
+   [terrain.routes.favorites :refer [secured-favorites-routes]]
+   [terrain.routes.fileio :refer [secured-fileio-routes]]
+   [terrain.routes.filesystem :refer [admin-filesystem-metadata-routes
+                                      secured-filesystem-metadata-routes
+                                      secured-filesystem-routes]]
+   [terrain.routes.filesystem.exists :refer [filesystem-existence-routes]]
+   [terrain.routes.filesystem.navigation :refer [filesystem-navigation-routes]]
+   [terrain.routes.filesystem.stats :refer [filesystem-stat-routes]]
+   [terrain.routes.filesystem.tickets :refer [filesystem-ticket-routes]]
+   [terrain.routes.groups :refer [admin-groups-routes]]
+   [terrain.routes.instantlaunches :refer [admin-instant-launch-routes
+                                           instant-launch-routes]]
+   [terrain.routes.metadata :refer [admin-app-avu-routes
+                                    admin-app-community-routes
+                                    admin-category-routes
+                                    admin-integration-data-routes
+                                    admin-ontology-routes
+                                    admin-workspace-routes apps-routes
+                                    misc-metadata-routes]]
+   [terrain.routes.misc :refer [unsecured-misc-routes]]
+   [terrain.routes.notification :refer [admin-notification-routes
+                                        secured-notification-routes
+                                        unsecured-notification-routes]]
+   [terrain.routes.oauth :refer [oauth-admin-routes oauth-routes
+                                 secured-oauth-routes]]
+   [terrain.routes.permanent-id-requests :refer [admin-permanent-id-request-routes
+                                                 permanent-id-request-routes]]
+   [terrain.routes.pref :refer [secured-pref-routes]]
+   [terrain.routes.qms :refer [admin-qms-api-routes qms-api-routes
+                               service-account-qms-api-routes]]
+   [terrain.routes.requests :refer [admin-request-routes
+                                    admin-request-type-routes request-routes]]
+   [terrain.routes.resource-usage-api :refer [resource-usage-api-routes]]
+   [terrain.routes.search :refer [secured-search-routes]]
+   [terrain.routes.session :refer [secured-session-routes]]
+   [terrain.routes.settings :refer [admin-setting-routes]]
+   [terrain.routes.tags :refer [secured-tag-routes]]
+   [terrain.routes.token :refer [admin-token-routes token-routes]]
+   [terrain.routes.user-info :refer [admin-user-info-routes
+                                     secured-user-info-routes]]
+   [terrain.routes.vice :refer [admin-vice-routes vice-routes]]
+   [terrain.routes.webhooks :refer [webhook-routes]]
+   [terrain.util :as util]
+   [terrain.util.config :as config]
+   [terrain.util.service :as service]
+   [terrain.util.transformers :as transform]))
 
 (defn- wrap-user-info
   [handler]
@@ -212,6 +221,7 @@
   []
   (util/flagged-routes
    (service-account-qms-api-routes)
+   (service-account-email-routes)
    (route/not-found (service/unrecognized-path-response))))
 
 (defn unsecured-routes
@@ -352,6 +362,7 @@
                                      {:name "user-info", :description "User Information Endpoints"}
                                      {:name "webhooks", :description "Webhook Endpoints"}
                                      {:name "vice", :description "VICE Endpoints"}
+                                     {:name "service-account-email" :description "Service Account Email Endpoints"}
                                      {:name "service-account-qms", :description "Service Account QMS Endpoints"}]
                :securityDefinitions security-definitions}})
   (route-middleware

--- a/src/terrain/routes/email.clj
+++ b/src/terrain/routes/email.clj
@@ -1,0 +1,26 @@
+(ns terrain.routes.email
+  (:require
+   [common-swagger-api.schema :refer [context POST]]
+   [ring.util.http-response :refer [ok]]
+   [terrain.auth.user-attributes :refer [require-service-account]]
+   [terrain.routes.schemas.email :as s]
+   [terrain.services.email :as email-service]
+   [terrain.util :refer [optional-routes]]
+   [terrain.util.config :as config]))
+
+(declare body)
+(defn service-account-email-routes
+  []
+  (optional-routes
+    [config/email-api-routes-enabled]
+
+    (context "/email" []
+      :tags ["service-account-email"]
+
+      (POST "/" []
+        :middleware [[require-service-account ["cyverse-emailer"]]]
+        :summary s/SendEmailSummary
+        :description s/SendEmailDescription
+        :body [body s/SendEmailRequestBody]
+        :return s/SendEmailResponse
+        (ok (email-service/send-email body))))))

--- a/src/terrain/routes/schemas/email.clj
+++ b/src/terrain/routes/schemas/email.clj
@@ -1,0 +1,19 @@
+(ns terrain.routes.schemas.email
+  (:require
+   [common-swagger-api.schema :as s]
+   [schema.core :refer [Keyword]]))
+
+(def SendEmailSummary "Send an Email")
+
+(def SendEmailDescription "Submits a request to send an email to a user.")
+
+(def SendEmailResponse
+  {:status (s/describe s/NonBlankString "The status of the request")})
+
+(def SendEmailRequestBody
+  {:to        (s/describe s/NonBlankString "The email address to send the message to")
+   :from_addr (s/describe s/NonBlankString "The email address of the message sender")
+   :from_name (s/describe s/NonBlankString "The name of the message sender")
+   :subject   (s/describe s/NonBlankString "The message subject")
+   :template  (s/describe s/NonBlankString "The name of the email template to use")
+   :values    (s/describe {Keyword s/NonBlankString} "The values to plug into the email template")})

--- a/src/terrain/services/email.clj
+++ b/src/terrain/services/email.clj
@@ -1,0 +1,11 @@
+(ns terrain.services.email
+  (:require
+   [terrain.util.email :as email]))
+
+(defn send-email
+  [body]
+  (-> (select-keys body [:to :subject :template :values])
+      (assoc :from-addr (:from_addr body)
+             :from-name (:from_name body))
+      email/send-email)
+  {:status "OK"})

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -1,10 +1,11 @@
 (ns terrain.util.config
-  (:require [clojure.string :as string]
-            [async-tasks-client.core :as async-tasks-client]
-            [clojure-commons.config :as cc]
-            [clojure-commons.error-codes :as ce]
-            [metadata-client.core :as metadata-client]
-            [slingshot.slingshot :refer [throw+]]))
+  (:require
+   [async-tasks-client.core :as async-tasks-client]
+   [clojure-commons.config :as cc]
+   [clojure-commons.error-codes :as ce]
+   [clojure.string :as string]
+   [metadata-client.core :as metadata-client]
+   [slingshot.slingshot :refer [throw+]]))
 
 (def de-system-id "de")
 (def docs-uri "/docs")
@@ -168,6 +169,12 @@
   "Enables or disables data-usage-api endpoints."
   [props config-valid configs]
   "terrain.routes.data-usage-api" true)
+
+(declare email-api-routes-enabled)
+(cc/defprop-optboolean email-api-routes-enabled
+  "Enables or disables email-api routes."
+  [props config-valid configs]
+  "terrain.routes.email-api" true)
 
 (declare iplant-email-base-url)
 (cc/defprop-optstr iplant-email-base-url

--- a/src/terrain/util/email.clj
+++ b/src/terrain/util/email.clj
@@ -1,8 +1,9 @@
 (ns terrain.util.email
-  (:require [clj-http.client :as client]
-            [clojure.string :as string]
-            [terrain.auth.user-attributes :refer [current-user]]
-            [terrain.util.config :as config]))
+  (:require
+   [clj-http.client :as client]
+   [clojure.string :as string]
+   [terrain.auth.user-attributes :refer [current-user]]
+   [terrain.util.config :as config]))
 
 (defn send-email
   "Sends an e-mail message via the iPlant e-mail service."


### PR DESCRIPTION
The primary purpose of this PR is to add an endpoint that the Subscription Portal can use to send emails to users on behalf of CyVerse. We wanted this endpoint to be fairly secure, so the `cyverse-emailer` role has to be associated with the account in order for calls to this endpoint to succeed.

## Testing

The test is fairly simple. The first step is to obtain an access token for the service account:

``` bash
$ export AUTH_HEADER="Authorization: Bearer $(curl -su "$CLIENT_ID:$CLIENT_SECRET" https://kc.cyverse.org/auth/realms/CyVerse/protocol/openid-connect/token -d grant_type=client_credentials | jq -r .access_token)"
```

**Note:** I was testing against production because I know that emails from production are working. If I had been testing against the QA environment then the Keycloak realm would have been `CyVerseTest`.

Once that's done, sending the email is fairly easy:

``` bash
$ curl -sH "$AUTH_HEADER" "http://localhost:60000/service/email" -H 'Content-type: application/json' -d '{"to": "sarahr@cyverse.org", "from_addr": "support@cyverse.org", "from_name": "CyVerse Support", "subject": "Testing", "template": "bettertest", "values": {"UserEmail": "sarahr@cyverse.org", "Value": "27"}}' | jq
{
  "status": "OK"
}
```

In this case, the email looks like this:

<img width="1701" height="781" alt="image" src="https://github.com/user-attachments/assets/4f2fb3a2-8516-4e6d-aa91-db0bd45cf5a2" />