### PR TITLE
Add admin APIS for vice-operators

### DIFF
--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -274,3 +274,42 @@
   (-> (app-exposer-url ["instantlaunches" "quicklaunches" "public"] {})
       (client/get {:as :json})
       (:body)))
+
+(defn admin-list-operators
+  "Calls app-exposer's GET /vice/admin/operators endpoint."
+  []
+  (-> (app-exposer-url ["vice" "admin" "operators"] {} :no-user true)
+      (client/get {:as :json})
+      (:body)))
+
+(defn admin-create-operator
+  "Calls app-exposer's POST /vice/admin/operators endpoint to register a new operator."
+  [body]
+  (-> (app-exposer-url ["vice" "admin" "operators"] {} :no-user true)
+      (client/post {:content-type :json
+                    :as           :json
+                    :form-params  body})
+      (:body)))
+
+(defn admin-get-operator-capacities
+  "Calls app-exposer's GET /vice/admin/operators/capacities endpoint."
+  []
+  (-> (app-exposer-url ["vice" "admin" "operators" "capacities"] {} :no-user true)
+      (client/get {:as :json})
+      (:body)))
+
+(defn admin-update-operator
+  "Calls app-exposer's PATCH /vice/admin/operators/id/{id} endpoint with a partial update body."
+  [id body]
+  (-> (app-exposer-url ["vice" "admin" "operators" "id" id] {} :no-user true)
+      (client/patch {:content-type :json
+                     :as           :json
+                     :form-params  body})
+      (:body)))
+
+(defn admin-delete-operator
+  "Calls app-exposer's DELETE /vice/admin/operators/id/{id} endpoint."
+  [id]
+  (-> (app-exposer-url ["vice" "admin" "operators" "id" id] {} :no-user true)
+      (client/delete {:as :json})
+      (:body)))

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -2,7 +2,8 @@
   (:require
    [common-swagger-api.schema :refer [describe NonBlankString]]
    [schema.core :refer [Any defschema maybe optional-key]]
-   [schema.core :as s])
+   [schema.core :as s]
+   [schema-tools.core :as st])
   (:import
    [java.util UUID]))
 
