### PR TITLE
Give the file-upload endpoint a longer, configurable Jetty idle timeout

### DIFF
--- a/src/terrain/core.clj
+++ b/src/terrain/core.clj
@@ -9,6 +9,7 @@
             [terrain.middleware :refer [wrap-fake-user]]
             [terrain.services.filesystem.icat :as icat]
             [terrain.util.config :as config]
+            [terrain.util.jetty :as jetty]
             [terrain.util.nats :as nats]
             [service-logging.thread-context :as tc]))
 
@@ -99,7 +100,12 @@
   (log/warn "Started listening on" port)
   ((eval 'ring.adapter.jetty/run-jetty)
    (wrap-fake-user (eval 'terrain.routes/app-wrapper) fake-user)
-   {:port port}))
+   {:port          port
+    :max-idle-time (config/jetty-max-idle-time)
+    :configurator  (jetty/idle-timeout-configurator
+                    (fn [^String path] (and path (.contains path "/fileio/upload")))
+                    (config/jetty-max-idle-time)
+                    (config/jetty-upload-idle-time))}))
 
 (defn- load-config
   [config-path]

--- a/src/terrain/util/config.clj
+++ b/src/terrain/util/config.clj
@@ -34,6 +34,20 @@
   [props config-valid configs]
   "terrain.app.listen-port" 60000)
 
