### PR TITLE
Add user-level VICE and binary file-overwrite routes for formation

### DIFF
--- a/src/terrain/auth/user_attributes.clj
+++ b/src/terrain/auth/user_attributes.clj
@@ -240,7 +240,7 @@
   "Attempts to resolve a test user from either a username or a map of user attributes."
   [user]
   (cond (string? user) (lookup-user user)
-        (map? user)    (user-from-attributes {:user-attribues user})
+        (map? user)    (user-from-attributes {:user-attributes user})
         :else          (cxu/internal-system-error "user must be a string or a map of attributes")))
 
 (defmacro with-user

--- a/src/terrain/clients/app_exposer.clj
+++ b/src/terrain/clients/app_exposer.clj
@@ -111,9 +111,11 @@
   (:body (client/get (app-exposer-url ["vice" "async-data"] query) {:as :json})))
 
 (defn admin-external-id
-  "Gets the external-id for the provided analysis-id. VICE analyses only have a single external-id"
+  "Gets the external-id for the provided analysis-id. VICE analyses only have a single external-id.
+   app-exposer responds with an external_id key; the published schema uses externalID."
   [analysis-id]
-  (:body (client/get (app-exposer-url ["vice" "admin" "analyses" analysis-id "external-id"] {} :no-user true) {:as :json})))
+  (let [body (:body (client/get (app-exposer-url ["vice" "admin" "analyses" analysis-id "external-id"] {} :no-user true) {:as :json}))]
+    {:externalID (:external_id body)}))
 
 (defn admin-exit
   "Forces the analysis to exit without transferring output files"

--- a/src/terrain/clients/permissions.clj
+++ b/src/terrain/clients/permissions.clj
@@ -21,3 +21,13 @@
   "Copies permissions from one subject to one or more other subjects."
   [source-type source-id dest-subjects]
   (c/copy-permissions (get-client) source-type source-id dest-subjects))
+
+(defn get-analysis-permission-level
+  "Returns the most privileged permission level the user holds on an analysis, including grants
+   held via group membership, or nil if the user has no access to it. The permission levels are
+   the ones used by the apps service: read, admin, write, and own."
+  [user analysis-id]
+  (-> (c/get-subject-permissions-for-resource (get-client) "user" user "analysis" (str analysis-id) true)
+      :permissions
+      first
+      :permission_level))

--- a/src/terrain/clients/permissions.clj
+++ b/src/terrain/clients/permissions.clj
@@ -27,6 +27,8 @@
    held via group membership, or nil if the user has no access to it. The permission levels are
    the ones used by the apps service: read, admin, write, and own."
   [user analysis-id]
+  ;; The permissions service returns at most one entry per resource: the most privileged grant
+  ;; across the user and their groups, so `first` always yields the effective level.
   (-> (c/get-subject-permissions-for-resource (get-client) "user" user "analysis" (str analysis-id) true)
       :permissions
       first

--- a/src/terrain/routes/fileio.clj
+++ b/src/terrain/routes/fileio.clj
@@ -34,7 +34,10 @@
        :description "Uploads a file to the CyVerse Data Store."
        :query [params fileio-schema/FileUploadQueryParams]
        :multipart-params [file :- fileio-schema/DataStoreUpload]
-       :middleware [require-authentication fio/wrap-file-upload mw/check-user-data-overages]
+       ;; The overage check must run before the multipart middleware: parsing
+       ;; the multipart body performs the upload, so checking afterwards would
+       ;; store the file and then reject the request.
+       :middleware [require-authentication mw/check-user-data-overages fio/wrap-file-upload]
        :return stats-schema/FileStat
 
        ;; The upload is handled in the middleware. All that remains to be done is to return the response body.
@@ -48,10 +51,8 @@
                          "/terrain/secured/fileio/upload endpoint.")
        :query [params fileio-schema/FileOverwriteQueryParams]
        :multipart-params [file :- fileio-schema/DataStoreUpload]
-       ;; The overage check must run before the multipart middleware: parsing
-       ;; the multipart body performs the overwrite, so the order on the upload
-       ;; route (which checks afterwards) would replace the file and then
-       ;; reject the request.
+       ;; As on the upload route, the overage check must run before the
+       ;; multipart middleware that performs the overwrite.
        :middleware [require-authentication mw/check-user-data-overages fio/wrap-file-overwrite]
        :return stats-schema/FileStat
 

--- a/src/terrain/routes/fileio.clj
+++ b/src/terrain/routes/fileio.clj
@@ -48,7 +48,11 @@
                          "/terrain/secured/fileio/upload endpoint.")
        :query [params fileio-schema/FileOverwriteQueryParams]
        :multipart-params [file :- fileio-schema/DataStoreUpload]
-       :middleware [require-authentication fio/wrap-file-overwrite mw/check-user-data-overages]
+       ;; The overage check must run before the multipart middleware: parsing
+       ;; the multipart body performs the overwrite, so the order on the upload
+       ;; route (which checks afterwards) would replace the file and then
+       ;; reject the request.
+       :middleware [require-authentication mw/check-user-data-overages fio/wrap-file-overwrite]
        :return stats-schema/FileStat
 
        ;; The overwrite is handled in the middleware, like the upload endpoint above.

--- a/src/terrain/routes/fileio.clj
+++ b/src/terrain/routes/fileio.clj
@@ -40,6 +40,20 @@
        ;; The upload is handled in the middleware. All that remains to be done is to return the response body.
        (ok (select-keys file [:file])))
 
