### PR TITLE
Fix upload of files with non-ASCII names (RFC6532 multipart mode)

### DIFF
--- a/src/terrain/clients/data_info/raw.clj
+++ b/src/terrain/clients/data_info/raw.clj
@@ -6,7 +6,8 @@
             [cheshire.core :as json]
             [clj-http.client :as http]
             [terrain.util.config :as cfg])
-  (:import [clojure.lang IPersistentMap ISeq Keyword]))
+  (:import [clojure.lang IPersistentMap ISeq Keyword]
+           [org.apache.http.entity.mime HttpMultipartMode]))
 
 ;; HELPER FUNCTIONS
 
@@ -133,14 +134,18 @@
 (defn upload-file
   [user dest-path filename content-type istream]
   (:body (http/post (str (url/url (cfg/data-info-base-url) "data"))
-                    {:query-params {:user user
-                                    :dest dest-path}
-                     :accept       :json
-                     :as           :json
-                     :multipart    [{:part-name "file"
-                                     :name      filename
-                                     :mime-type content-type
-                                     :content   istream}]})))
+                    {:query-params   {:user user
+                                      :dest dest-path}
+                     :accept         :json
+                     :as             :json
+                     ;; RFC6532 encodes the multipart filename as UTF-8. The default
+                     ;; STRICT mode encodes it as US-ASCII, replacing characters like
+                     ;; ä/ö/ü with '?' before data-info ever stores the file.
+                     :multipart-mode HttpMultipartMode/RFC6532
+                     :multipart      [{:part-name "file"
+                                       :name      filename
+                                       :mime-type content-type
+                                       :content   istream}]})))
 (defn create-dirs
   "Uses the data-info directories endpoint to create several directories."
   [user paths]

--- a/test/terrain/clients/data_info/raw_test.clj
+++ b/test/terrain/clients/data_info/raw_test.clj
@@ -1,0 +1,46 @@
+(ns terrain.clients.data-info.raw-test
+  (:require [clojure.string :as string]
+            [clojure.test :refer :all]
+            [clj-http.client :as http]
+            [clj-http.multipart :as multipart]
+            [terrain.clients.data-info.raw :as raw]
+            [terrain.util.config :as cfg])
+  (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
+           [org.apache.http.entity.mime HttpMultipartMode]))
+
+(def ^:private non-ascii-filename "test-ä-ö-ü.txt")
+
+(defn- serialize-multipart
+  "Serializes the multipart body data-info-style upload-file builds, under the
+   given HttpMultipartMode, and returns the bytes decoded as UTF-8."
+  [filename mode]
+  (let [entity (multipart/create-multipart-entity
+                [{:part-name "file"
+                  :name      filename
+                  :mime-type "text/plain"
+                  :content   (ByteArrayInputStream. (.getBytes "hello" "UTF-8"))}]
+                {:multipart-mode mode})
+        baos   (ByteArrayOutputStream.)]
+    (.writeTo entity baos)
+    (String. (.toByteArray baos) "UTF-8")))
+
+(deftest multipart-mode-filename-encoding
+  (testing "only a UTF-8-capable multipart mode preserves non-ASCII filenames"
+    (are [mode preserved?]
+         (= preserved? (string/includes? (serialize-multipart non-ascii-filename mode)
+                                         non-ascii-filename))
+      ;; the mode upload-file now uses
+      HttpMultipartMode/RFC6532 true
+      ;; clj-http's default, which mangles ä/ö/ü to '?'
+      HttpMultipartMode/STRICT  false)))
+
+(deftest upload-file-uses-utf8-multipart-mode
+  (let [captured (atom nil)]
+    (with-redefs [cfg/data-info-base-url (constantly "http://data-info")
+                  http/post              (fn [_url opts] (reset! captured opts) {:body {}})]
+      (raw/upload-file "user" "/dest/dir" non-ascii-filename "text/plain"
+                       (ByteArrayInputStream. (.getBytes "hello" "UTF-8")))
+      (testing "requests the RFC6532 multipart mode so filenames are UTF-8 encoded"
+        (is (= HttpMultipartMode/RFC6532 (:multipart-mode @captured))))
+      (testing "passes the original filename through unchanged"
+        (is (= non-ascii-filename (-> @captured :multipart first :name)))))))


### PR DESCRIPTION
## Problem

Uploading a file whose name contains non-ASCII characters (e.g. `test-ä-ö-ü.txt`) stores it with those characters replaced by `?`. Reproduced via the web UI: uploading `test-ä-ö-ü.txt` lands a file named `test-?-?-?.txt`.

## Root cause

The corruption happens in terrain, not sonora, data-info, or iRODS:

- **sonora** pipes the raw multipart request body straight through (`req.pipe(...).pipe(res)`), so the browser's UTF-8 filename reaches terrain intact.
- **terrain** re-parses the upload and re-emits a *new* multipart request to data-info via clj-http in `upload-file` (`src/terrain/clients/data_info/raw.clj`). clj-http defaults to `HttpMultipartMode/STRICT`, which encodes the multipart `filename` parameter as **US-ASCII** and replaces any character it cannot represent with `?` — before data-info ever receives the file.
- data-info / clj-jargon / iRODS were exonerated (Jargon's default protocol encoding is UTF-8; JDK 22/25 default charset is UTF-8). The `?` (rather than mojibake) is the signature of an ASCII-replacement step, which only STRICT-mode multipart encoding performs on this path.

## Fix

Set `:multipart-mode HttpMultipartMode/RFC6532` on the `upload-file` request. RFC6532 encodes the filename as UTF-8, preserving the original characters end-to-end.

`overwrite-file` is intentionally left unchanged: it identifies the target file by UUID in the URL and sends no user-supplied filename (data-info's overwrite handler ignores the multipart filename), so it cannot exhibit this bug.

## Tests

`test/terrain/clients/data_info/raw_test.clj`:

- `multipart-mode-filename-encoding` — table-driven behavioral test that serializes the actual multipart body and asserts RFC6532 preserves `test-ä-ö-ü.txt` while the old STRICT default mangles it (documents the bug and the rationale).
- `upload-file-uses-utf8-multipart-mode` — asserts `upload-file` requests RFC6532 mode and passes the original filename through unchanged (guards the call site against regression).

Verified the wiring test fails if the mode is reverted to STRICT. `lein uberjar` builds cleanly.

## Scope note (download path)

An earlier draft of this PR flagged a download-side defect: data-info builds `Content-Disposition` with the raw filename and no RFC 6266 `filename*` encoding (`data_info/services/entry.clj`). On closer inspection this does **not** affect the reported characters — ä/ö/ü (and the whole Latin-1 supplement) are ≤ U+00FF, and the HTTP header transport charset (ISO-8859-1) coincides with RFC 6266's `filename=` fallback charset, so the byte round-trips correctly and downloads work (verified manually). The only theoretical residual is filenames containing characters above U+00FF, which is unverified, cosmetic at worst, and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)