### PR TITLE
CORE-2197: add support for metadata filtering to the app search endpo…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                  [org.cyverse/cyverse-groups-client "0.1.10"]
                  [org.cyverse/common-cfg "2.8.4"]
                  [org.cyverse/common-cli "2.8.3"]
-                 [org.cyverse/common-swagger-api "3.4.23"]
+                 [org.cyverse/common-swagger-api "3.4.24"]
                  [metosin/ring-swagger-ui "5.32.11"]
                  [org.cyverse/kameleon "3.0.11"
                   :exclusions [com.impossibl.pgjdbc-ng/pgjdbc-ng]]


### PR DESCRIPTION
…ints.

These endpoints are simple pass-through calls to the apps service, so the only change that is required is to bump the common-swagger-api version.