+     (POST "/overwrite" []
+       :summary "Overwrite a File"
+       :description (str "Overwrites the contents of an existing file in the Data Store with the uploaded content. "
+                         "Unlike the POST /terrain/secured/fileio/save endpoint, the content is forwarded as-is, so "
+                         "binary files are safe. The file must exist already; to upload a new file, use the POST "
+                         "/terrain/secured/fileio/upload endpoint.")
+       :query [params fileio-schema/FileOverwriteQueryParams]
+       :multipart-params [file :- fileio-schema/DataStoreUpload]
+       :middleware [require-authentication fio/wrap-file-overwrite mw/check-user-data-overages]
+       :return stats-schema/FileStat
+
+       ;; The overwrite is handled in the middleware, like the upload endpoint above.
+       (ok (select-keys file [:file])))
+
      (POST "/urlupload" []
        :summary "Upload a File from a URL"
        :description (str "Schedules a task to have the DE retrieve the contents of a new file in the data store from "

--- a/src/terrain/routes/filesystem.clj
+++ b/src/terrain/routes/filesystem.clj
@@ -184,6 +184,10 @@
      :middleware [require-authentication]
      (controller req meta/do-metadata-set data-id :params :body))
 
+   (POST "/filesystem/:data-id/metadata/add" [data-id :as req]
+     :middleware [require-authentication]
+     (controller req meta/do-metadata-add data-id :params :body))
+
    (POST "/filesystem/:data-id/metadata/copy" [data-id :as req]
      :middleware [require-authentication]
      (controller req meta/do-metadata-copy :params data-id :body))

--- a/src/terrain/routes/schemas/fileio.clj
+++ b/src/terrain/routes/schemas/fileio.clj
@@ -10,6 +10,9 @@
 (s/defschema FileUploadQueryParams
   {:dest (describe NonBlankString "The destination directory for the uploaded file.")})
 
+(s/defschema FileOverwriteQueryParams
+  {:dest (describe NonBlankString "The path to the existing file to overwrite in the data store.")})
+
 (def DataStoreUpload
   "Schema for a data store upload file parameter. The multipart request has to be processed in middleware because
   the input stream for the file contents is closed before the body of the endpoint implementation is reached. We're

--- a/src/terrain/routes/vice.clj
+++ b/src/terrain/routes/vice.clj
@@ -3,6 +3,7 @@
             [ring.util.http-response :refer [ok]]
             [terrain.clients.app-exposer :as vice]
             [terrain.routes.schemas.vice :as vice-schema]
+            [terrain.services.vice :as vice-services]
             [terrain.util :refer [optional-routes]]
             [terrain.util.config :as config]))
 
@@ -139,6 +140,28 @@
        :summary "List Kubernetes resources deployed in the cluster"
        :description "Lists all Kubernetes resources associated with an analysis running in the cluster for a user"
        (ok (vice/get-resources filter)))
+
+     (GET "/async-data" []
+       :query [params vice-schema/AsyncDataParams]
+       :return vice-schema/AsyncData
+       :summary "Get data that is generated asynchronously"
+       :description "Get data for the VICE analysis that is generated asynchronously, after verifying that the user can read the analysis"
+       (ok (vice-services/async-data params)))
+
+     (context "/analyses" []
+       (context "/:analysis-id" []
+         :path-params [analysis-id :- vice-schema/AnalysisID]
+
+         (GET "/external-id" []
+           :return vice-schema/ExternalIDResponse
+           :summary "Get external UUID"
+           :description "Returns the external UUID associated with the analysis after verifying that the user can read it. VICE analyses only have a single external UUID"
+           (ok (vice-services/external-id analysis-id)))
+
+         (POST "/exit" []
+           :summary "Exit without saving"
+           :description "Terminates the analysis without uploading files to the data store, after verifying that the user can write to the analysis"
+           (ok (vice-services/exit analysis-id)))))
 
      (context "/:host" []
        :path-params [host :- vice-schema/Host]

--- a/src/terrain/services/fileio/controllers.clj
+++ b/src/terrain/services/fileio/controllers.clj
@@ -30,6 +30,22 @@
   (fn [{{:keys [user]} :user-info {:keys [dest]} :params :as req}]
     (handler (multipart/multipart-params-request req {:store (store-fn user dest)}))))
 
+(defn overwrite-store-fn
+  "Returns a multipart :store function that overwrites the existing file at dest in the data-info
+  service with the uploaded part's contents. Unlike the string-based save endpoint, the part's
+  stream is forwarded as-is, so binary content survives the round trip."
+  [user dest]
+  (fn [{:keys [stream] :as file-info}]
+    (merge (select-keys file-info [:filename :content-type])
+           (data/overwrite-file user dest stream))))
+
+(defn wrap-file-overwrite
+  "Like wrap-file-upload, but overwrites the existing file at the dest path instead of creating a
+  new file in a destination directory."
+  [handler]
+  (fn [{{:keys [user]} :user-info {:keys [dest]} :params :as req}]
+    (handler (multipart/multipart-params-request req {:store (overwrite-store-fn user dest)}))))
+
 (defn saveas
   "Save a file to a location given the content in a (utf-8) string."
   [{user :shortUsername} {:keys [dest content]}]

--- a/src/terrain/services/fileio/controllers.clj
+++ b/src/terrain/services/fileio/controllers.clj
@@ -22,13 +22,18 @@
     (merge (select-keys file-info [:filename :content-type])
            (data-raw/upload-file user dest filename content-type stream))))
 
-(defn wrap-file-upload
-  "This is a specialized replacement for ring.middleware.multipart-params/wrap-mutlipart-params that forwards uploads
-  to the data-info service. The username and file destination are extracted from the request before processing the
-  multipart parameters."
-  [handler]
+(defn- wrap-multipart-store
+  "Builds a specialized replacement for ring.middleware.multipart-params/wrap-multipart-params
+  that forwards uploaded file contents to the data-info service via the store function returned
+  by (make-store user dest). The username and destination are extracted from the request before
+  processing the multipart parameters."
+  [make-store handler]
   (fn [{{:keys [user]} :user-info {:keys [dest]} :params :as req}]
-    (handler (multipart/multipart-params-request req {:store (store-fn user dest)}))))
+    (handler (multipart/multipart-params-request req {:store (make-store user dest)}))))
+
+(def wrap-file-upload
+  "Multipart middleware that uploads the file part as a new file in the dest directory."
+  (partial wrap-multipart-store store-fn))
 
 (defn overwrite-store-fn
   "Returns a multipart :store function that overwrites the existing file at dest in the data-info
@@ -39,12 +44,9 @@
     (merge (select-keys file-info [:filename :content-type])
            (data/overwrite-file user dest stream))))
 
