### PR TITLE
Allow the ingresses key through the VICE resources listing

### DIFF
--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -380,11 +380,22 @@
    BaseListing
    {:rules (describe [HTTPRouteRule] "Rules used to match requests with the route")}))
 
+(defschema IngressRule
+  {(optional-key :host) (describe String "The fully qualified domain name the rule applies to")
+   s/Keyword            s/Any})
+
+(defschema Ingress
+  (merge
+   BaseListing
+   {(optional-key :defaultBackend) (describe String "The backend used for requests that don't match a rule")
+    :rules                         (describe [IngressRule] "The list of host and path rules for the ingress")}))
+
 (defschema FullResourceListing
   {:deployments (describe [Deployment] "The list of deployments")
    :pods        (describe [Pod] "The list of pods")
    :configMaps  (describe [ConfigMap] "The list of config maps")
    :services    (describe [Service] "The list of services")
+   :ingresses   (describe [Ingress] "The list of ingresses")
    :routes      (describe [HTTPRoute] "The list of HTTP routes")})
 
 (defschema FilterParams

--- a/src/terrain/routes/schemas/vice.clj
+++ b/src/terrain/routes/schemas/vice.clj
@@ -388,7 +388,7 @@
   (merge
    BaseListing
    {(optional-key :defaultBackend) (describe String "The backend used for requests that don't match a rule")
-    :rules                         (describe [IngressRule] "The list of host and path rules for the ingress")}))
+    :rules                         (describe (maybe [IngressRule]) "The list of host and path rules for the ingress")}))
 
 (defschema FullResourceListing
   {:deployments (describe [Deployment] "The list of deployments")


### PR DESCRIPTION
## Summary

The `GET /api/admin/vice/resources` and non-admin `GET /api/vice/resources` endpoints return `FullResourceListing` as their `:return` schema. Because plumatic/schema strips keys not declared in the schema, the `:ingresses` key produced by app-exposer's `ResourceInfo` was being dropped from the response.

## Changes

- Add an `Ingress` schema mirroring app-exposer's `reporting.IngressInfo` (`MetaInfo` fields via `BaseListing`, plus `defaultBackend` and `rules`).
- Wire `:ingresses` into `FullResourceListing`, ordered between `:services` and `:routes` to match app-exposer's `ResourceInfo`.
- `IngressRule` documents `:host` as an optional key and adds an `s/Keyword s/Any` catch-all, so any additional Kubernetes `IngressRule` fields pass through untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)