+(declare jetty-max-idle-time)
+(cc/defprop-optint jetty-max-idle-time
+  "The default maximum idle time (in milliseconds) for a Jetty connection. Kept short; it
+   applies to every endpoint except uploads, which use jetty-upload-idle-time instead."
+  [props config-valid configs]
+  "terrain.app.jetty-max-idle-time" 200000)
+
+(declare jetty-upload-idle-time)
+(cc/defprop-optint jetty-upload-idle-time
+  "The maximum idle time (in milliseconds) applied to the file-upload endpoint. Raised well
+   above the short default so slow or intermittently-stalled uploads are not cut off mid-transfer."
+  [props config-valid configs]
+  "terrain.app.jetty-upload-idle-time" 3600000)
+
 (declare environment-name)
 (cc/defprop-optstr environment-name
   "The name of the environment that this instance of Terrain belongs to."

--- a/src/terrain/util/jetty.clj
+++ b/src/terrain/util/jetty.clj
@@ -5,18 +5,33 @@
    grace period for slow uploads would otherwise apply to every endpoint. Installing an
    HttpConfiguration customizer lets us keep a short default idle timeout while raising it
    only for the (long-lived, streaming) upload endpoint."
-  (:import [org.eclipse.jetty.server Server Connector HttpConnectionFactory HttpConfiguration$Customizer]))
+  (:import [org.eclipse.jetty.server Server Connector HttpConnectionFactory HttpConfiguration$Customizer Request]
+           [java.util.function Consumer]))
 
 (defn- idle-timeout-customizer
   "A per-request Jetty customizer. Sets the connection's idle timeout to upload-idle-ms for
    requests whose path satisfies upload-path?, and to default-idle-ms otherwise (so the value
-   is correct even when a connection is reused across requests)."
+   is correct even when a connection is reused across requests).
+
+   For upload requests it also registers a completion listener that resets the idle timeout
+   back to default-idle-ms once the request finishes. Otherwise the raised timeout would
+   persist on a keep-alive connection until the next request ran customize, letting a
+   post-upload connection linger for upload-idle-ms if the client stalls without sending
+   another request."
   [upload-path? ^long default-idle-ms ^long upload-idle-ms]
   (reify HttpConfiguration$Customizer
     (customize [_ request _response-headers]
-      (let [endpoint (.. request getConnectionMetaData getConnection getEndPoint)
+      (let [^Request request request
+            endpoint (.. request getConnectionMetaData getConnection getEndPoint)
             path     (.. request getHttpURI getPath)]
-        (.setIdleTimeout endpoint (if (upload-path? path) upload-idle-ms default-idle-ms)))
+        (if (upload-path? path)
+          (do
+            (.setIdleTimeout endpoint upload-idle-ms)
+            (Request/addCompletionListener request
+                                           (reify Consumer
+                                             (accept [_ _failure]
+                                               (.setIdleTimeout endpoint default-idle-ms)))))
+          (.setIdleTimeout endpoint default-idle-ms)))
       request)))
 
 (defn idle-timeout-configurator

--- a/src/terrain/util/jetty.clj
+++ b/src/terrain/util/jetty.clj
@@ -1,0 +1,31 @@
+(ns terrain.util.jetty
+  "Jetty customization: per-endpoint connection idle timeouts.
+
+   The ring-jetty adapter exposes only a single connector-level idle timeout, so a longer
+   grace period for slow uploads would otherwise apply to every endpoint. Installing an
+   HttpConfiguration customizer lets us keep a short default idle timeout while raising it
+   only for the (long-lived, streaming) upload endpoint."
+  (:import [org.eclipse.jetty.server Server Connector HttpConnectionFactory HttpConfiguration$Customizer]))
+
+(defn- idle-timeout-customizer
+  "A per-request Jetty customizer. Sets the connection's idle timeout to upload-idle-ms for
+   requests whose path satisfies upload-path?, and to default-idle-ms otherwise (so the value
+   is correct even when a connection is reused across requests)."
+  [upload-path? ^long default-idle-ms ^long upload-idle-ms]
+  (reify HttpConfiguration$Customizer
+    (customize [_ request _response-headers]
+      (let [endpoint (.. request getConnectionMetaData getConnection getEndPoint)
+            path     (.. request getHttpURI getPath)]
+        (.setIdleTimeout endpoint (if (upload-path? path) upload-idle-ms default-idle-ms)))
+      request)))
+
+(defn idle-timeout-configurator
+  "Returns a ring-jetty :configurator fn that installs idle-timeout-customizer on every HTTP
+   connection factory of the server."
+  [upload-path? default-idle-ms upload-idle-ms]
+  (fn [^Server server]
+    (let [customizer (idle-timeout-customizer upload-path? (long default-idle-ms) (long upload-idle-ms))]
+      (doseq [^Connector connector (.getConnectors server)
+              factory              (.getConnectionFactories connector)
+              :when                (instance? HttpConnectionFactory factory)]
+        (.addCustomizer (.getHttpConfiguration ^HttpConnectionFactory factory) customizer)))))


### PR DESCRIPTION
## Problem

Large file uploads over slow/intermittently-stalled connections were cut off with an **I/O timeout after ~200s of socket inactivity**. Terrain's `run-jetty` used Jetty's default 200000 ms idle timeout, which applies to the (long-lived, streaming) upload connection just like any quick API call.

## Change

Rather than raise the global idle timeout (which would also let dead connections on ordinary API endpoints linger), install a Jetty `HttpConfiguration` customizer that:

- keeps a short default idle timeout (`terrain.app.jetty-max-idle-time`, 200s) for all endpoints, and
- raises it (`terrain.app.jetty-upload-idle-time`, 1h) only for the `/secured/fileio/upload` endpoint.

The customizer sets the value per request, so it stays correct across keep-alive connection reuse. Both timeouts are configurable.

Files: `util/jetty.clj` (new), `core.clj` (wire the `:configurator`), `util/config.clj` (new properties).

## Testing

Verified against the QA environment:

- 210s stall during an upload → **HTTP 200** (previously `Idle timeout expired: 200000/200000 ms`).
- 31-minute steady 512 MB upload → **HTTP 200**, full file intact.
- Ordinary authenticated API calls unaffected (they keep the short default timeout).

Pairs with cyverse-de/data-info#79, which does the same for data-info (and fixes the related spurious `ERR_EXISTS` on interrupted uploads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)