-(defn wrap-file-overwrite
-  "Like wrap-file-upload, but overwrites the existing file at the dest path instead of creating a
-  new file in a destination directory."
-  [handler]
-  (fn [{{:keys [user]} :user-info {:keys [dest]} :params :as req}]
-    (handler (multipart/multipart-params-request req {:store (overwrite-store-fn user dest)}))))
+(def wrap-file-overwrite
+  "Multipart middleware that overwrites the existing file at the dest path."
+  (partial wrap-multipart-store overwrite-store-fn))
 
 (defn saveas
   "Save a file to a location given the content in a (utf-8) string."

--- a/src/terrain/services/fileio/controllers.clj
+++ b/src/terrain/services/fileio/controllers.clj
@@ -29,11 +29,12 @@
   processing the multipart parameters."
   [make-store handler]
   (fn [{{:keys [user]} :user-info {:keys [dest]} :params :as req}]
-    (handler (multipart/multipart-params-request req {:store (make-store user dest)}))))
+    (handler (multipart/multipart-params-request req {:store (make-store user (some-> dest string/trim))}))))
 
-(def wrap-file-upload
+(defn wrap-file-upload
   "Multipart middleware that uploads the file part as a new file in the dest directory."
-  (partial wrap-multipart-store store-fn))
+  [handler]
+  (wrap-multipart-store store-fn handler))
 
 (defn overwrite-store-fn
   "Returns a multipart :store function that overwrites the existing file at dest in the data-info
@@ -44,9 +45,10 @@
     (merge (select-keys file-info [:filename :content-type])
            (data/overwrite-file user dest stream))))
 
