### PR TITLE
CORE-2086: add support for `CC` and `BCC` email headers.

### DIFF
--- a/src/terrain/routes/schemas/email.clj
+++ b/src/terrain/routes/schemas/email.clj
@@ -1,7 +1,7 @@
 (ns terrain.routes.schemas.email
   (:require
    [common-swagger-api.schema :as s]
-   [schema.core :refer [Keyword]]))
+   [schema.core :refer [Keyword optional-key]]))
 
 (def SendEmailSummary "Send an Email")
 
@@ -11,9 +11,11 @@
   {:status (s/describe s/NonBlankString "The status of the request")})
 
 (def SendEmailRequestBody
-  {:to        (s/describe s/NonBlankString "The email address to send the message to")
-   :from_addr (s/describe s/NonBlankString "The email address of the message sender")
-   :from_name (s/describe s/NonBlankString "The name of the message sender")
-   :subject   (s/describe s/NonBlankString "The message subject")
-   :template  (s/describe s/NonBlankString "The name of the email template to use")
-   :values    (s/describe {Keyword s/NonBlankString} "The values to plug into the email template")})
+  {:to                 (s/describe s/NonBlankString "The email address to send the message to")
+   (optional-key :cc)  (s/describe [s/NonBlankString] "Email addresses to send courtecy copies to")
+   (optional-key :bcc) (s/describe [s/NonBlankString] "Email addresses to send blind courtecy copies to")
+   :from_addr          (s/describe s/NonBlankString "The email address of the message sender")
+   :from_name          (s/describe s/NonBlankString "The name of the message sender")
+   :subject            (s/describe s/NonBlankString "The message subject")
+   :template           (s/describe s/NonBlankString "The name of the email template to use")
+   :values             (s/describe {Keyword s/NonBlankString} "The values to plug into the email template")})

--- a/src/terrain/services/email.clj
+++ b/src/terrain/services/email.clj
@@ -4,7 +4,7 @@
 
 (defn send-email
   [body]
-  (-> (select-keys body [:to :subject :template :values])
+  (-> (select-keys body [:to :cc :bcc :subject :template :values])
       (assoc :from-addr (:from_addr body)
              :from-name (:from_name body))
       email/send-email)

--- a/src/terrain/util/email.clj
+++ b/src/terrain/util/email.clj
@@ -7,11 +7,13 @@
 
 (defn send-email
   "Sends an e-mail message via the iPlant e-mail service."
-  [& {:keys [to from-addr from-name subject template values]}]
+  [& {:keys [to cc bcc from-addr from-name subject template values]}]
   (client/post
    (config/iplant-email-base-url)
    {:content-type :json
     :form-params  {:to        to
+                   :cc        cc
+                   :bcc       bcc
                    :from-addr from-addr
                    :from-name from-name
                    :subject   subject


### PR DESCRIPTION
The purpose of this change is to allow the subscription portal to send courtesy copies of emails to CyVerse so that we have a record of the email.