@@ -437,10 +438,7 @@
   (describe [OperatorAdminSummary] "Registered operators"))
 
 (defschema UpdateOperatorRequest
-  {(optional-key :name)            (describe NonBlankString "New operator display name")
-   (optional-key :url)             (describe NonBlankString "New HTTP(S) base URL")
-   (optional-key :tls_skip_verify) (describe Boolean "New TLS-skip flag")
-   (optional-key :priority)        (describe Long "New scheduling priority")})
+  (st/optional-keys-schema OperatorConfig))
 
 (defschema OperatorCapacityInfo
   {:maxAnalyses              (describe Long "Maximum concurrent analyses")

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -421,3 +421,43 @@
 
 (defschema URLReady
   {:ready (describe Boolean "Whether or not the analysis is ready to be accessed.")})
+
+(defschema OperatorConfig
+  {:name            (describe NonBlankString "The operator's display name")
+   :url             (describe NonBlankString "HTTP(S) base URL of the operator")
+   :tls_skip_verify (describe Boolean "Skip TLS verification for the operator's URL")
+   :priority        (describe Long "Scheduling priority; lower runs first")})
+
+(defschema OperatorAdminSummary
+  (merge
+   {:id (describe UUID "Server-assigned UUID of the operator")}
+   OperatorConfig))
+
+(defschema OperatorAdminSummaryList
+  (describe [OperatorAdminSummary] "Registered operators"))
+
+(defschema UpdateOperatorRequest
+  {(optional-key :name)            (describe NonBlankString "New operator display name")
+   (optional-key :url)             (describe NonBlankString "New HTTP(S) base URL")
+   (optional-key :tls_skip_verify) (describe Boolean "New TLS-skip flag")
+   (optional-key :priority)        (describe Long "New scheduling priority")})
+
+(defschema OperatorCapacityInfo
+  {:maxAnalyses              (describe Long "Maximum concurrent analyses")
+   :runningAnalyses          (describe Long "Currently running analyses")
+   :availableSlots           (describe Long "Free slots; -1 = unlimited, 0 = at capacity")
+   :allocatableCPU           (describe Long "Allocatable CPU in millicores")
+   :allocatableMemory        (describe Long "Allocatable memory in bytes")
+   :usedCPU                  (describe Long "Used CPU in millicores")
+   :usedMemory               (describe Long "Used memory in bytes")
+   (optional-key :gpuVendor) (describe String "GPU vendor (\"nvidia\", \"amd\", or empty)")})
+
+(defschema OperatorCapacity
+  {:operator                (describe String "Operator name")
+   (optional-key :capacity) (describe (maybe OperatorCapacityInfo) "Capacity report (omitted when error is set)")
+   (optional-key :error)    (describe (maybe String) "Error message if the operator could not be reached")})
+
+(defschema OperatorCapacityList
+  (describe [OperatorCapacity] "Per-operator capacity"))
+
+(def OperatorIDParam (describe UUID "Operator UUID"))

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -1,5 +1,5 @@
 (ns terrain.routes.vice
-  (:require [common-swagger-api.schema :refer [context GET POST]]
+  (:require [common-swagger-api.schema :refer [context GET POST PATCH DELETE]]
             [ring.util.http-response :refer [ok]]
             [terrain.clients.app-exposer :as vice]
             [terrain.routes.schemas.vice :as vice-schema]
@@ -7,7 +7,7 @@
             [terrain.util.config :as config]))
 
 ;; Declarations to eliminate lint warnings for path and query parameter bindings.
-(declare params analysis-id host)
+(declare params analysis-id host id)
 
 (defn admin-vice-routes
   []
@@ -72,6 +72,43 @@
            :summary "Get external UUID"
            :description "Returns the external UUID associated with the analysis. VICE analyses only have a single external UUID"
            (ok (vice/admin-external-id analysis-id)))))
+
+     (context "/operators" []
+       :tags ["admin-vice-operators"]
+
+       (GET "/" []
+         :return vice-schema/OperatorAdminSummaryList
+         :summary "List registered operators"
+         :description "Returns id, name, URL, tls_skip_verify, and priority for all operators in the database."
+         (ok (vice/admin-list-operators)))
+
+       (POST "/" []
+         :body [body vice-schema/OperatorConfig]
+         :return vice-schema/OperatorAdminSummary
+         :summary "Register a new operator"
+         :description "Adds a new operator to the database and returns the persisted row, including its server-assigned UUID."
+         (ok (vice/admin-create-operator body)))
+
+       (GET "/capacities" []
+         :return vice-schema/OperatorCapacityList
+         :summary "Get live operator capacities"
+         :description "Queries each configured operator's capacity endpoint in parallel and returns the results."
+         (ok (vice/admin-get-operator-capacities)))
+
+       (context "/id/:id" []
+         :path-params [id :- vice-schema/OperatorIDParam]
+
+         (PATCH "/" []
+           :body [body vice-schema/UpdateOperatorRequest]
+           :return vice-schema/OperatorAdminSummary
+           :summary "Update an operator"
+           :description "Partial update of an operator identified by UUID. Only fields supplied in the body are changed."
+           (ok (vice/admin-update-operator id body)))
+
+         (DELETE "/" []
+           :summary "Delete an operator"
+           :description "Removes the operator with the given UUID. Idempotent. Fails if jobs still reference the operator."
+           (ok (vice/admin-delete-operator id)))))
 
      (context "/:host" []
        :path-params [host :- vice-schema/Host]


### PR DESCRIPTION
Adds admin API calls for managing operators to terrain. They're all pass-throughs to the app-exposer service. Deployed into QA and tested through the Swagger UI.