-(def wrap-file-overwrite
+(defn wrap-file-overwrite
   "Multipart middleware that overwrites the existing file at the dest path."
-  (partial wrap-multipart-store overwrite-store-fn))
+  [handler]
+  (wrap-multipart-store overwrite-store-fn handler))
 
 (defn saveas
   "Save a file to a location given the content in a (utf-8) string."

--- a/src/terrain/services/filesystem/metadata.clj
+++ b/src/terrain/services/filesystem/metadata.clj
@@ -31,6 +31,19 @@
 
 (with-post-hook! #'do-metadata-set (log-func "do-metadata-set"))
 
+(defn do-metadata-add
+  "Entrypoint for the API that calls (metadata-add): associates the given AVUs
+   with the data item without touching the existing ones."
+  [data-id {user :user} body]
+  (data-raw/add-avus user (uuidify data-id) body))
+
+(with-pre-hook! #'do-metadata-add
+  (fn [data-id params body]
+    (log-call "do-metadata-add" data-id params body)
+    (validate-map params {:user string?})))
+
+(with-post-hook! #'do-metadata-add (log-func "do-metadata-add"))
+
 (defn do-metadata-copy
   "Entrypoint for the API that calls (metadata-copy)."
   [{:keys [user]} data-id body]

--- a/src/terrain/services/vice.clj
+++ b/src/terrain/services/vice.clj
@@ -2,32 +2,46 @@
   "User-level VICE operations that verify the caller's analysis permissions
    before delegating to app-exposer endpoints that have no user enforcement of
    their own."
-  (:require [clojure-commons.exception-util :as cxu]
+  (:require [cheshire.core :as json]
+            [clojure-commons.exception-util :as cxu]
             [terrain.auth.user-attributes :refer [current-user]]
             [terrain.clients.app-exposer :as app-exposer]
             [terrain.clients.apps.raw :as apps]))
 
+(defn- get-readable-analysis
+  "Returns the analysis listing entry visible to the current user, or throws
+   not-found; the apps service hides analyses the user cannot read, so this is
+   also a read-level access check."
+  [analysis-id]
+  (let [filter  (json/encode [{:field "id" :value (str analysis-id)}])
+        listing (apps/list-jobs {:filter filter})]
+    (or (first (:analyses listing))
+        (cxu/not-found (str "analysis " analysis-id " not found")))))
+
 (def ^:private write-levels #{"write" "own"})
 
-(defn- analysis-permission-grants
-  "Returns the permission grants for the analysis. The permission lister
-   rejects analyses the caller cannot read, so calling this is also a
-   read-level access check."
-  [analysis-id]
-  (-> (apps/list-job-permissions {:analyses [analysis-id]} {})
-      :analyses
-      first
-      :permissions))
-
-(defn- validate-write-access
-  "Applies the same write-permission bar the apps service uses for analysis
-   stop requests."
+(defn- has-write-grant?
+  "Checks the analysis permission listing for a write-level grant to the
+   current user. The listing only contains grants to subjects other than the
+   requesting user, so this is only consulted for non-owners."
   [analysis-id]
   (let [username  (:shortUsername current-user)
+        grants    (-> (apps/list-job-permissions {:analyses [analysis-id]} {})
+                      :analyses
+                      first
+                      :permissions)
         writable? (fn [{:keys [subject permission]}]
                     (and (= (:id subject) username)
                          (contains? write-levels permission)))]
-    (when-not (some writable? (analysis-permission-grants analysis-id))
+    (boolean (some writable? grants))))
+
+(defn- validate-write-access
+  "Allows the analysis owner or a user holding a write-level grant, matching
+   the bar the apps service applies to analysis stop requests."
+  [analysis-id]
+  (let [{owner :username} (get-readable-analysis analysis-id)]
+    (when-not (or (= owner (:username current-user))
+                  (has-write-grant? analysis-id))
       (cxu/forbidden (str "insufficient privileges for analysis " analysis-id)))))
 
 (defn exit
@@ -39,7 +53,7 @@
 (defn external-id
   "Returns the external ID associated with the analysis."
   [analysis-id]
-  (analysis-permission-grants analysis-id)
+  (get-readable-analysis analysis-id)
   (app-exposer/admin-external-id analysis-id))
 
 (defn async-data
@@ -48,5 +62,5 @@
   [params]
   (let [data (app-exposer/async-data params)]
     (when-let [analysis-id (:analysisID data)]
-      (analysis-permission-grants analysis-id))
+      (get-readable-analysis analysis-id))
     data))

--- a/src/terrain/services/vice.clj
+++ b/src/terrain/services/vice.clj
@@ -22,11 +22,13 @@
 
 (defn- has-write-grant?
   "Checks the analysis permission listing for a write-level grant to the
-   current user. The listing only contains grants to subjects other than the
-   requesting user, so this is only consulted for non-owners."
+   current user. full-listing makes the listing include the requesting user's
+   own grants; without it only other subjects' grants are returned. Grants held
+   via group membership are listed under the group's subject and therefore do
+   not match here, so this is consulted after the cheaper owner check."
   [analysis-id]
   (let [username  (:shortUsername current-user)
-        grants    (-> (apps/list-job-permissions {:analyses [analysis-id]} {})
+        grants    (-> (apps/list-job-permissions {:analyses [analysis-id]} {:full-listing true})
                       :analyses
                       first
                       :permissions)
@@ -58,9 +60,12 @@
 
 (defn async-data
   "Returns the asynchronously-generated data for the analysis step identified
-   by the external-id query parameter."
+   by the external-id query parameter. Fails closed: a response that cannot be
+   attributed to an analysis the user can read is treated as not found."
   [params]
-  (let [data (app-exposer/async-data params)]
-    (when-let [analysis-id (:analysisID data)]
-      (get-readable-analysis analysis-id))
+  (let [data        (app-exposer/async-data params)
+        analysis-id (:analysisID data)]
+    (when-not analysis-id
+      (cxu/not-found (str "no analysis found for external ID " (:external-id params))))
+    (get-readable-analysis analysis-id)
     data))

--- a/src/terrain/services/vice.clj
+++ b/src/terrain/services/vice.clj
@@ -1,0 +1,52 @@
+(ns terrain.services.vice
+  "User-level VICE operations that verify the caller's analysis permissions
+   before delegating to app-exposer endpoints that have no user enforcement of
+   their own."
+  (:require [clojure-commons.exception-util :as cxu]
+            [terrain.auth.user-attributes :refer [current-user]]
+            [terrain.clients.app-exposer :as app-exposer]
+            [terrain.clients.apps.raw :as apps]))
+
+(def ^:private write-levels #{"write" "own"})
+
+(defn- analysis-permission-grants
+  "Returns the permission grants for the analysis. The permission lister
+   rejects analyses the caller cannot read, so calling this is also a
+   read-level access check."
+  [analysis-id]
+  (-> (apps/list-job-permissions {:analyses [analysis-id]} {})
+      :analyses
+      first
+      :permissions))
+
+(defn- validate-write-access
+  "Applies the same write-permission bar the apps service uses for analysis
+   stop requests."
+  [analysis-id]
+  (let [username  (:shortUsername current-user)
+        writable? (fn [{:keys [subject permission]}]
+                    (and (= (:id subject) username)
+                         (contains? write-levels permission)))]
+    (when-not (some writable? (analysis-permission-grants analysis-id))
+      (cxu/forbidden (str "insufficient privileges for analysis " analysis-id)))))
+
+(defn exit
+  "Terminates the analysis without saving outputs."
+  [analysis-id]
+  (validate-write-access analysis-id)
+  (app-exposer/admin-exit analysis-id))
+
+(defn external-id
+  "Returns the external ID associated with the analysis."
+  [analysis-id]
+  (analysis-permission-grants analysis-id)
+  (app-exposer/admin-external-id analysis-id))
+
+(defn async-data
+  "Returns the asynchronously-generated data for the analysis step identified
+   by the external-id query parameter."
+  [params]
+  (let [data (app-exposer/async-data params)]
+    (when-let [analysis-id (:analysisID data)]
+      (analysis-permission-grants analysis-id))
+    data))

--- a/src/terrain/services/vice.clj
+++ b/src/terrain/services/vice.clj
@@ -2,49 +2,39 @@
   "User-level VICE operations that verify the caller's analysis permissions
    before delegating to app-exposer endpoints that have no user enforcement of
    their own."
-  (:require [cheshire.core :as json]
-            [clojure-commons.exception-util :as cxu]
+  (:require [clojure-commons.exception-util :as cxu]
             [terrain.auth.user-attributes :refer [current-user]]
             [terrain.clients.app-exposer :as app-exposer]
-            [terrain.clients.apps.raw :as apps]))
-
-(defn- get-readable-analysis
-  "Returns the analysis listing entry visible to the current user, or throws
-   not-found; the apps service hides analyses the user cannot read, so this is
-   also a read-level access check."
-  [analysis-id]
-  (let [filter  (json/encode [{:field "id" :value (str analysis-id)}])
-        listing (apps/list-jobs {:filter filter})]
-    (or (first (:analyses listing))
-        (cxu/not-found (str "analysis " analysis-id " not found")))))
+            [terrain.clients.permissions :as perms]))
 
 (def ^:private write-levels #{"write" "own"})
 
-(defn- has-write-grant?
-  "Checks the analysis permission listing for a write-level grant to the
-   current user. full-listing makes the listing include the requesting user's
-   own grants; without it only other subjects' grants are returned. Grants held
-   via group membership are listed under the group's subject and therefore do
-   not match here, so this is consulted after the cheaper owner check."
+(defn- permission-level
+  "Returns the current user's most privileged permission level on the analysis,
+   or nil if the user has no access to it. The permissions service resolves
+   grants held via group membership, so this matches the bar the apps service
+   applies when it authorizes analysis requests."
   [analysis-id]
-  (let [username  (:shortUsername current-user)
-        grants    (-> (apps/list-job-permissions {:analyses [analysis-id]} {:full-listing true})
-                      :analyses
-                      first
-                      :permissions)
-        writable? (fn [{:keys [subject permission]}]
-                    (and (= (:id subject) username)
-                         (contains? write-levels permission)))]
-    (boolean (some writable? grants))))
+  (perms/get-analysis-permission-level (:shortUsername current-user) analysis-id))
+
+(defn- validate-read-access
+  "Reports analyses the user cannot read as not found rather than revealing
+   that they exist."
+  [analysis-id]
+  (when-not (permission-level analysis-id)
+    (cxu/not-found (str "analysis " analysis-id " not found"))))
 
 (defn- validate-write-access
-  "Allows the analysis owner or a user holding a write-level grant, matching
-   the bar the apps service applies to analysis stop requests."
+  "Requires a write-level permission, matching the bar the apps service
+   applies to analysis stop requests. Analyses the user cannot read at all are
+   reported as not found."
   [analysis-id]
-  (let [{owner :username} (get-readable-analysis analysis-id)]
-    (when-not (or (= owner (:username current-user))
-                  (has-write-grant? analysis-id))
-      (cxu/forbidden (str "insufficient privileges for analysis " analysis-id)))))
+  (let [level (permission-level analysis-id)]
+    (cond (nil? level)
+          (cxu/not-found (str "analysis " analysis-id " not found"))
+
+          (not (contains? write-levels level))
+          (cxu/forbidden (str "insufficient privileges for analysis " analysis-id)))))
 
 (defn exit
   "Terminates the analysis without saving outputs."
@@ -55,17 +45,18 @@
 (defn external-id
   "Returns the external ID associated with the analysis."
   [analysis-id]
-  (get-readable-analysis analysis-id)
+  (validate-read-access analysis-id)
   (app-exposer/admin-external-id analysis-id))
 
 (defn async-data
   "Returns the asynchronously-generated data for the analysis step identified
    by the external-id query parameter. Fails closed: a response that cannot be
-   attributed to an analysis the user can read is treated as not found."
+   attributed to an analysis the user can read is treated as not found, and the
+   error never echoes the analysis ID, which the caller may not be entitled to
+   learn."
   [params]
   (let [data        (app-exposer/async-data params)
         analysis-id (:analysisID data)]
-    (when-not analysis-id
-      (cxu/not-found (str "no analysis found for external ID " (:external-id params))))
-    (get-readable-analysis analysis-id)
-    data))
+    (if (and analysis-id (permission-level analysis-id))
+      data
+      (cxu/not-found (str "no analysis found for external ID " (:external-id params))))))

--- a/test/terrain/test_fixtures.clj
+++ b/test/terrain/test_fixtures.clj
@@ -1,6 +1,15 @@
 (ns terrain.test-fixtures
-  (:require [terrain.auth.user-attributes :as user-attributes]
+  (:require [cheshire.core :as json]
+            [terrain.auth.user-attributes :as user-attributes]
             [terrain.util.config :as config]))
+
+(defn json-response
+  "Builds a clj-http.fake handler that responds with the given body serialized as JSON."
+  [body]
+  (fn [_req]
+    {:status  200
+     :headers {"Content-Type" "application/json"}
+     :body    (json/generate-string body)}))
 
 (def test-config
   {:terrain.uid.domain                   "iplantcollaborative.org"

--- a/test/terrain/vice_test.clj
+++ b/test/terrain/vice_test.clj
@@ -1,116 +1,106 @@
 (ns terrain.vice-test
   (:require [cemerick.url :as curl]
-            [cheshire.core :as json]
             [clj-http.fake :refer [with-fake-routes-in-isolation]]
+            [clojure.string :as string]
             [clojure.test :refer :all]
-            [medley.core :refer [map-vals]]
             [terrain.services.vice :as vice]
             [terrain.test-fixtures :as test-fixtures]
-            [terrain.util.config :as config]
-            [terrain.util.transformers :refer [add-current-user-to-map]])
+            [terrain.util.config :as config])
   (:import [clojure.lang ExceptionInfo]))
 
 (use-fixtures :once test-fixtures/with-test-config test-fixtures/with-test-user)
 
 (def ^:private analysis-id "0123abcd-0000-4000-8000-00000000beef")
 
-(defn- apps-url [& components]
-  (str (apply curl/url (config/apps-base-url) components)))
-
 (defn- app-exposer-url [& components]
   (str (apply curl/url (config/app-exposer-base-uri) components)))
 
-(defn- json-response [body]
-  (fn [_req]
-    {:status  200
-     :headers {"Content-Type" "application/json"}
-     :body    (json/generate-string body)}))
+(defn- perms-url [& components]
+  (str (apply curl/url (config/permissions-base) components)))
 
-(defn- analysis-listing-route
-  "Fakes the apps analysis listing for the id filter; owner is the full
-   username of the analysis owner, and nil fakes an invisible analysis."
-  [owner]
-  (let [filter (json/encode [{:field "id" :value analysis-id}])]
-    {{:address      (apps-url "analyses")
-      :query-params (map-vals str (add-current-user-to-map {:filter filter}))}
-     {:get (json-response
-            {:analyses (if owner
-                         [{:id analysis-id :name "test-analysis" :username owner :status "Running"}]
-                         [])})}}))
-
-(defn- permission-lister-route
-  "Fakes the apps permission-lister (with the full-listing flag the service
-   sends); grants lists [subject-id permission] pairs."
-  [grants]
-  {{:address      (apps-url "analyses" "permission-lister")
-    :query-params (map-vals str (add-current-user-to-map {:full-listing true}))}
-   {:post (json-response
-           {:analyses [{:id          analysis-id
-                        :name        "test-analysis"
-                        :permissions (for [[subject-id permission] grants]
-                                       {:subject    {:source_id "ldap" :id subject-id}
-                                        :permission permission})}]})}})
+(defn- permissions-route
+  "Fakes the permissions service lookup for the current user's most privileged
+   permission on the analysis; a nil level fakes an analysis the user has no
+   access to."
+  [level]
+  {{:address      (perms-url "permissions" "subjects" "user" "ipcdev" "analysis" analysis-id)
+    :query-params {:lookup "true"}}
+   {:get (test-fixtures/json-response
+          {:permissions
+           (if level
+             [{:id               "78b8ba84-3f23-11f1-bc05-008cfa5ae621"
+               :subject          {:id           "9e496e8e-3f23-11f1-bb2f-008cfa5ae621"
+                                  :subject_id   "ipcdev"
+                                  :subject_type "user"}
+               :resource         {:id            "a55f1b9a-3f23-11f1-b8b8-008cfa5ae621"
+                                  :name          analysis-id
+                                  :resource_type "analysis"}
+               :permission_level level}]
+             [])})}})
 
 (defn- exit-route
   [exited]
   {(app-exposer-url "vice" "admin" "analyses" analysis-id "exit")
    {:post (fn [_req] (reset! exited true) {:status 200 :headers {} :body ""})}})
 
-(deftest exit-as-owner
-  (let [exited (atom false)]
-    (with-fake-routes-in-isolation
-      (merge (analysis-listing-route "ipcdev@iplantcollaborative.org")
-             (exit-route exited))
-      (vice/exit analysis-id)
-      (testing "the analysis owner can exit without an explicit grant"
-        (is @exited)))))
+(defn- async-data-route
+  [body]
+  {{:address      (app-exposer-url "vice" "async-data")
+    :query-params {:external-id "ext-1" :user "ipcdev"}}
+   {:get (test-fixtures/json-response body)}})
 
-(deftest exit-with-write-grant
-  (let [exited (atom false)]
-    (with-fake-routes-in-isolation
-      (merge (analysis-listing-route "someoneelse@iplantcollaborative.org")
-             (permission-lister-route [["ipcdev" "write"]])
-             (exit-route exited))
-      (vice/exit analysis-id)
-      (testing "a write-level grant allows exit for non-owners"
-        (is @exited)))))
-
-(deftest exit-forbidden-for-readers
-  (with-fake-routes-in-isolation
-    (merge (analysis-listing-route "someoneelse@iplantcollaborative.org")
-           (permission-lister-route [["ipcdev" "read"]]))
-    (testing "a read-level grant is not enough to terminate an analysis"
-      (is (thrown? ExceptionInfo (vice/exit analysis-id))))))
-
-(deftest exit-not-found-when-invisible
-  (with-fake-routes-in-isolation
-    (analysis-listing-route nil)
-    (testing "analyses the user cannot see read as not found"
-      (is (thrown? ExceptionInfo (vice/exit analysis-id))))))
+(deftest exit-permission-enforcement
+  (doseq [{:keys [desc level allowed?]}
+          [{:desc "an own-level permission allows exit"              :level "own"   :allowed? true}
+           {:desc "a write-level permission allows exit"             :level "write" :allowed? true}
+           {:desc "a read-level permission is not enough"            :level "read"  :allowed? false}
+           {:desc "an admin-level permission is not enough"          :level "admin" :allowed? false}
+           {:desc "an analysis the user cannot see reads as missing" :level nil     :allowed? false}]]
+    (testing desc
+      (let [exited (atom false)]
+        (with-fake-routes-in-isolation
+          (merge (permissions-route level)
+                 (exit-route exited))
+          (if allowed?
+            (do (vice/exit analysis-id)
+                (is @exited))
+            (do (is (thrown? ExceptionInfo (vice/exit analysis-id)))
+                (is (not @exited)))))))))
 
 (deftest external-id-reshapes-key
   (with-fake-routes-in-isolation
     (merge
-     (analysis-listing-route "ipcdev@iplantcollaborative.org")
+     (permissions-route "read")
      {(app-exposer-url "vice" "admin" "analyses" analysis-id "external-id")
-      {:get (json-response {:external_id "ext-1"})}})
+      {:get (test-fixtures/json-response {:external_id "ext-1"})}})
     (testing "app-exposer's external_id is reshaped to the schema's externalID"
       (is (= {:externalID "ext-1"} (vice/external-id analysis-id))))))
+
+(deftest external-id-not-found-when-invisible
+  (with-fake-routes-in-isolation
+    (permissions-route nil)
+    (testing "analyses the user cannot read are reported as not found"
+      (is (thrown? ExceptionInfo (vice/external-id analysis-id))))))
 
 (deftest async-data-checks-analysis-visibility
   (with-fake-routes-in-isolation
     (merge
-     (analysis-listing-route "ipcdev@iplantcollaborative.org")
-     {{:address      (app-exposer-url "vice" "async-data")
-       :query-params {:external-id "ext-1" :user "ipcdev"}}
-      {:get (json-response {:analysisID analysis-id :subdomain "a1b2c3" :ipAddr "127.0.0.1"})}})
+     (permissions-route "read")
+     (async-data-route {:analysisID analysis-id :subdomain "a1b2c3" :ipAddr "127.0.0.1"}))
     (testing "async data passes through once the analysis is readable"
       (is (= "a1b2c3" (:subdomain (vice/async-data {:external-id "ext-1"})))))))
 
 (deftest async-data-fails-closed-without-analysis-id
   (with-fake-routes-in-isolation
-    {{:address      (app-exposer-url "vice" "async-data")
-      :query-params {:external-id "ext-1" :user "ipcdev"}}
-     {:get (json-response {:analysisID nil :subdomain "a1b2c3" :ipAddr "127.0.0.1"})}}
+    (async-data-route {:analysisID nil :subdomain "a1b2c3" :ipAddr "127.0.0.1"})
     (testing "a response without an analysis id is rejected instead of leaked"
       (is (thrown? ExceptionInfo (vice/async-data {:external-id "ext-1"}))))))
+
+(deftest async-data-does-not-leak-analysis-ids
+  (with-fake-routes-in-isolation
+    (merge
+     (permissions-route nil)
+     (async-data-route {:analysisID analysis-id :subdomain "a1b2c3" :ipAddr "127.0.0.1"}))
+    (testing "the not-found error for an unreadable analysis omits the analysis id"
+      (let [e (is (thrown? ExceptionInfo (vice/async-data {:external-id "ext-1"})))]
+        (is (not (string/includes? (str e) analysis-id)))))))

--- a/test/terrain/vice_test.clj
+++ b/test/terrain/vice_test.clj
@@ -39,11 +39,11 @@
                          [])})}}))
 
 (defn- permission-lister-route
-  "Fakes the apps permission-lister; grants lists [subject-id permission]
-   pairs for subjects other than the requesting user."
+  "Fakes the apps permission-lister (with the full-listing flag the service
+   sends); grants lists [subject-id permission] pairs."
   [grants]
   {{:address      (apps-url "analyses" "permission-lister")
-    :query-params (map-vals str (add-current-user-to-map {}))}
+    :query-params (map-vals str (add-current-user-to-map {:full-listing true}))}
    {:post (json-response
            {:analyses [{:id          analysis-id
                         :name        "test-analysis"
@@ -106,3 +106,11 @@
       {:get (json-response {:analysisID analysis-id :subdomain "a1b2c3" :ipAddr "127.0.0.1"})}})
     (testing "async data passes through once the analysis is readable"
       (is (= "a1b2c3" (:subdomain (vice/async-data {:external-id "ext-1"})))))))
+
+(deftest async-data-fails-closed-without-analysis-id
+  (with-fake-routes-in-isolation
+    {{:address      (app-exposer-url "vice" "async-data")
+      :query-params {:external-id "ext-1" :user "ipcdev"}}
+     {:get (json-response {:analysisID nil :subdomain "a1b2c3" :ipAddr "127.0.0.1"})}}
+    (testing "a response without an analysis id is rejected instead of leaked"
+      (is (thrown? ExceptionInfo (vice/async-data {:external-id "ext-1"}))))))

--- a/test/terrain/vice_test.clj
+++ b/test/terrain/vice_test.clj
@@ -1,0 +1,74 @@
+(ns terrain.vice-test
+  (:require [cemerick.url :as curl]
+            [cheshire.core :as json]
+            [clj-http.fake :refer [with-fake-routes-in-isolation]]
+            [clojure.test :refer :all]
+            [medley.core :refer [map-vals]]
+            [terrain.services.vice :as vice]
+            [terrain.test-fixtures :as test-fixtures]
+            [terrain.util.config :as config]
+            [terrain.util.transformers :refer [add-current-user-to-map]])
+  (:import [clojure.lang ExceptionInfo]))
+
+(use-fixtures :once test-fixtures/with-test-config test-fixtures/with-test-user)
+
+(def ^:private analysis-id "0123abcd-0000-4000-8000-00000000beef")
+
+(defn- apps-url [& components]
+  (str (apply curl/url (config/apps-base-url) components)))
+
+(defn- app-exposer-url [& components]
+  (str (apply curl/url (config/app-exposer-base-uri) components)))
+
+(defn- json-response [body]
+  (fn [_req]
+    {:status  200
+     :headers {"Content-Type" "application/json"}
+     :body    (json/generate-string body)}))
+
+(defn- permission-lister-route
+  "Fakes the apps permission-lister, granting the test user the given permission level."
+  [permission]
+  {{:address      (apps-url "analyses" "permission-lister")
+    :query-params (map-vals str (add-current-user-to-map {}))}
+   {:post (json-response
+           {:analyses [{:id          analysis-id
+                        :name        "test-analysis"
+                        :permissions [{:subject    {:source_id "ldap" :id "ipcdev"}
+                                       :permission permission}]}]})}})
+
+(deftest exit-with-write-permission
+  (let [exited (atom false)]
+    (with-fake-routes-in-isolation
+      (merge
+       (permission-lister-route "own")
+       {(app-exposer-url "vice" "admin" "analyses" analysis-id "exit")
+        {:post (fn [_req] (reset! exited true) {:status 200 :headers {} :body ""})}})
+      (vice/exit analysis-id)
+      (testing "exit reaches app-exposer when the user holds a write-level permission"
+        (is @exited)))))
+
+(deftest exit-forbidden-for-readers
+  (with-fake-routes-in-isolation
+    (permission-lister-route "read")
+    (testing "read permission is not enough to terminate an analysis"
+      (is (thrown? ExceptionInfo (vice/exit analysis-id))))))
+
+(deftest external-id-reshapes-key
+  (with-fake-routes-in-isolation
+    (merge
+     (permission-lister-route "read")
+     {(app-exposer-url "vice" "admin" "analyses" analysis-id "external-id")
+      {:get (json-response {:external_id "ext-1"})}})
+    (testing "app-exposer's external_id is reshaped to the schema's externalID"
+      (is (= {:externalID "ext-1"} (vice/external-id analysis-id))))))
+
+(deftest async-data-checks-analysis-visibility
+  (with-fake-routes-in-isolation
+    (merge
+     (permission-lister-route "read")
+     {{:address      (app-exposer-url "vice" "async-data")
+       :query-params {:external-id "ext-1" :user "ipcdev"}}
+      {:get (json-response {:analysisID analysis-id :subdomain "a1b2c3" :ipAddr "127.0.0.1"})}})
+    (testing "async data passes through once the analysis is readable"
+      (is (= "a1b2c3" (:subdomain (vice/async-data {:external-id "ext-1"})))))))

--- a/test/terrain/vice_test.clj
+++ b/test/terrain/vice_test.clj
@@ -26,38 +26,72 @@
      :headers {"Content-Type" "application/json"}
      :body    (json/generate-string body)}))
 
