### PR TITLE
Adds the :access_url key to the URLReady response schema. It's optional.

### DIFF
--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -420,4 +420,5 @@
 (def Host (describe String "The hostname/subdomain of a VICE analysis"))
 
 (defschema URLReady
-  {:ready (describe Boolean "Whether or not the analysis is ready to be accessed.")})
+  {:ready                          (describe Boolean "Whether or not the analysis is ready to be accessed.")
+   (optional-key :access_url)      (describe (maybe String) "The access URL for the analysis, if ready.")})


### PR DESCRIPTION
The new version of app-exposer will include the access_url in the response from the url-ready endpoint. This change allows the new value to flow through terrain to Sonora.