### PR TITLE
Add support for new operator fields

### DIFF
--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -434,13 +434,21 @@
 (defschema OperatorAdminSummary
   (merge
    {:id (describe UUID "Server-assigned UUID of the operator")}
-   OperatorConfig))
+   OperatorConfig
+   {:accepting_launches (describe Boolean "Whether the operator accepts new launches; false drains it but leaves it in service")
+    :deactivated        (describe Boolean "Whether the operator is fully removed from the live pool; takes precedence over accepting_launches")}))
 
 (defschema OperatorAdminSummaryList
   (describe [OperatorAdminSummary] "Registered operators"))
 
 (defschema UpdateOperatorRequest
-  (st/optional-keys-schema OperatorConfig))
+  (merge
+   (st/optional-keys-schema OperatorConfig)
+   {(optional-key :accepting_launches)
+    (describe Boolean "Whether the operator accepts new launches; false drains it but leaves it in service")
+
+    (optional-key :deactivated)
+    (describe Boolean "Whether the operator is fully removed from the live pool; takes precedence over accepting_launches")}))
 
 (defschema OperatorCapacityInfo
   {:maxAnalyses              (describe Long "Maximum concurrent analyses")
@@ -450,7 +458,9 @@
    :allocatableMemory        (describe Long "Allocatable memory in bytes")
    :usedCPU                  (describe Long "Used CPU in millicores")
    :usedMemory               (describe Long "Used memory in bytes")
-   (optional-key :gpuVendor) (describe String "GPU vendor (\"nvidia\", \"amd\", or empty)")})
+   (optional-key :gpuVendor) (describe String "GPU vendor (\"nvidia\", \"amd\", or empty)")
+   (optional-key :supportedGPUModels)
+   (describe [String] "Canonical GFD-style GPU model names this operator can deliver; empty means model-agnostic")})
 
 (defschema OperatorCapacity
   {:operator                (describe String "Operator name")

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -79,7 +79,7 @@
        (GET "/" []
          :return vice-schema/OperatorAdminSummaryList
          :summary "List registered operators"
-         :description "Returns id, name, URL, base_url, tls_skip_verify, and priority for all operators in the database."
+         :description "Returns id, name, URL, base_url, tls_skip_verify, priority, accepting_launches, and deactivated for all operators in the database."
          (ok (vice/admin-list-operators)))
 
        (POST "/" []


### PR DESCRIPTION
Adds support for the following fields:
* accepting_launches - whether the operator accepts new app launches. Turning this to false allows us to phase out an operator without just terminating a bunch of running analyses.

* deactivated - essentially a soft-delete of an operator.

* supportedGPUModels - the operators can now return a listing of their supportedGPUModels in their capacity endpoint. It's useful to have access to that info through the API.

I noticed the inconsistency in the casing across fields, but upon exploration of the code a bit it's become clear that this is a very common issue in our codebase. Not something I can easily address here, unfortunately.