### PR TITLE
CORE-2158: Add OIDC Authorization Code Flow support to terrain

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,6 +29,7 @@
                  [org.cyverse/common-cfg "2.8.3"]
                  [org.cyverse/common-cli "2.8.2"]
                  [org.cyverse/common-swagger-api "3.4.17"]
+                 [metosin/ring-swagger-ui "5.20.0"]
                  [org.cyverse/kameleon "3.0.10"
                   :exclusion [com.impossibl.pgjdbc-ng/pgjdbc-ng]]
                  [com.impossibl.pgjdbc-ng/pgjdbc-ng "0.8.9"]

--- a/resources/swagger-ui/swagger-initializer.js
+++ b/resources/swagger-ui/swagger-initializer.js
@@ -1,0 +1,37 @@
+// Custom Swagger UI initializer for terrain.
+//
+// This file shadows the copy shipped in the ring-swagger-ui jar (terrain's resources directory precedes
+// dependency jars on the classpath). In addition to the stock behavior of loading the API spec, it wires up the
+// OAuth2 "Authorize" button for the OIDC Authorization Code Flow by calling initOAuth with the Keycloak client
+// id and scopes supplied (config-driven) via ./config.json.
+window.onload = function () {
+  fetch("./config.json")
+    .then(function (response) { return response.json(); })
+    .then(function (config) {
+      var redirectUrl =
+        window.location.origin +
+        window.location.pathname.replace(/\/$/, "") +
+        "/oauth2-redirect.html";
+
+      window.ui = SwaggerUIBundle({
+        url: config.url,
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout",
+        oauth2RedirectUrl: redirectUrl
+      });
+
+      window.ui.initOAuth({
+        clientId: config.oauth2ClientId,
+        scopes: config.oauth2Scopes,
+        usePkceWithAuthorizationCodeGrant: true
+      });
+    });
+};

--- a/src/terrain/auth/user_attributes.clj
+++ b/src/terrain/auth/user_attributes.clj
@@ -156,6 +156,12 @@
     (when (and (is-bearer? header) (is-jwt? header))
       (second header))))
 
+(defn- get-keycloak-oidc-cookie-token
+  "Returns the Keycloak OIDC access token from the request's cookies, or nil if it isn't present. This cookie is
+   set by terrain's OIDC Authorization Code Flow callback."
+  [request]
+  (get-in request [:cookies keycloak-oidc-util/access-token-cookie :value]))
+
 (defn- wrap-fake-auth
   [handler]
   (wrap-current-user handler fake-user-from-attributes))
@@ -172,6 +178,13 @@
       (wrap-service-account keycloak-oidc-util/service-account-from-token)
       (keycloak-oidc-util/validate-token get-keycloak-oidc-token)))
 
+(defn- wrap-keycloak-oidc-cookie
+  [handler]
+  (-> handler
+      (wrap-current-user keycloak-oidc-util/user-from-token)
+      (wrap-service-account keycloak-oidc-util/service-account-from-token)
+      (keycloak-oidc-util/validate-token get-keycloak-oidc-cookie-token)))
+
 (defn authenticate-current-user
   "Authenticates the user and binds current-user to a map that is built from the user attributes retrieved
    during the authentication process. This middleware does not require authentication information to be
@@ -179,19 +192,21 @@
    request to be processed. Requests without credentials will be passed to the handler without authentication.
    Routes that require authentication can use the require-authentication middleware."
   [handler]
-  (wrap-auth-selection [[get-fake-auth           (wrap-fake-auth handler)]
-                        [get-de-jwt-assertion    (wrap-de-jwt-auth handler)]
-                        [get-keycloak-oidc-token (wrap-keycloak-oidc handler)]
-                        [(constantly true)       handler]]))
+  (wrap-auth-selection [[get-fake-auth                  (wrap-fake-auth handler)]
+                        [get-de-jwt-assertion           (wrap-de-jwt-auth handler)]
+                        [get-keycloak-oidc-token        (wrap-keycloak-oidc handler)]
+                        [get-keycloak-oidc-cookie-token (wrap-keycloak-oidc-cookie handler)]
+                        [(constantly true)              handler]]))
 
 (defn validate-current-user
   "Verifies that the user belongs to one of the groups that are permitted to access the resource."
   [handler]
   (wrap-auth-selection
-   [[get-fake-auth           handler]
-    [get-de-jwt-assertion    (jwt/validate-group-membership handler cfg/allowed-groups)]
-    [get-keycloak-oidc-token (keycloak-oidc-util/validate-group-membership handler cfg/allowed-groups)]
-    [(constantly true)       (constantly (resp/unauthorized "Admin endpoints require authentication."))]]))
+   [[get-fake-auth                  handler]
+    [get-de-jwt-assertion           (jwt/validate-group-membership handler cfg/allowed-groups)]
+    [get-keycloak-oidc-token        (keycloak-oidc-util/validate-group-membership handler cfg/allowed-groups)]
+    [get-keycloak-oidc-cookie-token (keycloak-oidc-util/validate-group-membership handler cfg/allowed-groups)]
+    [(constantly true)              (constantly (resp/unauthorized "Admin endpoints require authentication."))]]))
 
 (defn require-authentication
   "Middleware that checks for user information in an incoming request and returns a 401 if it's not found.

--- a/src/terrain/clients/keycloak.clj
+++ b/src/terrain/clients/keycloak.clj
@@ -8,6 +8,27 @@
   [& components]
   (str (apply curl/url (config/keycloak-base-uri) "realms" (config/keycloak-realm) components)))
 