+(defn- analysis-listing-route
+  "Fakes the apps analysis listing for the id filter; owner is the full
+   username of the analysis owner, and nil fakes an invisible analysis."
+  [owner]
+  (let [filter (json/encode [{:field "id" :value analysis-id}])]
+    {{:address      (apps-url "analyses")
+      :query-params (map-vals str (add-current-user-to-map {:filter filter}))}
+     {:get (json-response
+            {:analyses (if owner
+                         [{:id analysis-id :name "test-analysis" :username owner :status "Running"}]
+                         [])})}}))
+
 (defn- permission-lister-route
-  "Fakes the apps permission-lister, granting the test user the given permission level."
-  [permission]
+  "Fakes the apps permission-lister; grants lists [subject-id permission]
+   pairs for subjects other than the requesting user."
+  [grants]
   {{:address      (apps-url "analyses" "permission-lister")
     :query-params (map-vals str (add-current-user-to-map {}))}
    {:post (json-response
            {:analyses [{:id          analysis-id
                         :name        "test-analysis"
-                        :permissions [{:subject    {:source_id "ldap" :id "ipcdev"}
-                                       :permission permission}]}]})}})
+                        :permissions (for [[subject-id permission] grants]
+                                       {:subject    {:source_id "ldap" :id subject-id}
+                                        :permission permission})}]})}})
 