+(defn authorization-endpoint
+  "Returns the Keycloak OIDC authorization endpoint URL."
+  []
+  (keycloak-url "protocol" "openid-connect" "auth"))
+
+(defn token-endpoint
+  "Returns the Keycloak OIDC token endpoint URL."
+  []
+  (keycloak-url "protocol" "openid-connect" "token"))
+
+(defn authorization-code-url
+  "Builds the Keycloak authorization endpoint URL used to initiate the OIDC Authorization Code Flow."
+  [state]
+  (-> (curl/url (authorization-endpoint))
+      (assoc :query {:response_type "code"
+                     :client_id     (config/keycloak-client-id)
+                     :redirect_uri  (config/oidc-redirect-uri)
+                     :scope         (config/oidc-scopes)
+                     :state         state})
+      str))
+
 (defn get-oidc-certs
   "Retrieves a list of active public certificates from Keycloak."
   []
@@ -19,7 +40,7 @@
 (defn get-token
   "Obtains an authorization token."
   [username password]
-  (:body (http/post (keycloak-url "protocol" "openid-connect" "token")
+  (:body (http/post (token-endpoint)
                     {:form-params {:grant_type    "password"
                                    :client_id     (config/keycloak-client-id)
                                    :client_secret (config/keycloak-client-secret)
@@ -30,11 +51,32 @@
 (defn get-impersonation-token
   "Obtains an impersonation token for troubleshooting purposes."
   [subject-token username]
-  (:body (http/post (keycloak-url "protocol" "openid-connect" "token")
+  (:body (http/post (token-endpoint)
                     {:form-params {:grant_type           "urn:ietf:params:oauth:grant-type:token-exchange"
                                    :client_id            (config/keycloak-client-id)
                                    :client_secret        (config/keycloak-client-secret)
                                    :subject_token        subject-token
                                    :requested_token_type "urn:ietf:params:oauth:token-type:access_token"
                                    :requested_subject    username}
+                     :as          :json})))
+
+(defn exchange-code-for-token
+  "Exchanges an OIDC authorization code for an access token using the Authorization Code grant."
+  [code]
+  (:body (http/post (token-endpoint)
+                    {:form-params {:grant_type    "authorization_code"
+                                   :client_id     (config/keycloak-client-id)
+                                   :client_secret (config/keycloak-client-secret)
+                                   :code          code
+                                   :redirect_uri  (config/oidc-redirect-uri)}
+                     :as          :json})))
+
+(defn refresh-token
+  "Obtains a new access token from a refresh token using the Refresh Token grant."
+  [refresh-token]
+  (:body (http/post (token-endpoint)
+                    {:form-params {:grant_type    "refresh_token"
+                                   :client_id     (config/keycloak-client-id)
+                                   :client_secret (config/keycloak-client-secret)
+                                   :refresh_token refresh-token}
                      :as          :json})))

--- a/src/terrain/routes.clj
+++ b/src/terrain/routes.clj
@@ -8,10 +8,12 @@
    [common-swagger-api.schema :as schema]
    [compojure.api.core :refer [route-middleware]]
    [compojure.route :as route]
+   [ring.middleware.cookies :refer [wrap-cookies]]
    [ring.middleware.keyword-params :refer [wrap-keyword-params]]
    [service-logging.middleware :refer [clean-context wrap-logging]]
    [service-logging.thread-context :as tc]
    [terrain.auth.user-attributes :as user-attributes]
+   [terrain.clients.keycloak :as keycloak]
    [terrain.middleware :refer [wrap-context-path-adder wrap-create-workspace
                                wrap-query-param-remover]]
    [terrain.routes.admin :refer [secured-admin-routes]]
@@ -70,6 +72,7 @@
    [terrain.routes.notification :refer [secured-notification-routes]]
    [terrain.routes.oauth :refer [oauth-admin-routes oauth-routes
                                  secured-oauth-routes]]
+   [terrain.routes.oidc :refer [oidc-routes]]
    [terrain.routes.permanent-id-requests :refer [admin-permanent-id-request-routes
                                                  permanent-id-request-routes]]
    [terrain.routes.pref :refer [secured-pref-routes]]
@@ -229,6 +232,7 @@
   (util/flagged-routes
    (admin-token-routes)
    (callback-routes)
+   (oidc-routes)
    (token-routes)
    (unsecured-misc-routes)))
 
@@ -290,17 +294,25 @@
    optionally-authenticated-routes-handler
    secured-routes-no-context-handler))
 
-(def ^:private security-definitions
+(defn- security-definitions
+  []
   {:basic  {:type "basic"}
    :bearer {:type "apiKey"
             :name "Authorization"
-            :in   "header"}})
+            :in   "header"}
+   :oauth2 {:type             "oauth2"
+            :flow             "accessCode"
+            :authorizationUrl (keycloak/authorization-endpoint)
+            :tokenUrl         (keycloak/token-endpoint)
+            :scopes           {:openid "OpenID Connect scope"}}})
 
 (schema/defapi app
   {:exceptions cx/exception-handlers}
   (schema/swagger-routes
    {:ui       (str "/terrain" config/docs-uri)
     :spec     "/terrain/swagger.json"
+    :options  {:ui {:oauth2-client-id (config/keycloak-client-id)
+                    :oauth2-scopes    (config/oidc-scopes)}}
     :data     {:info                {:title       "Discovery Environment API"
                                      :description "Documentation for the Discovery Environment REST API"
                                      :version     "0.1.0"}
@@ -346,6 +358,7 @@
                                      {:name "filesystem", :description "Filesystem Endpoints"}
                                      {:name "instant-launches", :description "Instant Launch Endpoints"}
                                      {:name "notifications", :description "Notifications and related Endpoints"}
+                                     {:name "oidc", :description "OIDC Authorization Code Flow Endpoints"}
                                      {:name "permanent-id-requests", :description "Permanent ID Request Endpoints"}
                                      {:name "qms", :description "Quota Management Service Endpoints"}
                                      {:name "reference-genomes", :description "Reference Genome Endpoints"}
@@ -365,13 +378,14 @@
                                      {:name "service-account-email" :description "Service Account Email Endpoints"}
                                      {:name "service-account-qms", :description "Service Account QMS Endpoints"}
                                      {:name "service-account-user-info", :description "Service Account User Info Endpoints"}]
-               :securityDefinitions security-definitions}})
+               :securityDefinitions (security-definitions)}})
   (route-middleware
    [[wrap-query-param-remover "ip-address" #{#"^/terrain/secured/bootstrap"
                                              #"^/terrain/secured/logout"}]
     wrap-query-params
     wrap-lcase-params
     wrap-keyword-params
+    wrap-cookies
     clean-context]
    (schema/context "/terrain" []
      (terrain-routes))))

--- a/src/terrain/routes/oidc.clj
+++ b/src/terrain/routes/oidc.clj
@@ -1,0 +1,33 @@
+(ns terrain.routes.oidc
+  (:require [common-swagger-api.schema :refer [context routes GET POST]]
+            [terrain.services.oidc :as oidc]))
+
+(defn oidc-routes
+  []
+  (routes
+   (context "/oidc" []
+     :tags ["oidc"]
+
+     (GET "/login" [:as request]
+       :summary "Initiate OIDC Authorization Code Flow"
+       :description "Redirects the browser to Keycloak to begin the OIDC Authorization Code Flow. Upon successful
+       authentication, Keycloak redirects back to the callback endpoint."
+       (oidc/login request))
+
+     (GET "/callback" [:as request]
+       :summary "OIDC Authorization Code Flow Callback"
+       :description "Handles the redirect from Keycloak after authentication. Verifies the state parameter,
+       exchanges the authorization code for tokens, stores the tokens in HttpOnly cookies, and redirects to the
+       configured landing URI."
+       (oidc/callback request))
+
+     (POST "/refresh" [:as request]
+       :summary "Refresh OIDC Tokens"
+       :description "Uses the refresh token stored in the request's cookies to obtain a fresh access token and
+       resets the token cookies."
+       (oidc/refresh request))
+
+     (GET "/logout" [:as request]
+       :summary "OIDC Logout"
+       :description "Clears the OIDC token cookies and redirects the browser to the configured landing URI."
+       (oidc/logout request)))))

--- a/src/terrain/services/oidc.clj
+++ b/src/terrain/services/oidc.clj
@@ -1,0 +1,91 @@
+(ns terrain.services.oidc
+  (:require [ring.util.http-response :as http-response]
+            [terrain.clients.keycloak :as keycloak]
+            [terrain.util.config :as config]
+            [terrain.util.keycloak-oidc :as keycloak-oidc])
+  (:import [java.security SecureRandom]
+           [java.util Base64]))
+
+(def ^:private state-cookie
+  "The name of the short-lived cookie used to guard against CSRF during the Authorization Code Flow."
+  "de-oidc-state")
+
+(def ^:private ^SecureRandom secure-random (SecureRandom.))
+
+(defn- generate-state
+  "Generates a random, URL-safe state value for the Authorization Code Flow."
+  []
+  (let [buf (byte-array 32)]
+    (.nextBytes secure-random buf)
+    (.encodeToString (.withoutPadding (Base64/getUrlEncoder)) buf)))
+
+(defn- token-cookie
+  "Builds a cookie map for an OIDC token."
+  [value max-age]
+  {:value     value
+   :path      "/"
+   :http-only true
+   :secure    (config/secure-cookies?)
+   :same-site :lax
+   :max-age   max-age})
+
+(defn- expired-cookie
+  "Builds a cookie map that immediately expires a cookie."
+  []
+  {:value     ""
+   :path      "/"
+   :http-only true
+   :secure    (config/secure-cookies?)
+   :same-site :lax
+   :max-age   0})
+
+(defn login
+  "Initiates the OIDC Authorization Code Flow by redirecting the browser to Keycloak. A random state value is
+   generated and stored in a short-lived cookie so that it can be verified when Keycloak redirects back to the
+   callback endpoint."
+  [_]
+  (let [state (generate-state)]
+    (-> (http-response/found (keycloak/authorization-code-url state))
+        (assoc-in [:cookies state-cookie] (token-cookie state 300)))))
+
+(defn callback
+  "Handles the redirect from Keycloak after the user authenticates. The state parameter is verified against the
+   state cookie, the authorization code is exchanged for tokens, the tokens are stored in HttpOnly cookies, and
+   the browser is redirected to the configured landing URI."
+  [{:keys [params cookies]}]
+  (let [code         (:code params)
+        state        (:state params)
+        cookie-state (get-in cookies [state-cookie :value])]
+    (cond
+      (or (nil? code) (nil? state))
+      (http-response/bad-request "Missing authorization code or state parameter.")
+
+      (or (nil? cookie-state) (not= state cookie-state))
+      (http-response/bad-request "Invalid OIDC state parameter.")
+
+      :else
+      (let [{:keys [access_token refresh_token expires_in refresh_expires_in]}
+            (keycloak/exchange-code-for-token code)]
+        (-> (http-response/found (config/oidc-landing-uri))
+            (assoc-in [:cookies keycloak-oidc/access-token-cookie] (token-cookie access_token expires_in))
+            (assoc-in [:cookies keycloak-oidc/refresh-token-cookie] (token-cookie refresh_token refresh_expires_in))
+            (assoc-in [:cookies state-cookie] (expired-cookie)))))))
+
+(defn refresh
+  "Obtains a fresh access token using the refresh token stored in the request's cookies and resets the token
+   cookies."
+  [{:keys [cookies]}]
+  (if-let [refresh-token (get-in cookies [keycloak-oidc/refresh-token-cookie :value])]
+    (let [{:keys [access_token refresh_token expires_in refresh_expires_in]}
+          (keycloak/refresh-token refresh-token)]
+      (-> (http-response/ok {:expires_in expires_in})
+          (assoc-in [:cookies keycloak-oidc/access-token-cookie] (token-cookie access_token expires_in))
+          (assoc-in [:cookies keycloak-oidc/refresh-token-cookie] (token-cookie refresh_token refresh_expires_in))))
+    (http-response/unauthorized "No refresh token found in request.")))
+
+(defn logout
+  "Clears the OIDC token cookies and redirects the browser to the configured landing URI."
+  [_]
+  (-> (http-response/found (config/oidc-landing-uri))
+      (assoc-in [:cookies keycloak-oidc/access-token-cookie] (expired-cookie))
+      (assoc-in [:cookies keycloak-oidc/refresh-token-cookie] (expired-cookie))))

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -1,6 +1,7 @@
 (ns terrain.util.config
   (:require
    [async-tasks-client.core :as async-tasks-client]
+   [cemerick.url :as curl]
    [clojure-commons.config :as cc]
    [clojure-commons.error-codes :as ce]
    [clojure.string :as string]
@@ -706,6 +707,37 @@
   "The keycloak client secret to use."
   [props config-valid configs]
   "terrain.keycloak.client-secret")
+
+(declare base-uri)
+(cc/defprop-optstr base-uri
+  "The public base URI for Terrain (for example, https://qa.cyverse.org/terrain). Used to derive the OIDC
+   redirect and landing URIs. Must be set for the OIDC Authorization Code Flow endpoints to function."
+  [props config-valid configs]
+  "terrain.base-uri" "")
+
+(defn oidc-redirect-uri
+  "The redirect URI registered with Keycloak for terrain's OIDC Authorization Code Flow callback, derived from
+   the public Terrain base URI."
+  []
+  (str (curl/url (base-uri) "oidc" "callback")))
+
+(defn oidc-landing-uri
+  "The URI to redirect the browser to after a successful OIDC Authorization Code Flow login, derived from the
+   public Terrain base URI."
+  []
+  (str (curl/url (base-uri) "docs")))
+
+(declare oidc-scopes)
+(cc/defprop-optstr oidc-scopes
+  "The space-delimited OIDC scopes to request during the Authorization Code Flow."
+  [props config-valid configs]
+  "terrain.keycloak.oidc-scopes" "openid")
+
+(declare secure-cookies?)
+(cc/defprop-optboolean secure-cookies?
+  "Whether cookies set by terrain should have the Secure flag. Disable for local HTTP testing."
+  [props config-valid configs]
+  "terrain.keycloak.secure-cookies" true)
 
 (declare keycloak-admin-base-uri)
 (cc/defprop-optstr keycloak-admin-base-uri

--- a/src/terrain/util/keycloak_oidc.clj
+++ b/src/terrain/util/keycloak_oidc.clj
@@ -6,6 +6,14 @@
             [terrain.clients.keycloak :as kc]
             [terrain.util.config :as config]))
 
+(def access-token-cookie
+  "The name of the cookie used to store the Keycloak OIDC access token after an Authorization Code Flow login."
+  "de-access-token")
+
+(def refresh-token-cookie
+  "The name of the cookie used to store the Keycloak OIDC refresh token after an Authorization Code Flow login."
+  "de-refresh-token")
+
 (defn- is-service-account?
   [{:keys [preferred_username]}]
   (string/starts-with? preferred_username "service-account-"))


### PR DESCRIPTION
Terrain has only ever consumed Keycloak OIDC bearer tokens. This adds support for acting as an OIDC relying party using the browser-based Authorization Code Flow, and integrates it into the Swagger UI.

New unsecured endpoints under /oidc:
  - GET  /oidc/login    redirect to Keycloak's authorize endpoint
  - GET  /oidc/callback verify state, exchange code, set token cookies
  - POST /oidc/refresh  refresh-token grant, reset cookies
  - GET  /oidc/logout   clear the token cookies

After the callback exchanges the code for tokens, the access and refresh tokens are stored in HttpOnly cookies and the browser is redirected to a landing URI. The auth middleware now also accepts the access token from the cookie, so requests carrying it authenticate like a bearer token.

The OIDC redirect and landing URIs are derived from a single new public terrain.base-uri setting so the two can't drift and there's less to misconfigure.

For Swagger, ring-swagger-ui is upgraded to 5.x and an oauth2 securityDefinition (accessCode flow) is added pointing at Keycloak. A config-driven swagger-initializer.js calls initOAuth so the Authorize button can perform the flow.