-(deftest exit-with-write-permission
+(defn- exit-route
+  [exited]
+  {(app-exposer-url "vice" "admin" "analyses" analysis-id "exit")
+   {:post (fn [_req] (reset! exited true) {:status 200 :headers {} :body ""})}})
+
+(deftest exit-as-owner
   (let [exited (atom false)]
     (with-fake-routes-in-isolation
-      (merge
-       (permission-lister-route "own")
-       {(app-exposer-url "vice" "admin" "analyses" analysis-id "exit")
-        {:post (fn [_req] (reset! exited true) {:status 200 :headers {} :body ""})}})
+      (merge (analysis-listing-route "ipcdev@iplantcollaborative.org")
+             (exit-route exited))
       (vice/exit analysis-id)
-      (testing "exit reaches app-exposer when the user holds a write-level permission"
+      (testing "the analysis owner can exit without an explicit grant"
+        (is @exited)))))
+
+(deftest exit-with-write-grant
+  (let [exited (atom false)]
+    (with-fake-routes-in-isolation
+      (merge (analysis-listing-route "someoneelse@iplantcollaborative.org")
+             (permission-lister-route [["ipcdev" "write"]])
+             (exit-route exited))
+      (vice/exit analysis-id)
+      (testing "a write-level grant allows exit for non-owners"
         (is @exited)))))
 
 (deftest exit-forbidden-for-readers
   (with-fake-routes-in-isolation
-    (permission-lister-route "read")
-    (testing "read permission is not enough to terminate an analysis"
+    (merge (analysis-listing-route "someoneelse@iplantcollaborative.org")
+           (permission-lister-route [["ipcdev" "read"]]))
+    (testing "a read-level grant is not enough to terminate an analysis"
+      (is (thrown? ExceptionInfo (vice/exit analysis-id))))))
+
+(deftest exit-not-found-when-invisible
+  (with-fake-routes-in-isolation
+    (analysis-listing-route nil)
+    (testing "analyses the user cannot see read as not found"
       (is (thrown? ExceptionInfo (vice/exit analysis-id))))))
 
 (deftest external-id-reshapes-key
   (with-fake-routes-in-isolation
     (merge
-     (permission-lister-route "read")
+     (analysis-listing-route "ipcdev@iplantcollaborative.org")
      {(app-exposer-url "vice" "admin" "analyses" analysis-id "external-id")
       {:get (json-response {:external_id "ext-1"})}})
     (testing "app-exposer's external_id is reshaped to the schema's externalID"
@@ -66,7 +100,7 @@
 (deftest async-data-checks-analysis-visibility
   (with-fake-routes-in-isolation
     (merge
-     (permission-lister-route "read")
+     (analysis-listing-route "ipcdev@iplantcollaborative.org")
      {{:address      (app-exposer-url "vice" "async-data")
        :query-params {:external-id "ext-1" :user "ipcdev"}}
       {:get (json-response {:analysisID analysis-id :subdomain "a1b2c3" :ipAddr "127.0.0.1"})}})


### PR DESCRIPTION
Formation is being retargeted to call terrain (with the caller's bearer token) instead of hitting app-exposer admin endpoints and iRODS directly. That needs user-level equivalents of a few operations that were previously admin-only or string-only:

- `GET /vice/async-data`, `GET /vice/analyses/{id}/external-id`, and `POST /vice/analyses/{id}/exit`, backed by a new `terrain.services.vice` namespace. Exit requires the same write permission the apps service enforces for analysis stop; the read-level routes require read permission. All checks are a single permissions-service lookup with `lookup=true`, so grants held via group/team membership are honored the same way apps honors them. The checks live in terrain because app-exposer's user-level handlers do no ownership enforcement.
- `POST /fileio/overwrite`: binary-safe multipart overwrite of an existing file, modeled on wrap-file-upload and wired to the already-existing data-info overwrite client chain (PUT /data/{data-id}). The existing fileio/save endpoint remains UTF-8-string-only.

Also fixes two pre-existing bugs found along the way:

- admin-external-id now reshapes app-exposer's external_id key to the published schema's externalID; the admin route's response validation has been broken since app-exposer fixed its malformed struct tag.
- resolve-test-user passed :user-attribues (typo) to user-from-attributes, leaving with-user test fixtures with a nil shortUsername.

Code review fixes:

- Replaced the original apps-listing + permission-lister authorization in `terrain.services.vice` with the permissions-service lookup described above. The original check missed write grants held via group membership (a team member who could stop an analysis through apps got a 403 from exit), tied authorization to apps listing semantics (analyses excluded from the default listing read as missing even to their owner), and cost up to three HTTP round trips per request — one of them apps' heaviest listing path. The new check is one permissions-service call.
- The async-data not-found error is keyed to the external ID instead of the analysis UUID, so an unauthorized caller can no longer harvest internal analysis IDs from the error message.
- `POST /fileio/upload` now runs the data-overage check before the multipart middleware. Previously the multipart store uploaded the file to the Data Store and *then* the overage check rejected the request, so over-quota users still landed files.
- The shared multipart middleware trims `dest`, matching save/saveas/urlupload.
- Cleanups: the multipart middlewares are plain defns (visible arity, REPL-rebindable store fns), the JSON-stub test helper moved to `terrain.test-fixtures` as the canonical copy, and the exit permission tests are table-driven across all four permission levels plus the no-access case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)